### PR TITLE
Refactor comment acceptance test similar to based on #4

### DIFF
--- a/tests/acceptance/shared.py
+++ b/tests/acceptance/shared.py
@@ -42,16 +42,20 @@ def get_listing_create_form(listing) -> WebDriverElement:
     return listing.find_by_css('.listing-create-form').first
 
 
-def get_content_listing(browser) -> WebDriverElement:
+def get_column_listing(browser, column_name: str) -> WebDriverElement:
     """Return the listing in the content column ."""
-    content_column = browser.browser.find_by_css('.moving-column-content')
-    listing = content_column.find_by_css('.listing')
+    column = browser.browser.find_by_css('.moving-column-' + column_name)
+    listing = column.find_by_css('.listing')
     return listing
 
 
-def get_list_element(listing, title):
-    """Return list element with text == `title`."""
+def get_list_element(listing, text, descendant=None, max_steps=20):
+    """Return list element with text == `text`."""
     for element in listing.find_by_css('.listing-element'):
-        wait(lambda: element.text, max_steps=20)
-        if element.text == title:
+        wait(lambda: element.text, max_steps=max_steps)
+        if descendant is None:
+            element_text = element.text
+        else:
+            element_text = element.find_by_css(descendant).first.text
+        if element_text == text:
             return element

--- a/tests/acceptance/test_comment.py
+++ b/tests/acceptance/test_comment.py
@@ -1,73 +1,35 @@
 from pytest import fixture
 
 from .shared import wait
+from .shared import get_column_listing
+from .shared import get_list_element
 from .shared import get_listing_create_form
 from .test_proposal import proposal
 
 
-def show_proposal_comments(proposal):
-    proposal.find_by_css('a').first.click()
-    proposal.find_by_css('button').last.click()
-
-
-def create(listing, content):
-    """Create a new Comment."""
-    form = get_listing_create_form(listing)
-    form.find_by_css('textarea').first.fill(content)
-    form.find_by_css('input[type="submit"]').first.click()
-
-
-def edit(comment, content):
-    comment.find_by_css('a')[-2].click()
-    comment.find_by_css('textarea').first.fill(content)
-    comment.find_by_css('a')[-3].click()
-    wait(lambda: len(comment.find_by_css('a')) == 2)
-
-
 @fixture
-def comment(browser, server_sample, proposal):
+def comment(browser, proposal):
+    """Go to content2 column and create comment with content 'comment1'."""
     show_proposal_comments(proposal)
-    column = '.moving-column-content2'
-    listing = browser.browser.find_by_css(column + ' .listing').first
-    create(listing, 'comment1')
-
-    browser.browser.is_element_present_by_css(column + ' .listing-element')
-    element = listing.find_by_css('.listing-element')
-    wait(lambda: element.text)
-
-    return element
+    listing = get_column_listing(browser, 'content2')
+    return create_comment(listing, 'comment1')
 
 
 def test_create(browser, proposal):
     show_proposal_comments(proposal)
-    column = '.moving-column-content2'
-    listing = browser.browser.find_by_css(column + ' .listing').first
-
-    create(listing, 'somecomment')
-
-    assert browser.browser.is_element_present_by_css(
-        column + ' .listing-element')
-    element = listing.find_by_css('.listing-element')
-    assert wait(lambda: element.text)
-
-    assert element.find_by_css('.comment-content').text == 'somecomment'
+    listing = get_column_listing(browser, 'content2')
+    comment = create_comment(listing, 'somecomment')
+    assert comment is not None
 
 
 def test_reply(browser, comment):
-    column = '.moving-column-content2'
-    listing = comment.find_by_css('.listing').first
-    create(listing, 'somereply')
-
-    assert browser.browser.is_element_present_by_css(
-        column + ' .listing-element .listing-element')
-    element = listing.find_by_css('.listing-element')
-    assert wait(lambda: element.text)
-
-    assert element.find_by_css('.comment-content').text == 'somereply'
+    listing = get_column_listing(browser, 'content2').find_by_css('.listing')
+    element = create_comment(listing, 'somereply')
+    assert element is not None
 
 
 def test_edit(browser, comment):
-    edit(comment, 'edited')
+    edit_comment(comment, 'edited')
     assert comment.find_by_css('.comment-content').text == 'edited'
 
     browser.reload()
@@ -76,3 +38,23 @@ def test_edit(browser, comment):
     show_proposal_comments(proposal)
     assert len(browser.find_by_css('.comment-content')) == 1
     assert browser.find_by_css('.comment-content').text == 'edited'
+
+
+def show_proposal_comments(proposal):
+    proposal.find_by_css('a').first.click()
+    proposal.find_by_css('button').last.click()
+
+
+def create_comment(listing, content):
+    """Create a new Comment."""
+    form = get_listing_create_form(listing)
+    form.find_by_css('textarea').first.fill(content)
+    form.find_by_css('input[type="submit"]').first.click()
+    return get_list_element(listing, content, descendant='.comment-content')
+
+
+def edit_comment(comment, content):
+    comment.find_by_css('a')[-2].click()
+    comment.find_by_css('textarea').first.fill(content)
+    comment.find_by_css('a')[-3].click()
+    wait(lambda: len(comment.find_by_css('a')) == 2)

--- a/tests/acceptance/test_proposal.py
+++ b/tests/acceptance/test_proposal.py
@@ -4,7 +4,7 @@ from pytest import fixture
 
 from .shared import wait
 from .shared import get_listing_create_form
-from .shared import get_content_listing
+from .shared import get_column_listing
 from .shared import get_list_element
 from .shared import title_is_in_listing
 
@@ -12,18 +12,18 @@ from .shared import title_is_in_listing
 @fixture()
 def proposal(browser):
     """Go to content listing and create proposal with title `test proposal`."""
-    listing = get_content_listing(browser)
+    listing = get_column_listing(browser, 'content')
     return create_proposal(listing, 'test proposal')
 
 
 def test_proposal_create(browser):
-    content_listing = get_content_listing(browser)
+    content_listing = get_column_listing(browser, 'content')
     proposal = create_proposal(content_listing, 'some title')
-    assert title_is_in_listing(content_listing, proposal.text)
+    assert proposal is not None
 
 
 def test_proposal_view(browser, proposal):
-    content_listing = get_content_listing(browser)
+    content_listing = get_column_listing(browser, 'content')
     browser.click_link_by_partial_text('test proposal')
     assert proposal_details_are_in_listing(content_listing, 'test proposal')
 


### PR DESCRIPTION
The comment branch was recently merged. But in the meantime, the proposal acceptance tests have been refactored (#4). This applies similar refactoring to comment acceptance tests.
