### PR TITLE
New resource constructor calling conventions.

### DIFF
--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Comment/Adapter.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Comment/Adapter.ts
@@ -6,7 +6,7 @@ import AdhPreliminaryNames = require("../../Packages/PreliminaryNames/Preliminar
 
 export class CommentAdapter implements AdhComment.ICommentAdapter<RICommentVersion> {
     create(adhPreliminaryNames : AdhPreliminaryNames) : RICommentVersion {
-        var resource = new RICommentVersion(adhPreliminaryNames);
+        var resource = new RICommentVersion({preliminaryNames: adhPreliminaryNames});
         resource.data["adhocracy_sample.sheets.comment.IComment"] = {
             refers_to: null,
             content: null

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Comment/Comment.ts
@@ -81,7 +81,7 @@ export class CommentCreate {
                     _self.adapter.content(resource, $scope.content);
                     _self.adapter.refersTo(resource, $scope.refersTo);
 
-                    var comment = new RIComment(adhPreliminaryNames, "comment");
+                    var comment = new RIComment({preliminaryNames: adhPreliminaryNames, name: "comment"});
 
                     return adhHttp.postToPool($scope.poolPath, comment)
                         .then(adhHttp.resolve.bind(adhHttp), displayErrors)

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Http/HttpIg.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Http/HttpIg.ts
@@ -35,14 +35,14 @@ export var register = (angular, config, meta_api) => {
 
             var cb = (transaction : any) : ng.IPromise<void> => {
                 var proposal : AdhHttp.ITransactionResult =
-                    transaction.post(poolPath, new RIProposal(adhPreliminaryNames, proposalName));
+                    transaction.post(poolPath, new RIProposal({preliminaryNames: adhPreliminaryNames, name: proposalName}));
                 var section : AdhHttp.ITransactionResult =
-                    transaction.post(proposal.path, new RISection(adhPreliminaryNames, "Motivation"));
+                    transaction.post(proposal.path, new RISection({preliminaryNames: adhPreliminaryNames, name : "Motivation"}));
 
-                var sectionVersionResource = new RISectionVersion(adhPreliminaryNames);
+                var sectionVersionResource = new RISectionVersion({preliminaryNames: adhPreliminaryNames});
                 var sectionVersion : AdhHttp.ITransactionResult = transaction.post(section.path, sectionVersionResource);
 
-                var proposalVersionResource = new RIProposalVersion(adhPreliminaryNames);
+                var proposalVersionResource = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
                 proposalVersionResource.data["adhocracy.sheets.document.IDocument"] = {
                     title: proposalName,
                     description: "whoof",

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Proposal/Proposal.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Proposal/Proposal.ts
@@ -168,7 +168,7 @@ export class ProposalVersionNew {
             controller: ["$scope", "adhPreliminaryNames", ($scope : IScopeProposalVersion, adhPreliminaryNames : AdhPreliminaryNames) => {
                 $scope.viewmode = "edit";
 
-                $scope.content = new RIProposalVersion(adhPreliminaryNames);
+                $scope.content = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
                 $scope.content.data["adhocracy.sheets.document.IDocument"] = {
                     title: "",
                     description: "",
@@ -177,7 +177,7 @@ export class ProposalVersionNew {
                 $scope.paragraphVersions = [];
 
                 $scope.addParagraphVersion = () => {
-                    var pv = new RIParagraphVersion(adhPreliminaryNames);
+                    var pv = new RIParagraphVersion({preliminaryNames: adhPreliminaryNames});
                     pv.data["adhocracy.sheets.document.IParagraph"] = {
                         content: ""
                     };
@@ -268,17 +268,17 @@ export class Service {
     ) {}
 
     private postProposal(path : string, name : string, scope : {proposal? : any}) : ng.IPromise<void> {
-        return this.adhHttp.postToPool(path, new RIProposal(this.adhPreliminaryNames, name))
+        return this.adhHttp.postToPool(path, new RIProposal({preliminaryNames: this.adhPreliminaryNames, name: name}))
             .then((ret) => { scope.proposal = ret; });
     }
 
     private postSection(path : string, name : string, scope : {section? : any}) : ng.IPromise<void> {
-        return this.adhHttp.postToPool(path, new RISection(this.adhPreliminaryNames, name))
+        return this.adhHttp.postToPool(path, new RISection({preliminaryNames: this.adhPreliminaryNames, name: name}))
             .then((ret) => { scope.section = ret; });
     }
 
     private postParagraph(path : string, name : string, scope : {paragraphs}) : ng.IPromise<void> {
-        return this.adhHttp.postToPool(path, new RIParagraph(this.adhPreliminaryNames, name))
+        return this.adhHttp.postToPool(path, new RIParagraph({preliminaryNames: this.adhPreliminaryNames, name: name}))
             .then((ret) => { scope.paragraphs[name] = ret; });
     }
 
@@ -351,7 +351,7 @@ export class Service {
     ) {
         var _self = this;
 
-        var sectionVersion : RISectionVersion = new RISectionVersion(_self.adhPreliminaryNames);
+        var sectionVersion : RISectionVersion = new RISectionVersion({preliminaryNames: _self.adhPreliminaryNames});
         sectionVersion.data["adhocracy.sheets.document.ISection"] = {
             title : "single section",
             elements : [],
@@ -406,7 +406,7 @@ export class Service {
     ) {
         var _self = this;
 
-        var sectionVersion : RISectionVersion = new RISectionVersion(_self.adhPreliminaryNames);
+        var sectionVersion : RISectionVersion = new RISectionVersion({preliminaryNames: _self.adhPreliminaryNames});
         sectionVersion.data["adhocracy.sheets.document.ISection"] = {
             title : "single_section",
             elements : [],
@@ -430,12 +430,14 @@ export class Service {
             .withTransaction((transaction) : ng.IPromise<Resources.Content<any>> => {
                 // items
                 var postProposal : AdhHttp.ITransactionResult =
-                    transaction.post(poolPath, new RIProposal(_self.adhPreliminaryNames, name));
+                    transaction.post(poolPath, new RIProposal({preliminaryNames: _self.adhPreliminaryNames, name: name}));
                 var postSection : AdhHttp.ITransactionResult =
-                    transaction.post(postProposal.path, new RISection(_self.adhPreliminaryNames, "section"));
+                    transaction.post(postProposal.path, new RISection({preliminaryNames: _self.adhPreliminaryNames, name: "section"}));
                 var postParagraphs : AdhHttp.ITransactionResult[] =
                     paragraphVersions.map((paragraphVersion, i) =>
-                        transaction.post(postProposal.path, new RIParagraph(_self.adhPreliminaryNames, "paragraph" + i)));
+                        transaction.post(
+                            postProposal.path,
+                            new RIParagraph({preliminaryNames: _self.adhPreliminaryNames, name: "paragraph" + i})));
 
                 // versions
                 var postParagraphVersions = paragraphVersions.map((paragraphVersion, i) => {


### PR DESCRIPTION
**before:**
1. resource constructors always expect PreliminaryNames service, and
2. sometimes as second arg an IName name.

**now:**
1. resource constructors expect a dictionary of required and optional args.
2. PreliminaryNames is required
3. name is optional.
4. path is also optional.  if provided, it is used instead of PreliminaryNames for resource.path.
