### PR TITLE
update ruby dependencies

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -278,10 +278,10 @@ eggs = supervisor
 [rubygems]
 recipe = rubygemsrecipe
 gems =
-    sass==3.3.10
-    compass==1.0.0.alpha.21
-    hologram==1.1.0
-    scss-lint==0.25.1
+    sass==3.4.1
+    compass==1.0.1
+    hologram==1.2.0
+    scss-lint==0.27.0
     susy==2.1.3
 
 [compass]


### PR DESCRIPTION
There has been quite some work in the ruby/CSS world.

sass, compass, hologram and scss-lint all released new versions.

The most notable change is that compass 1.0.0 was finally released so we
do not ihave to use an alpha version anymore.

The changelogs are here:
-   http://sass-lang.com/documentation/file.SASS_CHANGELOG.html
-   http://compass-style.org/CHANGELOG/
-   https://github.com/trulia/hologram/blob/master/CHANGELOG.md
-   https://github.com/causes/scss-lint/blob/master/CHANGELOG.md
