### PR TITLE
Replace underscore with lodash

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -219,7 +219,7 @@ mode = 755
 [nodejs]
 recipe = gp.recipe.node
 version = 0.10.28
-npms = typescript@1.0.1 tslint@0.4.12 bower@1.3.8 jasmine-node@2.0.0 q@1.0.1 underscore@1.6.0 node-fs@0.1.7 underscore.string@2.3.3
+npms = typescript@1.0.1 tslint@0.4.12 bower@1.3.8 jasmine-node@2.0.0 q@1.0.1 lodash@2.4.1 node-fs@0.1.7 underscore.string@2.3.3
 # a list of extra directory to add to NODE_PATH
 #node-path =
 scripts = node tsc tslint bower jasmine-node
@@ -231,7 +231,7 @@ packages =
     angular#1.2.21
     angular-route#1.2.21
     angular-animate#1.2.21
-    underscore#1.6.0
+    lodash#2.4.1
     requirejs#2.1.14
     requirejs-text#2.0.12
     DefinitelyTyped#08cef16e268f21f5710b460e402cb80777c2c4d5

--- a/src/adhocracy/adhocracy/frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Adhocracy.ts
@@ -1,6 +1,6 @@
 /// <reference path="../lib/DefinitelyTyped/requirejs/require.d.ts"/>
 /// <reference path="../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
-/// <reference path="../lib/DefinitelyTyped/underscore/underscore.d.ts"/>
+/// <reference path="../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
 /// <reference path="../lib/DefinitelyTyped/modernizr/modernizr.d.ts"/>
 /// <reference path="./_all.d.ts"/>
 

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Embed/Embed.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../lib/DefinitelyTyped/angularjs/angular-route.d.ts"/>
 
-import _ = require("underscore");
+import _ = require("lodash");
 
 import Util = require("../Util/Util");
 

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Embed/EmbedSpec.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Embed/EmbedSpec.ts
@@ -23,8 +23,8 @@ export var register = () => {
 
         describe("route2template", () => {
             it("compiles a template from the parameters given in $route", () => {
-                var expected = "<adh-document-workbench data-path=\"&#x27;/this/is/a/path&#x27;\" " +
-                    "data-test=\"&#x27;&quot;\\&#x27;&amp;&#x27;\"></adh-document-workbench>";
+                var expected = "<adh-document-workbench data-path=\"&#39;/this/is/a/path&#39;\" " +
+                    "data-test=\"&#39;&quot;\\&#39;&amp;&#39;\"></adh-document-workbench>";
                 expect(Embed.route2template($routeMock)).toBe(expected);
             });
             it("throws if $route does not specify a widget", () => {

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Listing/Listing.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../lib/DefinitelyTyped/requirejs/require.d.ts"/>
 /// <reference path="../../../lib/DefinitelyTyped/angularjs/angular.d.ts"/>
-/// <reference path="../../../lib/DefinitelyTyped/underscore/underscore.d.ts"/>
+/// <reference path="../../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
 /// <reference path="../../_all.d.ts"/>
 
 import AdhHttp = require("../Http/Http");

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Proposal/Proposal.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Proposal/Proposal.ts
@@ -1,6 +1,6 @@
-/// <reference path="../../../lib/DefinitelyTyped/underscore/underscore.d.ts"/>
+/// <reference path="../../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
 
-import _ = require("underscore");
+import _ = require("lodash");
 
 import Util = require("../Util/Util");
 import AdhHttp = require("../Http/Http");

--- a/src/adhocracy/adhocracy/frontend/static/js/mkResources.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/mkResources.ts
@@ -1,5 +1,5 @@
 /// <reference path="../lib/DefinitelyTyped/requirejs/require.d.ts"/>
-/// <reference path="../lib/DefinitelyTyped/underscore/underscore.d.ts"/>
+/// <reference path="../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
 
 /* tslint:disable:no-var-requires */
 var http : any = require("http");

--- a/src/adhocracy/adhocracy/frontend/static/js/mkResources/Util.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/mkResources/Util.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../lib/DefinitelyTyped/requirejs/require.d.ts"/>
-/// <reference path="../../lib/DefinitelyTyped/underscore/underscore.d.ts"/>
+/// <reference path="../../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
 
 /* tslint:disable:no-var-requires */
 var _s : any = require("underscore.string");

--- a/src/adhocracy/adhocracy/frontend/static/require-config.js
+++ b/src/adhocracy/adhocracy/frontend/static/require-config.js
@@ -6,7 +6,7 @@ require.config({
         angular: "../lib/angular/angular",
         angularRoute: "../lib/angular-route/angular-route",
         angularAnimate: "../lib/angular-animate/angular-animate",
-        underscore: "../lib/underscore/underscore",
+        lodash: "../lib/lodash/dist/lodash",
         q: "../lib/q/q",
         modernizr: "../lib2/modernizr/modernizr-2.8.3.min"
     },


### PR DESCRIPTION
While working on a task which involves more functional style programming,
I took the opportunity to look into lodash again and replaced underscore
with it. @mf59816 was in favor of this for some time.

Lodash is superior to underscore (more features, more consistant API,
lower footprint, better performance).

It's almost a drop-in replacement. The only needed change is to that
lodash `escape` uses decimal notation while underscore uses `hex`, which
results in a change in `EmbedSpec.ts`.
