### PR TITLE
Fix tests: Compare expected timestamp with UTC instead of local time

### DIFF
--- a/src/adhocracy/adhocracy/resources/test_init.py
+++ b/src/adhocracy/adhocracy/resources/test_init.py
@@ -230,7 +230,7 @@ class TestResourceFactory:
 
         set_appstructs = dummy_sheet.set.call_args[0][0]
         assert set_appstructs['creator'] is None
-        today = datetime.today().date()
+        today = datetime.utcnow().date()
         assert set_appstructs['creation_date'].date() == today
         assert set_appstructs['item_creation_date'] == set_appstructs['creation_date']
         assert set_appstructs['modification_date'].date() == today

--- a/src/adhocracy/adhocracy/schema/test_init.py
+++ b/src/adhocracy/adhocracy/schema/test_init.py
@@ -557,5 +557,5 @@ class DateTimeUnitTest(unittest.TestCase):
         inst = self._make_one().bind()
         result = inst.serialize()
         # we want an iso 8601 string with the current datetime
-        today = datetime.today().date().isoformat()
+        today = datetime.utcnow().strftime('%Y-%m-%d')
         assert today in result


### PR DESCRIPTION
Our API returns UTC timestamps, therefore we need to compare it with UTC
time instead of local time.

I just noticed this issue as dates are different in UTC and CEST between
0:00 and 2:00 in the night.
