### PR TITLE
listen to 'storage' events and update login status

### DIFF
--- a/src/adhocracy/adhocracy/frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Adhocracy.ts
@@ -84,13 +84,14 @@ export var init = (config, meta_api) => {
         $locationProvider.html5Mode(true);
     }]);
 
+    app.value("angular", angular);
     app.value("Modernizr", modernizr);
     app.value("moment", moment);
 
     app.filter("signum", () => (n : number) : string => n > 0 ? "+" + n.toString() : n.toString());
 
     app.service("adhProposal", ["adhHttp", "adhPreliminaryNames", "$q", AdhProposal.Service]);
-    app.service("adhUser", ["adhHttp", "$q", "$http", "$window", "Modernizr", AdhUser.User]);
+    app.service("adhUser", ["adhHttp", "$q", "$http", "$rootScope", "$window", "angular", "Modernizr", AdhUser.User]);
     app.directive("adhLogin", ["adhConfig", "$location", AdhUser.loginDirective]);
     app.directive("adhRegister", ["adhConfig", "$location", AdhUser.registerDirective]);
     app.directive("adhUserIndicator", ["adhConfig", AdhUser.indicatorDirective]);

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/User/User.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/User/User.ts
@@ -63,20 +63,35 @@ export class User {
         private adhHttp : AdhHttp.Service<any>,
         private $q : ng.IQService,
         private $http : ng.IHttpService,
+        private $rootScope : ng.IScope,
         private $window : Window,
+        private angular : ng.IAngularStatic,
         private Modernizr
     ) {
         var _self : User = this;
 
-        if (_self.Modernizr.localstorage) {
-            if (_self.$window.localStorage.getItem("user-token") !== null &&
-                    _self.$window.localStorage.getItem("user-path") !== null) {
-                _self.enableToken(
-                    _self.$window.localStorage.getItem("user-token"),
-                    _self.$window.localStorage.getItem("user-path")
-                );
+        var updateTokenFromStorage = () => {
+            if (_self.Modernizr.localstorage) {
+                if (_self.$window.localStorage.getItem("user-token") !== null &&
+                        _self.$window.localStorage.getItem("user-path") !== null) {
+                    _self.enableToken(
+                        _self.$window.localStorage.getItem("user-token"),
+                        _self.$window.localStorage.getItem("user-path")
+                    );
+                } else if (_self.$window.localStorage.getItem("user-token") === null &&
+                        _self.$window.localStorage.getItem("user-path") === null) {
+                    // For some reason, $apply is necessary here to trigger a UI update
+                    _self.$rootScope.$apply(() => {
+                        _self.deleteToken();
+                    });
+                }
             }
-        }
+        };
+
+        var win = _self.angular.element(_self.$window);
+        win.on("storage", updateTokenFromStorage);
+
+        updateTokenFromStorage();
     }
 
     private enableToken(token : string, userPath : string) : ng.IPromise<void> {


### PR DESCRIPTION
When multiple instances of adhocracy are embedded on a single host page,
the login status on all of them should be in sync. This also stretches
to other tabs and windows.

The user token is stored in local storage, so I implemented this
behavior by listening to 'storage' DOM events and updateing the user
service accordingly.
