### PR TITLE
Add header to embed directive

### DIFF
--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/Embed/Embed.ts
@@ -34,7 +34,11 @@ export var factory = ($compile : ng.ICompileService, $route : ng.route.IRouteSer
         restrict: "E",
         scope: {},
         link: (scope, element) => {
-            element.html(route2template($route));
+            var template = "<header class=\"l-header main-header\">" +
+                "<adh-user-indicator></adh-user-indicator>" +
+                "</header>";
+            template += route2template($route);
+            element.html(template);
             $compile(element.contents())(scope);
         }
     };


### PR DESCRIPTION
This way it is possible to login in embedded widgets.

This should be optional in the future because we have usecases for both.
