### PR TITLE
Fixup #49: Mock lodash in UserSpec

### DIFF
--- a/src/adhocracy/adhocracy/frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Adhocracy.ts
@@ -5,6 +5,7 @@
 /// <reference path="../lib/DefinitelyTyped/moment/moment.d.ts"/>
 /// <reference path="./_all.d.ts"/>
 
+import lodash = require("lodash");
 import angular = require("angular");
 import angularRoute = require("angularRoute");  if (angularRoute) { return; };
 // (since angularRoute does not export any objects or types we would
@@ -84,6 +85,7 @@ export var init = (config, meta_api) => {
         $locationProvider.html5Mode(true);
     }]);
 
+    app.value("lodash", lodash);
     app.value("angular", angular);
     app.value("Modernizr", modernizr);
     app.value("moment", moment);
@@ -91,7 +93,7 @@ export var init = (config, meta_api) => {
     app.filter("signum", () => (n : number) : string => n > 0 ? "+" + n.toString() : n.toString());
 
     app.service("adhProposal", ["adhHttp", "adhPreliminaryNames", "$q", AdhProposal.Service]);
-    app.service("adhUser", ["adhHttp", "$q", "$http", "$rootScope", "$window", "angular", "Modernizr", AdhUser.User]);
+    app.service("adhUser", ["adhHttp", "$q", "$http", "$rootScope", "$window", "angular", "Modernizr", "lodash", AdhUser.User]);
     app.directive("adhLogin", ["adhConfig", "$location", AdhUser.loginDirective]);
     app.directive("adhRegister", ["adhConfig", "$location", AdhUser.registerDirective]);
     app.directive("adhUserIndicator", ["adhConfig", AdhUser.indicatorDirective]);

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/User/User.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/User/User.ts
@@ -1,5 +1,3 @@
-import _ = require("lodash");
-
 import AdhHttp = require("../Http/Http");
 import AdhConfig = require("../Config/Config");
 
@@ -68,7 +66,8 @@ export class User {
         private $rootScope : ng.IScope,
         private $window : Window,
         private angular : ng.IAngularStatic,
-        private Modernizr
+        private Modernizr,
+        private _
     ) {
         var _self : User = this;
 

--- a/src/adhocracy/adhocracy/frontend/static/js/Packages/User/UserSpec.ts
+++ b/src/adhocracy/adhocracy/frontend/static/js/Packages/User/UserSpec.ts
@@ -23,6 +23,7 @@ export var register = () => {
             var elementMock;
             var angularMock;
             var modernizrMock;
+            var lodashMock;
 
             beforeEach(() => {
                 adhHttpMock = <any>jasmine.createSpyObj("adhHttpMock", ["get", "post"]);
@@ -56,7 +57,10 @@ export var register = () => {
                     localstorage: true
                 };
 
-                adhUser = new AdhUser.User(adhHttpMock, q, httpMock, rootScopeMock, windowMock, angularMock, modernizrMock);
+                lodashMock = {
+                    defer: (fn) => fn()
+                };
+                adhUser = new AdhUser.User(adhHttpMock, q, httpMock, rootScopeMock, windowMock, angularMock, modernizrMock, lodashMock);
             });
 
             it("registers a handler on 'storage' DOM events", () => {


### PR DESCRIPTION
This makes _.defer call the callback immediately, instead of after the
callstack has been cleared, which doesn't happen within one test.

I'm not sure if mocking _ is actually a good idea.
