### PR TITLE
don't show rate widget until it has finished loading

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.html
@@ -1,4 +1,4 @@
-<div class="rate">
+<div class="rate" data-ng-if="ready">
     <span class="rate-difference">
         <a href="" data-ng-click="toggleShowDetails()">
             {{rates.pro - rates.contra | signum}}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
@@ -64,6 +64,7 @@ export interface IRateScope extends ng.IScope {
     assureUserRateExists() : ng.IPromise<void>;
     postUpdate() : ng.IPromise<void>;
     optionsPostPool : AdhHttp.IOptions;
+    ready : boolean;
 }
 
 
@@ -309,6 +310,7 @@ export var rateController = (
     return updateRates(adapter, $scope, $q, adhHttp, adhUser)
         .then(() => {
             adhPermissions.bindScope($scope, $scope.postPoolPath, "optionsPostPool");
+            $scope.ready = true;
         });
 };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/RateSpec.ts
@@ -207,6 +207,10 @@ export var register = () => {
             afterEach(() => {
                 AdhRate.updateRates = realUpdateRates;
             });
+
+            it("sets scope.ready when finished initializing", () => {
+                expect(scopeMock.ready).toBe(true);
+            });
         });
     });
 };


### PR DESCRIPTION
This avoids an issue where `optionsPostPool.POST` was checked before it existed when users tried to cast a vote really fast.

The actual fix is tiny, but it required some refactoring in the unit tests.
