### PR TITLE
Make check_code only check changed files

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -186,19 +186,19 @@ input = inline:
 
     CHANGED_PY=`git diff --staged --name-only | grep '\.py$'`
     if [ -n "$CHANGED_PY" ] ; then
-        /home/nico/src/a3/bin/flake8 --ignore=N805,D101,D102 --exclude=bootstrap.py,conf.py,.svn,CVS,.bzr,.hg,.git,__pycache__,test_*,src/adhocracy_frontend/adhocracy_frontend/static/lib --max-complexity=14 ${CHANGED_PY}
+        ${buildout:bin-directory}/bin/flake8 --ignore=N805,D101,D102 --exclude=bootstrap.py,conf.py,.svn,CVS,.bzr,.hg,.git,__pycache__,test_*,src/adhocracy_frontend/adhocracy_frontend/static/lib --max-complexity=14 ${CHANGED_PY}
         ret_code=$(($ret_code + $?))
     fi
 
     CHANGED_SCSS=`git diff --staged --name-only | grep '\.scss$'`
     if [ -n "$CHANGED_SCSS" ] ; then
-        /home/nico/src/a3/bin/scss-lint -c /home/nico/src/a3/etc/scss-lint.yml ${CHANGED_SCSS}
+        ${buildout:bin-directory}/bin/scss-lint -c ${buildout:bin-directory}/etc/scss-lint.yml ${CHANGED_SCSS}
         ret_code=$(($ret_code + $?))
     fi
 
     CHANGED_TS=`git diff --staged --name-only | grep '\.ts$' | grep -v '\.d\.ts'`
     if [ -n "$CHANGED_TS" ] ; then
-        /home/nico/src/a3/bin/tslint -c  /home/nico/src/a3/etc/tslint.json -f ${CHANGED_TS}
+        ${buildout:bin-directory}/bin/tslint -c  ${buildout:bin-directory}/etc/tslint.json -f ${CHANGED_TS}
         ret_code=$(($ret_code + $?))
     fi
 


### PR DESCRIPTION
- Only call code checkers when something has changed
- Use sh instead of bash

This speeds up the pre-commit-hook from 5s to very fast.
