### PR TITLE
Fix LAST version path in frontend (trivial)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -150,7 +150,7 @@ export class Service<Content extends Resources.Content<any>> {
      * one version in LAST, throw an exception.
      */
     public getNewestVersionPathNoFork(path : string) : ng.IPromise<string> {
-        return this.get(path + "/LAST")
+        return this.get(path + "LAST/")
             .then((tag) => {
                 var heads = tag.data[SITag.nick].elements;
                 if (heads.length !== 1) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
@@ -182,8 +182,8 @@ export var register = () => {
             });
             describe("getNewestVersionPathNoFork", () => {
                 it("promises the unique path from the LAST tag", (done) => {
-                    var path = "path";
-                    var returnPath1 = "path1";
+                    var path = "path/";
+                    var returnPath1 = "path1/";
 
                     var dag = new RIParagraph({ preliminaryNames: adhPreliminaryNames });
                     dag.data["adhocracy_core.sheets.tags.ITag"] = new SITag.AdhocracyCoreSheetsTagsITag({ elements: [returnPath1] });
@@ -192,7 +192,7 @@ export var register = () => {
                     adhHttp.getNewestVersionPathNoFork(path).then(
                         (ret) => {
                             expect(ret).toBe(returnPath1);
-                            expect($httpMock.get).toHaveBeenCalledWith(path + "/LAST", { params: undefined });
+                            expect($httpMock.get).toHaveBeenCalledWith(path + "LAST/", { params: undefined });
                             done();
                         },
                         (msg) => {


### PR DESCRIPTION
Our paths now always end with a slash.
