### PR TITLE
use gunicorn instead of waitresss wsgi server:

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -352,5 +352,5 @@ environment =
 programs =
     10 zeo (stdout_logfile=var/log/zeo.log stderr_logfile=NONE startsecs=5 stopwaitsecs=10) ${buildout:bin-directory}/runzeo [-C etc/zeo.conf] ${buildout:directory} true
     20 autobahn (stdout_logfile=var/log/autobahn.log stderr_logfile=NONE) ${buildout:bin-directory}/start_ws_server [etc/development.ini] ${buildout:directory} true
-    30 adhocracy (stdout_logfile=var/log/adhocracy.log stderr_logfile=NONE startsecs=5 stopwaitsecs=10) ${buildout:bin-directory}/pserve [etc/development.ini] ${buildout:directory} true
-    40 adhocracy_frontend (stdout_logfile=var/log/adhocracy_frontend.log stderr_logfile=NONE) ${buildout:bin-directory}/pserve [etc/frontend_development.ini] ${buildout:directory} true
+    30 adhocracy (stdout_logfile=var/log/adhocracy.log stderr_logfile=NONE startsecs=5 stopwaitsecs=10) ${buildout:bin-directory}/gunicorn [--paste etc/development.ini] ${buildout:directory} true
+    40 adhocracy_frontend (stdout_logfile=var/log/adhocracy_frontend.log stderr_logfile=NONE) ${buildout:bin-directory}/gunicorn [--paste etc/frontend_development.ini] ${buildout:directory} true

--- a/etc/development.ini
+++ b/etc/development.ini
@@ -39,7 +39,7 @@ mail.tls = False
 mail.ssl = False
 
 [server:main]
-use = egg:waitress#main
+use = egg:gunicorn#main
 host = 0.0.0.0
 port = 6541
 

--- a/etc/frontend_development.ini
+++ b/etc/frontend_development.ini
@@ -32,7 +32,7 @@ adhocracy.trusted_domains =
 #     http://localhost:9001
 
 [server:main]
-use = egg:waitress#main
+use = egg:gunicorn#main
 host = 0.0.0.0
 port = 6551
 

--- a/etc/frontend_test.ini
+++ b/etc/frontend_test.ini
@@ -21,7 +21,7 @@ adhocracy.frontend.template_path = /static/templates
 adhocracy.frontend.rest_url = http://localhost:6542
 
 [server:main]
-use = egg:waitress#main
+use = egg:gunicorn#main
 host = localhost
 port = 6552
 

--- a/etc/noserver.ini
+++ b/etc/noserver.ini
@@ -40,7 +40,7 @@ mail.queue_path = %(here)s/../var/mail
 mail.default_sender = admin@example.com
 
 [server:main]
-use = egg:waitress#main
+use = egg:gunicorn#main
 host = 0.0.0.0
 port = 6541
 

--- a/etc/test.ini
+++ b/etc/test.ini
@@ -14,7 +14,7 @@ adhocracy.ws_url = ws://localhost:8081
 mail.default_sender = support@unconfigured.domain
 
 [server:main]
-use = egg:waitress#main
+use = egg:gunicorn#main
 host = localhost
 port = 6542
 

--- a/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
+++ b/src/adhocracy_core/adhocracy_core/scaffolds/adhocracy/development.ini_tmpl
@@ -40,7 +40,7 @@ mail.queue_path = %(here)s/../var/mail
 mail.default_sender = admin@example.com
 
 [server:main]
-use = egg:waitress#main
+use = egg:gunicorn#main
 host = 0.0.0.0
 port = 6541
 

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -13,7 +13,7 @@ requires = [
     'pyramid',
     'pyramid_debugtoolbar',
     'pyramid_exclog',
-    'waitress',
+    'gunicorn',
     'substanced',
     'pyramid_tm',
     'cornice',


### PR DESCRIPTION
- more stable backend (I could not reproduce TransientErrors or lost data in the front end)
- multi-threads/process possible
- measure request time possible
- python, simple to install
