### PR TITLE
fix embed resizing

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/_overwrite.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/_overwrite.scss
@@ -8,6 +8,18 @@ html, body {
     padding: 0;
 }
 
+/**
+ * When adhocracy is embedded, we have some code that determines its height and
+ * resizes the iframe accordingly.  For this to work, the body must not have
+ * any margins.  Apart from setting `margin: 0` on body we also need to prevent
+ * margin collapsing.  This can be done by adding a small padding both at the
+ * top and the bottom.  The trade-off is that there is some additional padding
+ * which might look strange.
+ */
+body {
+    padding: 1px 0;
+}
+
 .main-header {
     padding: 0.5em;
     background: $color-structure-surface;


### PR DESCRIPTION
There was a bug with collapsing margins that messed up the resizing when adhocracy is embedded.

To reproduce, I recommend to change embed.html to show the adh-comment-listing widget with the path of an existing proposal.
