### PR TITLE
Allow to configure frontend locale

### DIFF
--- a/etc/frontend_development.ini
+++ b/etc/frontend_development.ini
@@ -23,6 +23,8 @@ adhocracy.frontend.template_path = /static/templates
 adhocracy.frontend.rest_url = http://localhost:6541
 # The email address show to users seeking support
 adhocracy.frontend.support_email = support@unconfigured.domain
+# Default frontend locale
+adhocracy.frontend.locale = de
 
 # If the Adhocracy frontend is embedded in a website from a trusted domain,
 # Adhocracy may pass user authentication token to the embedding website.

--- a/src/adhocracy_frontend/adhocracy_frontend/__init__.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/__init__.py
@@ -29,6 +29,7 @@ def config_view(request):
         settings.get('adhocracy.trusted_domains', []))
     config['support_email'] = settings.get('adhocracy.frontend.support_email',
                                            'support@unconfigured.domain')
+    config['locale'] = settings.get('adhocracy.frontend.locale', 'en')
     return config
 
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -59,9 +59,6 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         window.document.body.className += " is-embedded";
     }
 
-    // FIXME: The functionality to set the locale is not yet done
-    config.locale = "de";
-
     var app = angular.module("adhocracy3SampleFrontend", [
         "monospaced.elastic",
         "pascalprecht.translate",

--- a/src/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/static/js/Adhocracy.ts
@@ -60,9 +60,6 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         window.document.body.className += " is-embedded";
     }
 
-    // FIXME: The functionality to set the locale is not yet done
-    config.locale = "de";
-
     var app = angular.module("adhocracy3SampleFrontend", [
         "monospaced.elastic",
         "pascalprecht.translate",


### PR DESCRIPTION
This allows to configure the frontend locale instead of hardcoding to
'de'.

At a later stage, we'll add more sophisticated options, such as browser
detection and fallback languages.

This is required for policycompass/policycompass-frontend#19.
