### PR TITLE
encode content2Url in path

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -48,6 +48,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
             var data = self.provider.get(resource.content_type);
             data["platform"] = path.split("/")[1];
 
+            // if path contains more than just the platform
             if (path.split("/").length > 2) {
                 data["content2Url"] = this.adhConfig.rest_url + path;
             }


### PR DESCRIPTION
this improves resource routing by encoding content2Url in path. This way the urls get much shorter. It is the first time we actually use path rewriting in the new routing mechanism.

This is probably still not the final form of resourceArea, but it is much better than before.
