### PR TITLE
Add trivial rating to mercator details

### DIFF
--- a/src/mercator/static/js/Packages/MercatorProposal/Detail.html
+++ b/src/mercator/static/js/Packages/MercatorProposal/Detail.html
@@ -12,4 +12,8 @@
             <span>votes: [#votes]</span>
         </div>
     </div>
+    <adh-rate data-refers-to="{{path}}"
+        data-post-pool-sheet="adhocracy.sheets.rate.IRateable"
+        data-post-pool-field="post_pool">
+    </adh-rate>
 </div>


### PR DESCRIPTION
This is still the wrong rating widget - we want to have "support only"
instead.
