### PR TITLE
Remove listing margins from create form

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_listing.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_listing.scss
@@ -47,7 +47,5 @@ a form for creating new elements. This form is then always visible.
 .listing-create-form {
     background-color: $color-structure-surface;
     padding: 0.5em;
-    margin-left: -0.5em;
-    margin-right: -0.5em;
     margin-bottom: 2em;
 }


### PR DESCRIPTION
The hereby removed margins caused the form to stand out of it actual
size.

This causes scrollbars if such a form is to be embedded.

As the design isn't final anyway, this simply removes the margins.
