### PR TITLE
AdhocracySDK: Only handle messages from embedded windows

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracySDK.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracySDK.ts
@@ -84,8 +84,18 @@
             $ = (<any>window).jQuery.noConflict(true);
 
             $(window).on("message", (event) => {
-                var message = JSON.parse(event.originalEvent.data);
-                handleMessage(message.name, message.data, event.originalEvent.source);
+                // Only parse messages from embedded windows
+                //
+                // FIXME: We should maintain a list of embedded windows
+                if (event.originalEvent.source !== window) {
+                    try {
+                        var message = JSON.parse(event.originalEvent.data);
+                        handleMessage(message.name, message.data, event.originalEvent.source);
+                    } catch (e) {
+                        // Make invalid messages fail silently as it may come
+                        // from another window
+                    }
+                }
             });
 
             callback(adhocracy);


### PR DESCRIPTION
Invalid messages fail silently. The better fix would be to maintain a list of embedded adhocracy windows.

This PR is motivated, as the Policy Compass frontend also uses the window messaging system, and that way causes errors in the console (see policycompass/policycompass-frontend#51).
