### PR TITLE
fix mercator proposal field types

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -675,7 +675,7 @@ mkFieldType = (field : MetaApi.ISheetField) : string => {
 
     switch (field.valuetype) {
     case "adhocracy_core.schema.Boolean":
-        result = "boolean";
+        result = "string";
         break;
     case "adhocracy_core.schema.AbsolutePath":
         result = "string";
@@ -723,7 +723,7 @@ mkFieldType = (field : MetaApi.ISheetField) : string => {
         result = "string[]";
         break;
     case "adhocracy_core.schema.CurrencyAmount":
-        result = "number";
+        result = "string";
         break;
     case "adhocracy_core.schema.ISOCountryCode":
         result = "number";

--- a/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -184,11 +184,11 @@ export class Widget<R extends ResourcesBase.Resource> extends AdhResourceWidgets
         data.user_info.last_name = mercatorProposalVersion.data[SIMercatorUserInfo.nick].family_name;
         data.user_info.country = mercatorProposalVersion.data[SIMercatorUserInfo.nick].country;
 
-        data.heard_from.colleague = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_from_colleague;
-        data.heard_from.website = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_from_website;
-        data.heard_from.newsletter = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_from_newsletter;
-        data.heard_from.facebook = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_from_facebook;
-        data.heard_from.other = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_elsewhere;
+        data.heard_from.colleague = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_from_colleague === "true";
+        data.heard_from.website = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_from_website === "true";
+        data.heard_from.newsletter = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_from_newsletter === "true";
+        data.heard_from.facebook = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_from_facebook === "true";
+        data.heard_from.other = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_elsewhere !== "";
         data.heard_from.other_specify = mercatorProposalVersion.data[SIMercatorHeardFrom.nick].heard_elsewhere;
 
         var subResourcePaths : SIMercatorSubResources.Sheet = mercatorProposalVersion.data[SIMercatorSubResources.nick];
@@ -233,12 +233,12 @@ export class Widget<R extends ResourcesBase.Resource> extends AdhResourceWidgets
                         var res : SIMercatorDetails.Sheet = subResource.data[SIMercatorDetails.nick];
 
                         scope.description = res.description;
-                        scope.location_is_specific = res.location_is_specific;
+                        scope.location_is_specific = res.location_is_specific === "true";
                         scope.location_specific_1 = res.location_specific_1;
                         scope.location_specific_2 = res.location_specific_2;
                         scope.location_specific_3 = res.location_specific_3;
-                        scope.location_is_online = res.location_is_online;
-                        scope.location_is_linked_to_ruhr = res.location_is_linked_to_ruhr;
+                        scope.location_is_online = res.location_is_online === "true";
+                        scope.location_is_linked_to_ruhr = res.location_is_linked_to_ruhr === "true";
                     })();
                     break;
                     case RIMercatorStoryVersion.content_type: (() => {
@@ -270,10 +270,10 @@ export class Widget<R extends ResourcesBase.Resource> extends AdhResourceWidgets
                         var scope = data.finance;
                         var res : SIMercatorFinance.Sheet = subResource.data[SIMercatorFinance.nick];
 
-                        scope.budget = res.budget;
-                        scope.requested_funding = res.requested_funding;
+                        scope.budget = parseInt(res.budget, 10);
+                        scope.requested_funding = parseInt(res.requested_funding, 10);
                         scope.other_sources = res.other_sources;
-                        scope.granted = res.granted;
+                        scope.granted = res.granted === "True";
                     })();
                     break;
                     case RIMercatorExperienceVersion.content_type: (() => {


### PR DESCRIPTION
for some reason, the backend returns strings for curreny amounts and booleans. This is a workaround in the frontend. See also FIXME in `MercatorProposal/Detail.html`.

I would rather like to have this fixed in the backend. If that is not possible or not desirable, we can merge this.
