### PR TITLE
misc bugs (a)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
@@ -40,10 +40,10 @@ export var logBackendError = (response : ng.IHttpPromiseCallbackArg<IBackendErro
         var errors : IBackendErrorItem[] = response.data.errors;
         throw errors;
     } else {
-        // FIXME: sometimes, $http.get (and possibly other verbs)
-        // throw an exception when the backend responds with an error
-        // status, and whipe the response object before passing it to
-        // the error handler callback (see disabled test "do not lose
+        // FIXME: the backend currently responds with errors in HTML,
+        // not in json, which provokes $http to throw an exception and
+        // whipe the response object before passing it to the error
+        // handler callback.  See #256 and disabled test "do not lose
         // error response status and body" in HttpIg.ts).
         //
         // the following line works around that.

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpIg.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpIg.ts
@@ -35,9 +35,9 @@ export var register = (angular, config, meta_api) => {
 
         // FIXME: there is a work-around for this problem in Error.ts
         // in function logBackendError.  if this test is re-enabled
-        // and the underlying issue is fixed, removed the work-around.
+        // and the underlying issue is fixed, remove the work-around.
         xit("do not lose error response status and body.", (done) => {
-            adhHttp.getRaw("/principials/groups/LAST/").then(
+            adhHttp.getRaw("/does/not/exist").then(
                 (response) => {
                     expect("should not succeed").toBe(true);
                     done();


### PR DESCRIPTION
sometimes, $http eats up the response data and throws it as an exception, where i would expect it to be available in the error handling callback.  this is a failing test case (disabled) plus work-around.  the work-around does not make the test succeed (then it would be a fix), but keeps the frontend from crashing.
