### PR TITLE
replace ng-switch by ng-if

### DIFF
--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.html
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.html
@@ -1,68 +1,68 @@
 <adh-spaces>
     <div data-adh-moving-columns="" data-space="content" class="moving-columns" data-ng-class="{'hidden': currentSpace !== 'content'}">
         <div class="moving-column moving-column-structure">
-                <div data-ng-if="view === 'create_proposal'">
-                    <div class="moving-column-menu placeholder"></div>
-                    <div class="moving-column-body" data-du-scroll-container="">
-                        <adh-resource-wrapper data-on-submit="goToListing()" data-on-cancel="goToListing()">
-                            <adh-mercator-proposal-create
-                                data-path="@preliminary"
-                                data-mode="edit"
-                                data-pool-path="{{path}}">
-                            <adh-mercator-proposal-create>
-                        </adh-resource-wrapper>
-                    </div>
+            <div data-ng-if="view === 'create_proposal'">
+                <div class="moving-column-menu placeholder"></div>
+                <div class="moving-column-body" data-du-scroll-container="">
+                    <adh-resource-wrapper data-on-submit="goToListing()" data-on-cancel="goToListing()">
+                        <adh-mercator-proposal-create
+                            data-path="@preliminary"
+                            data-mode="edit"
+                            data-pool-path="{{path}}">
+                        <adh-mercator-proposal-create>
+                    </adh-resource-wrapper>
                 </div>
-                <div data-ng-if="view !== 'create_proposal'">
-                    <div class="moving-column-menu placeholder">
-                        <a href="" data-ng-click="proposalListingData.showFacets = !proposalListingData.showFacets">{{ "filters" | translate }}</a>
-                    </div>
-                    <div
-                        class="moving-column-sidebar"
-                        data-ng-class="{'is-visible': proposalListingData.showFacets}"
-                        aria-visible="{{proposalListingData.showFacets}}">
-                        <adh-facets
-                            data-update="proposalListingData.update"
-                            data-facets="proposalListingData.facets">
-                        </adh-facets>
-                    </div>
-                    <div class="moving-column-body" data-du-scroll-container="">
-                        <adh-mercator-proposal-listing
-                            data-path="{{path}}"
-                            data-content-type="{{contentType}}"
-                            data-update="proposalListingData.update"
-                            data-facets="proposalListingData.facets">
-                        </adh-mercator-proposal-listing>
-                    </div>
+            </div>
+            <div data-ng-if="view !== 'create_proposal'">
+                <div class="moving-column-menu placeholder">
+                    <a href="" data-ng-click="proposalListingData.showFacets = !proposalListingData.showFacets">{{ "filters" | translate }}</a>
                 </div>
+                <div
+                    class="moving-column-sidebar"
+                    data-ng-class="{'is-visible': proposalListingData.showFacets}"
+                    aria-visible="{{proposalListingData.showFacets}}">
+                    <adh-facets
+                        data-update="proposalListingData.update"
+                        data-facets="proposalListingData.facets">
+                    </adh-facets>
+                </div>
+                <div class="moving-column-body" data-du-scroll-container="">
+                    <adh-mercator-proposal-listing
+                        data-path="{{path}}"
+                        data-content-type="{{contentType}}"
+                        data-update="proposalListingData.update"
+                        data-facets="proposalListingData.facets">
+                    </adh-mercator-proposal-listing>
+                </div>
+            </div>
         </div>
         <div class="moving-column moving-column-content">
-                <div data-ng-if="view === 'edit'">
-                    <div class="moving-column-menu placeholder"></div>
-                    <div class="moving-column-body" data-du-scroll-container="">
-                        <adh-resource-wrapper
-                            data-on-submit="goToProposal(proposalUrl)"
-                            data-on-cancel="goToProposal(proposalUrl)">
-                            <adh-mercator-proposal-create
-                                data-ng-if="proposalUrl"
-                                data-path="{{proposalUrl}}"
-                                data-mode="edit"
-                                data-pool-path="{{path}}">
-                            </adh-mercator-proposal-create>
-                        </adh-resource-wrapper>
-                    </div>
+            <div data-ng-if="view === 'edit'">
+                <div class="moving-column-menu placeholder"></div>
+                <div class="moving-column-body" data-du-scroll-container="">
+                    <adh-resource-wrapper
+                        data-on-submit="goToProposal(proposalUrl)"
+                        data-on-cancel="goToProposal(proposalUrl)">
+                        <adh-mercator-proposal-create
+                            data-ng-if="proposalUrl"
+                            data-path="{{proposalUrl}}"
+                            data-mode="edit"
+                            data-pool-path="{{path}}">
+                        </adh-mercator-proposal-create>
+                    </adh-resource-wrapper>
                 </div>
-                <div data-ng-if="view !== 'view'">
-                    <div class="moving-column-menu">
-                        <!-- FIXME: permission check -->
-                        <a href="{{ proposalUrl | adhResourceUrl:'edit' }}">{{ "edit" | translate }}</a>
-                    </div>
-                    <div class="moving-column-body" data-du-scroll-container="">
-                        <adh-resource-wrapper>
-                            <adh-mercator-proposal-detail-view data-ng-if="proposalUrl" data-path="{{proposalUrl}}"></adh-mercator-proposal-detail-view>
-                        </adh-resource-wrapper>
-                    </div>
+            </div>
+            <div data-ng-if="view !== 'view'">
+                <div class="moving-column-menu">
+                    <!-- FIXME: permission check -->
+                    <a href="{{ proposalUrl | adhResourceUrl:'edit' }}">{{ "edit" | translate }}</a>
                 </div>
+                <div class="moving-column-body" data-du-scroll-container="">
+                    <adh-resource-wrapper>
+                        <adh-mercator-proposal-detail-view data-ng-if="proposalUrl" data-path="{{proposalUrl}}"></adh-mercator-proposal-detail-view>
+                    </adh-resource-wrapper>
+                </div>
+            </div>
         </div>
         <div class="moving-column moving-column-content2">
             <div class="moving-column-menu placeholder"></div>


### PR DESCRIPTION
It seems like the contents of ng-switch are recompiled whenever the
switched expression changes. So even if both the old and new case end up
being ng-switch-default, the contents are recompiled (triggering all
kinds of requests and other nasty things).
