### PR TITLE
Sort mercator proposals by version name

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -55,6 +55,7 @@ export interface ListingScope<Container> extends ng.IScope {
     path : string;
     contentType? : string;
     facets? : IFacet[];
+    sort? : string;
     container : Container;
     poolPath : string;
     poolOptions : AdhHttp.IOptions;
@@ -100,6 +101,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
                 path: "@",
                 contentType: "@",
                 facets: "=",
+                sort: "=",
                 update: "=?",
                 noCreateForm: "="
             },
@@ -134,6 +136,9 @@ export class Listing<Container extends ResourcesBase.Resource> {
                                 }
                             });
                         });
+                    }
+                    if ($scope.sort) {
+                        params["sort"] = $scope.sort;
                     }
                     return adhHttp.get($scope.path, params).then((container) => {
                         $scope.container = container;

--- a/src/mercator/static/js/Packages/MercatorProposal/Listing.html
+++ b/src/mercator/static/js/Packages/MercatorProposal/Listing.html
@@ -2,6 +2,7 @@
     data-path="{{path}}"
     data-content-type="{{contentType}}"
     data-facets="facets"
+    data-sort="sort"
     data-update="update"
     data-no-create-form="true">
     <div data-ng-switch="transclusionId">

--- a/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -560,7 +560,8 @@ export var listing = (adhConfig : AdhConfig.IService) => {
             path: "@",
             contentType: "@",
             update: "=",
-            facets: "="
+            facets: "=",
+            sort: "="
         }
     };
 };

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.html
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.html
@@ -31,7 +31,9 @@
                         data-path="{{path}}"
                         data-content-type="{{contentType}}"
                         data-update="proposalListingData.update"
-                        data-facets="proposalListingData.facets">
+                        data-facets="proposalListingData.facets"
+                        data-sort="proposalListingData.sort"
+                    >
                     </adh-mercator-proposal-listing>
                 </div>
             </div>

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -27,6 +27,7 @@ interface IMercatorWorkbenchScope extends ng.IScope {
     proposalListingData : {
         facets : AdhListing.IFacet[];
         showFacets : boolean;
+        sort : string;
         update?;
     };
 }
@@ -73,7 +74,8 @@ export class MercatorWorkbench {
                             {key: "50000", name: "20000 - 50000 €"}
                         ]
                     }],
-                    showFacets: false
+                    showFacets: false,
+                    sort: "name"
                 };
 
                 adhTopLevelState.on("view", (value : string) => {


### PR DESCRIPTION
Note that this doesn't have any practical effect at the moment, because the _name_ of all versions is `VERSION_0000...`.

Therefore we need to index the title of the versions in order to really sort by title.

Alternatively we could, in order to get a stable sorting, fix the rate index - @joka is working on this.
