### PR TITLE
Sort mercator proposals by rate

### DIFF
--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.ts
@@ -83,7 +83,7 @@ export class MercatorWorkbench {
                         ]
                     }],
                     showFacets: false,
-                    sort: "name"
+                    sort: "rates"
                 };
 
                 $rootScope.mercatorProposalPostPoolOptions = AdhHttp.emptyOptions;


### PR DESCRIPTION
Note that this puts lowest rated first.

In order to put highest rated first, we can sort in the backend or in the frontend. I'd favor to do it in the backend for consistency reasons (extend the API to allow to add a `-` for descending sorting, e.g. `sort=-rates`), but doing it in the frontend is also easy.

But that can be done separately.
