### PR TITLE
recompileOnChange: destroy scope (fixes #300)

### DIFF
--- a/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -945,6 +945,7 @@ export var recompileOnChange = ($compile : ng.ICompileService) => {
 
             var contents = element.contents().remove();
             var compiledContents;
+            var innerScope : ng.IScope;
 
             return {
                 pre: (link && link.pre) ? link.pre : null,
@@ -953,11 +954,13 @@ export var recompileOnChange = ($compile : ng.ICompileService) => {
                         compiledContents = $compile(contents);
                     }
 
-                    var innerScope = scope.$new();
-
                     scope.$watch(() => attrs["value"], (value) => {
-                        element.html("");
+                        if (typeof innerScope !== "undefined") {
+                            innerScope.$destroy();
+                            element.contents().remove();
+                        }
 
+                        innerScope = scope.$new();
                         innerScope[attrs["key"]] = value;
 
                         compiledContents(innerScope, (clone) => {


### PR DESCRIPTION
See http://www.mattzeunert.com/2014/11/03/manually-removing-angular-directives.html
