### PR TITLE
Fix example domain in fixture script

### DIFF
--- a/src/mercator/tests/fixtures/fixturesUsers1.py
+++ b/src/mercator/tests/fixtures/fixturesUsers1.py
@@ -37,7 +37,7 @@ def register_user(user_name):
                     'password': 'password'
                 },
                 'adhocracy_core.sheets.principal.IUserBasic': {
-                'email': user_name + '@someisp.de',
+                'email': user_name + '@example.org',
                 'name': user_name
             }
         },


### PR DESCRIPTION
I start getting bounce emails from our mailserver, probably due to the deployment on the `a3-dev` test server.

We should in general use [reserved domains](https://www.iana.org/domains/reserved) as examples all over the code.
