### PR TITLE
2014 12 sz actest proposal heard of bug

### DIFF
--- a/src/mercator/tests/acceptance/test_mercator_proposal.py
+++ b/src/mercator/tests/acceptance/test_mercator_proposal.py
@@ -80,6 +80,7 @@ class TestMercatorForm:
         browser.find_by_name('heard-from-colleague').first.check()
         assert is_valid(browser)
 
+    @mark.xfail
     def test_heard_of_is_not_changed_after_submission(self, browser):
         browser.find_by_css('input[type="submit"]').first.click()
         wait(lambda: browser.url.endswith("/r/mercator/"))


### PR DESCRIPTION
There is a bug in mercator proposal submission, that causes the `heard-of` checkboxes in a proposal to be unchecked on submission. I wrote a test, that checks in the newly added proposal whether there is a non empty `heard-of` paragraph html element in the proposal. I am not sure, whether this is sufficient. We should have a test that verifies, that the data in a proposal view is the same data entered during proposal submission.
