### PR TITLE
avoid exceptions on parentPath

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -125,7 +125,7 @@ export var movingColumns = (
             adhTopLevelState.on("userUrl", (url : string) => {
                 scope.userUrl = url;
             });
-            adhPermissions.bindScope(scope, () => AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
+            adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
             adhTopLevelState.on("movingColumns", move);
             adhTopLevelState.on("focus", resize);


### PR DESCRIPTION
this is a fixup to #332: Sometimes, `scope.proposalPath` is `undefined`. In the cases, `AdhUtil.parentPath()` throws an exception. This commit avoids that exception.
