### PR TITLE
remove hidden column sidebar from taborder (fixes #352)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -224,6 +224,7 @@ States:
 }
 
 .moving-column-sidebar {
+    display: none;
     position: absolute;
     top: $moving-column-menu-height;
     bottom: 0;
@@ -237,5 +238,11 @@ States:
 
     &.is-visible {
         left: 0;
+    }
+
+    &.is-visible,
+    &.is-visible-add,
+    &.is-visible-remove {
+        display: block;
     }
 }


### PR DESCRIPTION
a similar problem exists for moving columns. But I did not manage to fix
it there and it is also less relevant because the child elements have
`display: none` there.
