### PR TITLE
Prevent upload of overly large assets

### DIFF
--- a/src/adhocracy_core/adhocracy_core/schema/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/schema/test_init.py
@@ -1120,3 +1120,19 @@ class TestFileStoreType:
         value = Mock()
         with raises(colander.Invalid):
             inst.deserialize(None, value)
+
+    def test_deserialize_too_large(self, inst, monkeypatch):
+        from adhocracy_core import schema
+        import os
+        mock_response = Mock()
+        mock_file_constructor = Mock(spec=schema.File,
+                                     return_value=mock_response)
+        monkeypatch.setattr(schema, 'File', mock_file_constructor)
+        mock_fstat_result = Mock()
+        mock_fstat_result.st_size = 20000000
+        mock_fstat = Mock(spec=os.fstat, return_value=mock_fstat_result)
+        monkeypatch.setattr(os, 'fstat', mock_fstat)
+        value = Mock()
+        with raises(colander.Invalid) as err_info:
+            inst.deserialize(None, value)
+        assert 'too large' in err_info.value.msg

--- a/src/adhocracy_core/docs/assets_and_images.rst
+++ b/src/adhocracy_core/docs/assets_and_images.rst
@@ -173,6 +173,10 @@ path of the new resource (just as with other resource types)::
     >>> pic_path
     'http://localhost/adhocracy/ProposalPool/assets/0000000/'
 
+If the frontend tries to upload an asset that is overly large (more than 16
+MB), the backend responds with an error. Stricter size limits may be
+appropriate for some asset types, but they are left to the frontend.
+
 
 Downloading Assets
 ------------------
@@ -320,5 +324,3 @@ Deleting and Hiding Assets
 
 Assets can be deleted or censored ("hidden") in the usual way, see
 :ref:`deletion`.
-
-TODO Add example testing this using delete (also for children).


### PR DESCRIPTION
Backend now prevents PUTting or POSTing assets with more than 16 MB.
