### PR TITLE
Repin setuptools to 8.0.3 (partially reverts #405)

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -51,7 +51,7 @@ compile python 3.4 and PIL ::
 
 install adhocracy ::
 
-    ./bin/python ./bootstrap.py
+    ./bin/python ./bootstrap.py -v 2.3.0 --setuptools-version=8.0.3
     ./bin/buildout
 
 update your shell environment::

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -39,6 +39,7 @@ repoze.profile = 2.0
 repoze.sendmail = 4.2
 rubygemsrecipe = 0.2.1
 selenium = 2.43.0
+setuptools = 8.0.3
 sphinx-autodoc-annotation = 1.0
 sphinxcontrib-napoleon = 0.2.8
 sphinxcontrib-zopeext = 0.2.1


### PR DESCRIPTION
Sorry for the noise: setuptools 8.0.4 introduced ugly warnings which
created more output than the buildout itself.

Let's keep setuptools pinned.
