### PR TITLE
RemoteBrowserConsole service.

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/RemoteBrowserConsole/RemoteBrowserConsole.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/RemoteBrowserConsole/RemoteBrowserConsole.ts
@@ -1,0 +1,94 @@
+import AdhHttp = require("../Http/Http");
+
+
+/**
+ * See `console.*` and `window.onerror` with functions that send all
+ * of console.log to the backend.
+ *
+ * WARNING: Before you activate this service, consider privacy
+ * implications and legal constraints!
+ *
+ * FIXME: some exceptions are not caught, e.g. (I think) exceptions in
+ * async calls (?) and things called from dom, like `<img
+ * src="bad-url" />`
+ *
+ * FIXME: this may break IE9.  it certainly won't work as intended.
+ */
+export class Service {
+    private verbosity = {
+        header: true,
+        reportToBackend: true,
+        reportToConsole: true
+    }
+
+    constructor(private adhHttp : AdhHttp.Service<any>) {
+        (<any>console).__log = (<any>console).log;
+        (<any>console).log = () => {
+            if (this.verbosity.header) (<any>console).__log("*** log");
+            if (this.verbosity.reportToBackend) this.report(arguments);
+            if (this.verbosity.reportToConsole) (<any>console).__log.apply((<any>console), arguments);
+        };
+
+        (<any>console).__assert = (<any>console).assert;
+        (<any>console).assert = () => {
+            if (this.verbosity.header) (<any>console).__log("*** assert");
+            if (this.verbosity.reportToBackend) this.report(arguments);
+            if (this.verbosity.reportToConsole) (<any>console).__assert.apply((<any>console), arguments);
+        };
+
+        (<any>console).__trace = (<any>console).trace;
+        (<any>console).trace = () => {
+            if (this.verbosity.header) (<any>console).__log("*** trace");
+            if (this.verbosity.reportToBackend) this.report(arguments);
+            if (this.verbosity.reportToConsole) (<any>console).__trace.apply((<any>console), arguments);
+        };
+
+        (<any>console).__debug = (<any>console).debug;
+        (<any>console).debug = () => {
+            if (this.verbosity.header) (<any>console).__debug("*** debug");
+            if (this.verbosity.reportToBackend) this.report(arguments);
+            if (this.verbosity.reportToConsole) (<any>console).__debug.apply((<any>console), arguments);
+        };
+
+        (<any>console).__info = (<any>console).info;
+        (<any>console).info = () => {
+            if (this.verbosity.header) (<any>console).__info("*** info");
+            if (this.verbosity.reportToBackend) this.report(arguments);
+            if (this.verbosity.reportToConsole) (<any>console).__info.apply((<any>console), arguments);
+        };
+
+        (<any>console).__warn = (<any>console).warn;
+        (<any>console).warn = () => {
+            if (this.verbosity.header) (<any>console).__warn("*** warn");
+            if (this.verbosity.reportToBackend) this.report(arguments);
+            if (this.verbosity.reportToConsole) (<any>console).__warn.apply((<any>console), arguments);
+        };
+
+        (<any>console).__error = (<any>console).error;
+        (<any>console).error = () => {
+            if (this.verbosity.header) (<any>console).__error("*** error");
+            if (this.verbosity.reportToBackend) this.report(arguments);
+            if (this.verbosity.reportToConsole) (<any>console).__error.apply((<any>console), arguments);
+        };
+
+        window.onerror = () => {
+            if (this.verbosity.header) (<any>console).__log("*** EXCEPTION!");
+            if (this.verbosity.reportToBackend) this.report(arguments);
+            if (this.verbosity.reportToConsole) (<any>console).__log.apply((<any>console), arguments);
+        };
+    }
+
+    private report(arguments : any) : void {
+        this.adhHttp.postRaw("/browser_console/", arguments);
+    }
+}
+
+export var moduleName = "adhRemoteBrowserConsole";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhHttp.moduleName
+        ])
+        .service("adhRemoteBrowserConsole", ["adhHttp", Service]);
+};

--- a/src/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/static/js/Adhocracy.ts
@@ -37,6 +37,7 @@ import AdhPreliminaryNames = require("./Packages/PreliminaryNames/PreliminaryNam
 import AdhProposal = require("./Packages/Proposal/Proposal");
 import AdhRate = require("./Packages/Rate/Rate");
 import AdhAngularHelpers = require("./Packages/AngularHelpers/AngularHelpers");
+import AdhRemoteBrowserConsole = require("./Packages/RemoteBrowserConsole/RemoteBrowserConsole");
 import AdhResourceArea = require("./Packages/ResourceArea/ResourceArea");
 import AdhResourceWidgets = require("./Packages/ResourceWidgets/ResourceWidgets");
 import AdhSticky = require("./Packages/Sticky/Sticky");
@@ -75,6 +76,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
         AdhEmbed.moduleName,
         AdhMercatorProposal.moduleName,
         AdhMercatorWorkbench.moduleName,
+        AdhRemoteBrowserConsole.moduleName,
         AdhResourceArea.moduleName,
         AdhProposal.moduleName,
         AdhSticky.moduleName
@@ -150,6 +152,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
     AdhProposal.register(angular);
     AdhRate.register(angular);
     AdhAngularHelpers.register(angular);
+    AdhRemoteBrowserConsole.register(angular);
     AdhResourceArea.register(angular);
     AdhResourceWidgets.register(angular);
     AdhSticky.register(angular);
@@ -159,6 +162,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
 
     // force-load some services
     var injector = angular.bootstrap(document, ["a3Mercator"]);
+    // injector.get("adhRemoteBrowserConsole");
     injector.get("adhCrossWindowMessaging");
 
     loadComplete();


### PR DESCRIPTION
Frontend part of a device for logging browser console output to the server.  In principle this could be merged without implementing the backend part, since it is not activated by default.

MISSING: Before loading this service, the backend needs to provide an end point `/browser_console/` that logs all bodies that it gets, together with information about the client (like e.g. session token; IP address would probably be bad).
