### PR TITLE
Cropped+resized images use same format as original image

### DIFF
--- a/src/adhocracy_core/adhocracy_core/sheets/asset.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/asset.py
@@ -135,15 +135,16 @@ class AssetFileDownload(Persistent):
         parent_file = retrieve_asset_file(context.__parent__, registry)
         # Crop and resize image via PIL
         with parent_file.blob.open('r') as blobdata:
+            mimetype = parent_file.mimetype
             image = Image.open(blobdata)
             cropped_image = self._crop_if_needed(image)
             resized_image = cropped_image.resize(self.dimensions,
                                                  Image.ANTIALIAS)
             bytestream = io.BytesIO()
-            resized_image.save(bytestream, 'JPEG')
+            resized_image.save(bytestream, mimetype.split('/')[1])
             bytestream.seek(0)
         # Store as substanced File and return
-        self.file = File(stream=bytestream, mimetype='image/jpeg')
+        self.file = File(stream=bytestream, mimetype=mimetype)
         transaction.commit()  # to avoid BlobError: Uncommitted changes
         return self.file
 

--- a/src/adhocracy_core/adhocracy_core/sheets/test_asset.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_asset.py
@@ -191,6 +191,7 @@ class TestAssetFileDownload:
         file = Mock(spec=File)
         file.blob = Mock()
         file.blob.open.return_value = io.BytesIO(b'dummy blob')
+        file.mimetype = 'image/png'
         mock_retrieve_asset_file = Mock(spec=asset.retrieve_asset_file,
                                         return_value=file)
         monkeypatch.setattr(asset, 'retrieve_asset_file',
@@ -209,6 +210,7 @@ class TestAssetFileDownload:
         assert mock_crop_image.resize.call_args[0] == (dimensions,
                                                        Image.ANTIALIAS)
         assert result == inst_with_dimensions.file
+        assert result.mimetype == file.mimetype
 
     def test_crop_if_needed_crop_height(self, inst_with_dimensions):
         mock_image = Mock()


### PR DESCRIPTION
This preserves transparency in PNGs and thus fixes #415.
