### PR TITLE
partly fix mercator proposal edit acceptance tests

### DIFF
--- a/src/mercator/tests/acceptance/test_mercator_proposal_edit.py
+++ b/src/mercator/tests/acceptance/test_mercator_proposal_edit.py
@@ -32,7 +32,7 @@ class TestMercatorForm:
     @fixture(scope='class')
     def browser(self, browser, proposals):
         browser.reload()  # make sure proposals are loaded
-        assert browser.is_text_present("supporters", wait_time=1)
+        assert browser.is_text_present("supporters", wait_time=2)
         return browser
 
     def test_edit_proposal_no_user(self, browser):


### PR DESCRIPTION
it seems like all users are allowed to edit any proposal

also note that the tests do not reset which interferes with the following tests (which are currently on xfail anyway)
