### PR TITLE
2015 01 sz comment actests

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/test_comment.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/test_comment.py
@@ -80,7 +80,6 @@ class TestComment:
 
     def test_edit_no_user(self, browser, rest_url, user):
         logout(browser)
-        _visit_url(browser, rest_url)
         comment = browser.find_by_css('.comment').first
         assert not _get_edit_button(browser, comment)
 


### PR DESCRIPTION
This pull request concerns the adhocracy comment tests:
- refactoring
- two new tests to ensure that the edit button is not shown for non-owners (addressing issue #440 and its fix #453)
