### PR TITLE
added check for FormData support to enable login in IE9

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -141,7 +141,7 @@ export class Service<Content extends ResourcesBase.Resource> {
         }
         path = this.formatUrl(path);
 
-        if (FormData.prototype.isPrototypeOf(obj)) {
+        if (typeof FormData !== "undefined" && FormData.prototype.isPrototypeOf(obj)) {
             return _self.$http({
                 method: "POST",
                 url: path,


### PR DESCRIPTION
This belongs to Issue #482
