### PR TITLE
do not clip outlines

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_annotated_section.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_annotated_section.scss
@@ -23,7 +23,7 @@ A section with a additional annotation, typically displayed in a second column.
 ```
 */
 .annotated-section {
-    @include clearfix;
+    @include pie-clearfix;
 
     .annotated-section-body {
         float: left;


### PR DESCRIPTION
...in mercator form by using a different clearfix implementation. The
default one uses `overflow: hidden`.
## before

![clipped_outlines_before](https://cloud.githubusercontent.com/assets/202576/5835392/67a0063e-a168-11e4-9f8c-6215a5e4788d.png)
## after

![clipped_outlines_after](https://cloud.githubusercontent.com/assets/202576/5835394/6a18c0ae-a168-11e4-9e6d-bb48f1ab189e.png)
