### PR TITLE
disable angular debug information

### DIFF
--- a/etc/frontend_development.ini
+++ b/etc/frontend_development.ini
@@ -25,6 +25,8 @@ adhocracy.frontend.rest_url = http://localhost:6541
 adhocracy.frontend.support_email = support@unconfigured.domain
 # Default frontend locale
 adhocracy.frontend.locale = de
+# Enable debugging mode
+adhocracy.frontend.debug = true
 
 # Name of the entire site. Used in account registration information etc.
 adhocracy.frontend.site_name = Adhocracy Test Site

--- a/src/adhocracy_frontend/adhocracy_frontend/__init__.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/__init__.py
@@ -40,6 +40,7 @@ def config_view(request):
                         for k in custom_keys}
     config['site_name'] = settings.get('adhocracy.frontend.site_name',
                                        'Adhocracy')
+    config['debug'] = asbool(settings.get('adhocracy.frontend.debug', 'false'))
 
     config['cachebust'] = asbool(settings.get('cachebust.enabled', 'false'))
     return config

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -103,7 +103,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
             });
     }]);
     app.config(["$compileProvider", ($compileProvider) => {
-        $compileProvider.debugInfoEnabled(false);
+        $compileProvider.debugInfoEnabled(config.debug);
     }]);
     app.config(["$locationProvider", ($locationProvider) => {
         // Make sure HTML5 history API works.  (If support for older

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
@@ -19,4 +19,5 @@ export interface IService {
     custom : {[key : string]: string};
     site_name : string;
     cachebust : boolean;
+    debug : boolean;
 }

--- a/src/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/static/js/Adhocracy.ts
@@ -116,7 +116,7 @@ export var init = (config : AdhConfig.IService, meta_api) => {
             });
     }]);
     app.config(["$compileProvider", ($compileProvider) => {
-        $compileProvider.debugInfoEnabled(false);
+        $compileProvider.debugInfoEnabled(config.debug);
     }]);
     app.config(["$locationProvider", ($locationProvider) => {
         // Make sure HTML5 history API works.  (If support for older


### PR DESCRIPTION
This is a second part to #517.

See https://docs.angularjs.org/guide/production for a discussion of angular debug information.
