### PR TITLE
fix validation crash

### DIFF
--- a/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
+++ b/src/mercator/static/js/Packages/MercatorProposal/MercatorProposal.ts
@@ -989,6 +989,10 @@ export var register = (angular) => {
                 if ($scope.$flow && $scope.$flow.support) {
                     var imgUploadController = $scope.mercatorProposalIntroductionForm["introduction-picture-upload"];
                     imgUploadController.$setValidity("required", imageExists());
+
+                    // HACK: `$setValidity` does not seem to add `ng-invalid` class directly.
+                    var imgUploadElement = $element.find("[name='introduction-picture-upload']");
+                    imgUploadElement.toggleClass("ng-invalid", imageExists());
                 }
 
                 if ($scope.mercatorProposalForm.$valid) {


### PR DESCRIPTION
Steps to reproduce:
-   Go to mercator proposal create form
-   fill everything except for image
-   submit (exactly once!)
-   there shoud be an error in the console saying "TypeError: Cannot read property 'getBoundingClientRect' of undefined"
-   submit again
-   the expected thing happens: you scroll up to the invalid image upload

This bug was caused by the following two lines:

```
var element = $element.find(".ng-invalid");
container.scrollToElementAnimated(element);
```

`element` was empty and so `scrollToElementAnimated` crashed. `element` in turn was empty because `$setValidity` seems to asynchrounsly set the class. That is why the submit worked as expected on second try.
