### PR TITLE
Fix HTML closing tags (fixes #572)

### DIFF
--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalCreateColumn.html
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorProposalCreateColumn.html
@@ -9,6 +9,6 @@
             data-path="@preliminary"
             data-mode="edit"
             data-pool-path="{{platformUrl}}">
-        <adh-mercator-proposal-create>
+        </adh-mercator-proposal-create>
     </adh-resource-wrapper>
 </div>

--- a/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.html
+++ b/src/mercator/static/js/Packages/MercatorWorkbench/MercatorWorkbench.html
@@ -2,7 +2,7 @@
     <div data-adh-moving-columns="" class="moving-columns">
         <adh-moving-column>
             <adh-mercator-proposal-create-column data-ng-if="view === 'create_proposal'"></adh-mercator-proposal-create-column>
-            <adh-mercator-proposal-listing-column data-ng-if="view !== 'create_proposal'"><adh-mercator-proposal-listing-column>
+            <adh-mercator-proposal-listing-column data-ng-if="view !== 'create_proposal'"></adh-mercator-proposal-listing-column>
         </adh-moving-column>
         <adh-moving-column>
             <adh-mercator-proposal-edit-column data-ng-if="view === 'edit'"></adh-mercator-proposal-edit-column>


### PR DESCRIPTION
These have been introduced in f4594e0068e805a6e7eeaec7b12890187b10d0e3 and broke IE11.

In general we should include an HTML linter/validator in our toolchain. I created https://stackoverflow.com/questions/28150293 for that.
