### PR TITLE
switch to relatively sticky

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Sticky/Sticky.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Sticky/Sticky.ts
@@ -11,9 +11,7 @@ export var createDirective = (Modernizr : ModernizrStatic) => {
                 element.addClass("sticky");
             } else {
                 element.stick_in_parent({
-                    scrolling_parent: ".moving-column-body",
-                    recalc_every: 2000,
-                    bottoming: false
+                    scrollable: ".moving-column-body"
                 });
             }
         }

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -205,7 +205,7 @@ packages =
     blanket#1.1.5
     q#1.1.2
     moment#2.8.3
-    xi/sticky-kit#feature-scrollable
+    xi/sticky-kit#refactor
     ng-flow#2.5.1
     jquery.socialshareprivacy#1.4.6
     jquery-html5-placeholder-shim


### PR DESCRIPTION
We currently maintain two forks of sticky-kit at https://github.com/xi/sticky-kit. Both have advantages and disadvantages. I talked to our designers and we decided to use the other one (the one that is not currently used in our code).
