### PR TITLE
Fix browser back button if embedded

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracySDK.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracySDK.ts
@@ -95,7 +95,13 @@
 
     var setHashFromUrl = (url : string) => {
         if (url.indexOf(origin) === 0) {
-            window.location.hash = "!" + url.substring(origin.length);
+            if (window.history && history.replaceState) {
+                var newurl = window.location.href.split("#")[0] + "#!" + url.substring(origin.length);
+                history.replaceState(null, null, newurl);
+            } else {
+                // IE 9 and other browsers without history support have a partially broken back button
+                window.location.hash = "!" + url.substring(origin.length);
+            }
         } else {
             throw "Embedded iframe got an src outside of origin.";
         }


### PR DESCRIPTION
Before this, the user needed to click "back" twice in order to navigate to the previous embedded page. Now the user only needs to click "back" once, as expected.

Note that I couldn't test the IE9 fallback due to #592.
