### PR TITLE
Check session validity on initial load

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserSpec.ts
@@ -82,7 +82,7 @@ export var register = () => {
                 it("calls 'enableToken' if 'user-token' and 'user-path' exist in storage", () => {
                     windowMock.localStorage.getItem.and.returnValue("huhu");
                     fn();
-                    expect(adhUser.enableToken).toHaveBeenCalledWith("huhu", "huhu");
+                    expect(adhUser.enableToken).toHaveBeenCalledWith("huhu", "huhu", true);
                 });
 
                 it("calls 'deleteToken' if neither 'user-token' nor 'user-path' exist in storage", (done) => {


### PR DESCRIPTION
This only copes with initial page load, not with the case that the session expires while the frontend is already loaded. We have to deal similar topics (e.g. backend API changes) anyway separately.

In order to test this, you can decrease `authn_timeout` to a couple of seconds in `src/adhocracy_core/adhocracy_core/__init__.py`.
