### PR TITLE
Fix logBackendBatchError

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
@@ -66,7 +66,6 @@ export var logBackendBatchError = (
         responses : {
             code : number;
             body : IBackendError;
-            responses : any;
         }[];
         updated_resources : any;
     }>


### PR DESCRIPTION
This fixes batch error logging, which broke due to the API change in

This fix would make #609 unnecessary, however we can also leave it in,
as it's good to break recursion at some point.
