### PR TITLE
Fix post after batchpost

### DIFF
--- a/src/adhocracy_core/adhocracy_core/rest/batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/batchview.py
@@ -67,7 +67,11 @@ class BatchView(RESTView):
                 err = _JSONError([], status=item_response.code)
                 err.text = dumps(self._response_list_to_json(response_list))
                 raise err
-        return self._response_list_to_json(response_list)
+        response = self._response_list_to_json(response_list)
+        # Explicitly unset batchmode because registry is shared between
+        # requests
+        set_batchmode(self.request.registry, False)
+        return response
 
     @view_config(name='batch',
                  request_method='OPTIONS')

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -58,7 +58,6 @@ from adhocracy_core.utils import extract_events_from_changelog_metadata
 from adhocracy_core.utils import get_sheet
 from adhocracy_core.utils import get_user
 from adhocracy_core.utils import is_batchmode
-from adhocracy_core.utils import set_batchmode
 from adhocracy_core.utils import strip_optional_prefix
 from adhocracy_core.utils import to_dotted_name
 from adhocracy_core.utils import unflatten_multipart_request
@@ -282,7 +281,6 @@ class RESTView:
         validate_request_data(context, request,
                               schema=schema_class(),
                               extra_validators=validators)
-        set_batchmode(request.registry, False)
 
     def options(self) -> dict:
         """Return options for view.


### PR DESCRIPTION
It seems like the registry isn't resetted on each request (unsure if intended). This made non-batch requests after batch requests believe they were batch requests, and not set `updated_resources` properly, which breaks frontend invalidation.
