### PR TITLE
Workaround: Strip metadata.hidden field in exportData (fixes #597)

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Convert.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Convert.ts
@@ -185,6 +185,11 @@ export var exportContent = <Rs extends ResourcesBase.Resource>(adhMetaApi : AdhM
                     } else {
                         delete sheet[fieldName];
                     }
+                    // workaround, as normal users can not set `hidden` field
+                    // FIXME: use more appropriate place, e.g. expose in meta api
+                    if (sheetName === "adhocracy_core.sheets.metadata.IMetadata" && fieldName === "hidden") {
+                        delete sheet[fieldName];
+                    }
                 }
             }
 


### PR DESCRIPTION
This is bad because:
- Nobody can set `hidden` anymore. But we admin users to do so very soon
  again.
- This should be done in a more generic way, e.g. exposed through the
  meta_api.
