### PR TITLE
[RFC] Login indicator can switch between `built-in` and `thentos`.

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Indicator.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Indicator.html
@@ -1,4 +1,10 @@
 <div class="user-indicator" data-ng-switch="credentials.loggedIn">
+
+
+    <div id="thentos-indicator"></div>  <!-- thentos: render here! -->
+    <div data-ng-if="!bootThentosIndicator()">  <!-- thentos-if: if disabled, render the built-in indicator widget -->
+
+
     <div data-ng-switch-when="true">
         <a data-ng-if="!noLink" data-ng-href="{{ credentials.userPath | adhResourceUrl }}" class="user-indicator-name">{{user.data.name}}</a
         ><span data-ng-if="noLink" class="user-indicator-name">{{user.data.name}}</span>,
@@ -13,4 +19,9 @@
             </span>
         </div>
     </div>
+
+
+    </div>  <!-- thentos-end-if -->
+
+
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -389,6 +389,35 @@ export var indicatorDirective = (
                 adhTopLevelState.setCameFrom($location.url());
                 $location.url("/register");
             };
+
+
+
+            // thentos indicator [begin]
+            $scope.bootThentosIndicatorShouldRun = true;
+            $scope.bootThentosIndicatorRunning = false;
+
+            $scope.bootThentosIndicator = () => {
+                if ($scope.bootThentosIndicatorShouldRun) {
+                    if ($scope.bootThentosIndicatorRunning) {
+                        return true;
+                    } else {
+                        $scope.bootThentosIndicatorRunning = true;
+                        PS['Main'].indicator("#thentos-indicator")();
+                        return true;
+                    }
+                } else {
+                    return false;
+                }
+            };
+            // thentos indicator [end]
+
+            // (missing: register widget destructor with dom element
+            // so that it is called when elem is removed from dom.
+            // this is only necessary for some widgets, e.g. ones
+            // that have their own $timeout-based event loop.)
+
+
+
         }]
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -393,7 +393,7 @@ export var indicatorDirective = (
 
 
             // thentos indicator [begin]
-            $scope.bootThentosIndicatorShouldRun = true;
+            $scope.bootThentosIndicatorShouldRun = false;
             $scope.bootThentosIndicatorRunning = false;
 
             $scope.bootThentosIndicator = () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/root.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/root.html.mako
@@ -9,6 +9,7 @@
         <base href="/" />
     </head>
     <body>
+        <script type="text/javascript" src="http://localhost:6546/js/thentos.js"></script>
         <!--[if gt IE 9]><!-->
         <adh-view></adh-view>
         % for url in js:


### PR DESCRIPTION
[I'm opening this so I can refer to it in discussions, which I can still do if you close it immediately.  Sorry for the noise!]

These few changes demonstrate how a login widget can be embedded from thentos-proxy.  The embedding is "shallow" in the sense that it shares the DOM with the surrounding angular event loop.  Since neither of ng, thentos know (or should care) about the other's DOM element, my hypothesis is that this is a viable approach.

You need to run adhocracy in thentos-proxy mode for this to work (poorly documented).