### PR TITLE
rm hint about adhocracy_sample in docs

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -150,15 +150,9 @@ Create scaffold for extension packages
     In the current repository layout, you then need to move the
     generated directories (``adhocracy_xx/`` and ``xx/``) to ``src/``.
 
-2.  The frontend currently always depends on ``adhocracy_sample``. For
-    that, you need to replace the line
-    ``config.include('adhocracy_core')`` by
-    ``config.include('adhocracy_sample')`` in
-    ``src/adhocracy_xx/adhocracy_xx/__init__.py``.
+2.  Add the new paths to ``develop`` and ``eggs`` in ``base.cfg``.
 
-3.  Add the new paths to ``develop`` and ``eggs`` in ``base.cfg``.
-
-4.  Create ``buildout-xx.cfg``
+3.  Create ``buildout-xx.cfg``
 
 You may then want to run ``bin/buildout -c buildout-xx.cfg`` to check
 that everything works fine.


### PR DESCRIPTION
not required anymore since the integration tests have been removed.