### PR TITLE
Add resources, sheets and workflow for mercator2

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -902,6 +902,18 @@ mkFieldType = (field : MetaApi.ISheetField) : FieldType => {
     case "adhocracy_mercator.sheets.mercator.SizeEnum":  // FIXME: this needs to go to the mercator package
         resultType = "string";
         break;
+    case "adhocracy_mercator.sheets.mercator2.TopicEnum":  // FIXME: this needs to go to the mercator package
+        resultType = "string";
+        break;
+    case "adhocracy_mercator.sheets.mercator2.HeardFromEnum":  // FIXME: this needs to go to the mercator package
+        resultType = "string";
+        break;
+    case "adhocracy_mercator.sheets.mercator2.ProjectStatusEnum":  // FIXME: this needs to go to the mercator package
+        resultType = "string";
+        break;
+    case "adhocracy_mercator.sheets.mercator2.OrganizationStatusEnum":  // FIXME: this needs to go to the mercator package
+        resultType = "string";
+        break;
     case "adhocracy_core.schema.FileStore":  // FIXME: this may be inappropriate, but it's a write-only field anyway
         resultType = "string";
         break;

--- a/src/adhocracy_mercator/adhocracy_mercator/catalog/adhocracy.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/catalog/adhocracy.py
@@ -8,6 +8,7 @@ from adhocracy_core.utils import get_sheet_field
 from adhocracy_mercator.sheets.mercator import IMercatorSubResources
 from adhocracy_mercator.sheets.mercator import IFinance
 from adhocracy_mercator.sheets.mercator import ILocation
+from adhocracy_mercator import sheets
 
 
 INDEX_EXAMPLE_VALUES['mercator_requested_funding'] = 1
@@ -71,6 +72,49 @@ def index_budget(resource: IResource, default) -> str:
     return ['above_50000']
 
 
+def mercator2_index_location(resource, default) -> list:
+    """Return search index keywords based on the location's fields."""
+    locations = []
+    if get_sheet_field(resource,
+                       sheets.mercator2.ILocation,
+                       'is_online'):
+        locations.append('online')
+    if get_sheet_field(resource,
+                       sheets.mercator2.ILocation,
+                       'has_link_to_ruhr'):
+        locations.append('linked_to_ruhr')
+    if get_sheet_field(resource,
+                       sheets.mercator2.ILocation,
+                       'location') is not '':
+        locations.append('specific')
+    return locations if locations else default
+
+
+def mercator2_index_requested_funding(resource: IResource, default) -> int:
+    """Return search index keyword based on the "requested_funding" field."""
+    requested_funding = get_sheet_field(resource,
+                                        sheets.mercator2.IFinancialPlanning,
+                                        'requested_funding')
+    for limit in BUDGET_INDEX_LIMIT_KEYWORDS:
+        if requested_funding <= limit:
+            return [limit]
+    return default
+
+
+def mercator2_index_budget(resource: IResource, default) -> str:
+    """Return search index keyword based on the "budget" field.
+
+    The returned values are the same values as per the "requested_funding"
+    field, or "above_50000" if the total budget value is more than 50,000 euro.
+    """
+    budget = get_sheet_field(resource,
+                             sheets.mercator2.IFinancialPlanning, 'budget')
+    for limit in BUDGET_INDEX_LIMIT_KEYWORDS:
+        if budget <= limit:
+            return [str(limit)]
+    return ['above_50000']
+
+
 def includeme(config):
     """Register catalog utilities and index functions."""
     config.add_catalog_factory('adhocracy', MercatorCatalogIndexes)
@@ -86,3 +130,18 @@ def includeme(config):
                          catalog_name='adhocracy',
                          index_name='mercator_budget',
                          context=IMercatorSubResources)
+    # this prevent an "AttributeError: 'module' object has no attribute
+    # 'mercator2'" error when executing polytester
+    import adhocracy_mercator.sheets.mercator2  # noqa
+    config.add_indexview(mercator2_index_location,
+                         catalog_name='adhocracy',
+                         index_name='mercator_location',
+                         context=sheets.mercator2.ILocation)
+    config.add_indexview(mercator2_index_requested_funding,
+                         catalog_name='adhocracy',
+                         index_name='mercator_requested_funding',
+                         context=sheets.mercator2.IFinancialPlanning)
+    config.add_indexview(mercator2_index_budget,
+                         catalog_name='adhocracy',
+                         index_name='mercator_budget',
+                         context=sheets.mercator2.IFinancialPlanning)

--- a/src/adhocracy_mercator/adhocracy_mercator/catalog/test_adhocracy.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/catalog/test_adhocracy.py
@@ -211,3 +211,177 @@ class TestMercatorBudgetIndex:
         from substanced.interfaces import IIndexView
         assert registry.adapters.lookup((IMercatorSubResources,), IIndexView,
                                         name='adhocracy|mercator_budget')
+
+
+def _make_mercator2_resource(context,
+                             location_appstruct={},
+                             financialplanning_appstruct={}):
+    from adhocracy_core.interfaces import IResource
+    from adhocracy_mercator.sheets.mercator2 import ILocation
+    from adhocracy_mercator.sheets.mercator2 import IFinancialPlanning
+    from adhocracy_core.utils import get_sheet
+    resource = testing.DummyResource(__provides__=[IResource,
+                                                   ILocation,
+                                                   IFinancialPlanning])
+    context['res'] = resource
+    location_sheet = get_sheet(resource, ILocation)
+    location_sheet.set(location_appstruct)
+    financialplanning_sheet = get_sheet(resource, IFinancialPlanning)
+    financialplanning_sheet.set(financialplanning_appstruct)
+    return resource
+
+
+@mark.usefixtures('integration')
+class TestMercator2LocationIndex:
+
+    @fixture
+    def context(self, pool_with_catalogs):
+        return pool_with_catalogs
+
+    def test_index_location_default(self, context):
+        from .adhocracy import mercator2_index_location
+        resource = _make_mercator2_resource(context)
+        result = mercator2_index_location(resource, 'default')
+        assert result == 'default'
+
+    def test_index_location_is_linked_to_ruhr(self, context):
+        from .adhocracy import mercator2_index_location
+        resource = _make_mercator2_resource(
+            context,
+            location_appstruct={'has_link_to_ruhr': True})
+        result = mercator2_index_location(resource, 'default')
+        assert result == ['linked_to_ruhr']
+
+    def test_index_location_is_online_and_linked_to_ruhr(self, context):
+        from .adhocracy import mercator2_index_location
+        resource = _make_mercator2_resource(
+            context,
+            location_appstruct={'is_online': True,
+                                'has_link_to_ruhr': True})
+        result = mercator2_index_location(resource, 'default')
+        assert set(result) == set(['online', 'linked_to_ruhr'])
+
+    def test_register_index_location(self, registry):
+        from adhocracy_mercator.sheets.mercator2 import ILocation
+        from substanced.interfaces import IIndexView
+        assert registry.adapters.lookup((ILocation,), IIndexView,
+                                        name='adhocracy|mercator_location')
+
+@mark.usefixtures('integration')
+class TestMercator2RequestedFundingIndex:
+
+    @fixture
+    def context(self, pool_with_catalogs):
+        return pool_with_catalogs
+
+    def test_index_requested_funding_default(self, context):
+        from .adhocracy import mercator2_index_requested_funding
+        resource = _make_mercator2_resource(context)
+        result = mercator2_index_requested_funding(resource, 'default')
+        assert result == [5000]
+
+    def test_index_requested_funding_lte_5000(self, context):
+        from .adhocracy import mercator2_index_requested_funding
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'requested_funding': 5000})
+        result = mercator2_index_requested_funding(resource, 'default')
+        assert result == [5000]
+
+    def test_index_requested_funding_lte_10000(self, context):
+        from .adhocracy import mercator2_index_requested_funding
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'requested_funding': 10000})
+        result = mercator2_index_requested_funding(resource, 'default')
+        assert result == [10000]
+
+    def test_index_requested_funding_lte_20000(self, context):
+        from .adhocracy import mercator2_index_requested_funding
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'requested_funding': 20000})
+        result = mercator2_index_requested_funding(resource, 'default')
+        assert result == [20000]
+
+    def test_index_requested_funding_lte_50000(self, context):
+        from .adhocracy import mercator2_index_requested_funding
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'requested_funding': 50000})
+        result = mercator2_index_requested_funding(resource, 'default')
+        assert result == [50000]
+
+    def test_index_requested_funding_gt_50000(self, context):
+        from .adhocracy import mercator2_index_requested_funding
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'requested_funding': 50001})
+        result = mercator2_index_requested_funding(resource, 'default')
+        assert result == 'default'
+
+    def test_register_mercator2_index_requested_funding(self, registry):
+        from adhocracy_mercator.sheets.mercator2 import IFinancialPlanning
+        from substanced.interfaces import IIndexView
+        assert registry.adapters.lookup((IFinancialPlanning,), IIndexView,
+                                        name='adhocracy|mercator_requested_funding')
+
+
+@mark.usefixtures('integration')
+class TestMercator2BudgetIndex:
+
+    @fixture
+    def context(self, pool_with_catalogs):
+        return pool_with_catalogs
+
+    def test_index_budget_default(self, context):
+        from .adhocracy import mercator2_index_budget
+        resource = _make_mercator2_resource(context)
+        result = mercator2_index_budget(resource, 'default')
+        assert result == ['5000']
+
+    def test_index_budget_lte_5000(self, context):
+        from .adhocracy import mercator2_index_budget
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'budget': 5000})
+        result = mercator2_index_budget(resource, 'default')
+        assert result == ['5000']
+
+    def test_index_budget_lte_10000(self, context):
+        from .adhocracy import mercator2_index_budget
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'budget': 10000})
+        result = mercator2_index_budget(resource, 'default')
+        assert result == ['10000']
+
+    def test_index_budget_lte_20000(self, context):
+        from .adhocracy import mercator2_index_budget
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'budget': 20000})
+        result = mercator2_index_budget(resource, 'default')
+        assert result == ['20000']
+
+    def test_index_budget_lte_50000(self, context):
+        from .adhocracy import mercator2_index_budget
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'budget': 50000})
+        result = mercator2_index_budget(resource, 'default')
+        assert result == ['50000']
+
+    def test_index_budget_gt_50000(self, context):
+        from .adhocracy import mercator2_index_budget
+        resource = _make_mercator2_resource(
+            context,
+            financialplanning_appstruct={'budget': 50001})
+        result = mercator2_index_budget(resource, 'default')
+        assert result == ['above_50000']
+
+    def test_register_index_budget(self, registry):
+        from adhocracy_mercator.sheets.mercator2 import IFinancialPlanning
+        from substanced.interfaces import IIndexView
+        assert registry.adapters.lookup((IFinancialPlanning,), IIndexView,
+                                        name='adhocracy|mercator_budget')

--- a/src/adhocracy_mercator/adhocracy_mercator/catalog/test_adhocracy.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/catalog/test_adhocracy.py
@@ -261,6 +261,16 @@ class TestMercator2LocationIndex:
         result = mercator2_index_location(resource, 'default')
         assert set(result) == set(['online', 'linked_to_ruhr'])
 
+    def test_index_location_is_specific(self, context):
+        from .adhocracy import mercator2_index_location
+        resource = _make_mercator2_resource(
+            context,
+            location_appstruct={'location': 'Berlin',
+                                'is_online': False,
+                                'has_link_to_ruhr': False})
+        result = mercator2_index_location(resource, 'default')
+        assert set(result) == set(['specific'])
+
     def test_register_index_location(self, registry):
         from adhocracy_mercator.sheets.mercator2 import ILocation
         from substanced.interfaces import IIndexView

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/__init__.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/__init__.py
@@ -5,4 +5,5 @@ def includeme(config):
     """Include resource types and subscribers."""
     config.include('.root')
     config.include('.mercator')
+    config.include('.mercator2')
     config.include('.subscriber')

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/mercator2.py
@@ -1,0 +1,155 @@
+"""Mercator 2 proposal."""
+
+from adhocracy_core.resources import add_resource_type_to_registry
+from adhocracy_core.resources import process
+from adhocracy_core.resources import proposal
+from adhocracy_core.interfaces import ISimple
+from adhocracy_core.resources.logbook import add_logbook_service
+from adhocracy_core.resources.proposal import IProposal
+from adhocracy_core.resources.simple import simple_meta
+from adhocracy_core.sheets.comment import ICommentable
+from adhocracy_core.sheets.description import IDescription
+from adhocracy_core.sheets.rate import IRateable
+from adhocracy_core.sheets.title import ITitle
+from adhocracy_core.sheets.image import IImageReference
+from adhocracy_core.resources.comment import add_commentsservice
+from adhocracy_core.resources.rate import add_ratesservice
+from adhocracy_core.resources.badge import add_badge_assignments_service
+
+import adhocracy_mercator.sheets.mercator2
+import adhocracy_core.sheets
+
+
+class IPitch(ISimple):
+    """Proposal's pitch."""
+
+
+pitch_meta = simple_meta._replace(
+    content_name='Pitch',
+    iresource=IPitch,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='pitch',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IPitch,
+        adhocracy_core.sheets.description.IDescription,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IPartners(ISimple):
+    """Proposal's partners."""
+
+
+partners_meta = simple_meta._replace(
+    content_name='Partners',
+    iresource=IPartners,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='partners',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IPartners,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IDuration(ISimple):
+    """Duration."""
+
+duration_meta = simple_meta._replace(
+    content_name='duration',
+    iresource=IDuration,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='duration',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IDuration,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IRoadToImpact(ISimple):
+    """Road to impact."""
+
+road_to_impact_meta = simple_meta._replace(
+    content_name='road_to_impact',
+    iresource=IRoadToImpact,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='road_to_impact',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IRoadToImpact,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class ISelectionCriteria(ISimple):
+    """Road to impact."""
+
+selection_criteria_meta = simple_meta._replace(
+    content_name='selection_criteria',
+    iresource=ISelectionCriteria,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='selection_criteria',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.ISelectionCriteria,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IMercatorProposal(IProposal):
+    """Mercator 2 proposal. Not versionable."""
+
+
+proposal_meta = proposal.proposal_meta._replace(
+    content_name='MercatorProposal2',
+    iresource=IMercatorProposal,
+    element_types=(IPitch,
+                   IPartners,
+                   IRoadToImpact,
+                   ISelectionCriteria),
+    after_creation=(
+        add_commentsservice,
+        add_ratesservice,
+        add_badge_assignments_service,
+        add_logbook_service,)
+)._add(extended_sheets=
+       (ITitle,
+        IDescription,
+        ICommentable,
+        IRateable,
+        IImageReference,
+        adhocracy_mercator.sheets.mercator2.IMercatorSubResources,
+        adhocracy_mercator.sheets.mercator2.IUserInfo,
+        adhocracy_mercator.sheets.mercator2.IOrganizationInfo,
+        adhocracy_mercator.sheets.mercator2.ITopic,
+        adhocracy_mercator.sheets.mercator2.ILocation,
+        adhocracy_mercator.sheets.mercator2.IStatus,
+        adhocracy_mercator.sheets.mercator2.IFinancialPlanning,
+        adhocracy_mercator.sheets.mercator2.IExtraFunding,
+        adhocracy_mercator.sheets.mercator2.ICommunity,
+        adhocracy_mercator.sheets.mercator2.IWinnerInfo))
+
+
+class IProcess(process.IProcess):
+    """Mercator 2 participation process."""
+
+
+process_meta = process.process_meta._replace(
+    iresource=IProcess,
+    element_types=(IMercatorProposal,
+                   ),
+    workflow_name='mercator2'
+)
+
+
+def includeme(config):
+    """Add resource type to content."""
+    add_resource_type_to_registry(process_meta, config)
+    add_resource_type_to_registry(proposal_meta, config)
+    add_resource_type_to_registry(pitch_meta, config)
+    add_resource_type_to_registry(partners_meta, config)
+    add_resource_type_to_registry(duration_meta, config)
+    add_resource_type_to_registry(road_to_impact_meta, config)
+    add_resource_type_to_registry(selection_criteria_meta, config)

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/mercator2.py
@@ -1,4 +1,7 @@
-"""Mercator 2 proposal."""
+"""Proposal forms for the 2016 advocate europe participation process.
+
+Proposals are not versionable anymore.
+"""
 
 from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources import process

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/mercator2.py
@@ -71,32 +71,137 @@ duration_meta = simple_meta._replace(
 )
 
 
-class IRoadToImpact(ISimple):
-    """Road to impact."""
+class IChallenge(ISimple):
+    """Challenge."""
 
-road_to_impact_meta = simple_meta._replace(
-    content_name='road_to_impact',
-    iresource=IRoadToImpact,
+challenge_meta = simple_meta._replace(
+    content_name='challenge',
+    iresource=IChallenge,
     permission_create='create_proposal',
     use_autonaming=True,
-    autonaming_prefix='road_to_impact',
+    autonaming_prefix='challenge',
     extended_sheets=(
-        adhocracy_mercator.sheets.mercator2.IRoadToImpact,
+        adhocracy_mercator.sheets.mercator2.IChallenge,
         adhocracy_core.sheets.comment.ICommentable),
 )
 
 
-class ISelectionCriteria(ISimple):
-    """Road to impact."""
+class IGoal(ISimple):
+    """Goal."""
 
-selection_criteria_meta = simple_meta._replace(
-    content_name='selection_criteria',
-    iresource=ISelectionCriteria,
+goal_meta = simple_meta._replace(
+    content_name='goal',
+    iresource=IGoal,
     permission_create='create_proposal',
     use_autonaming=True,
-    autonaming_prefix='selection_criteria',
+    autonaming_prefix='goal',
     extended_sheets=(
-        adhocracy_mercator.sheets.mercator2.ISelectionCriteria,
+        adhocracy_mercator.sheets.mercator2.IGoal,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IPlan(ISimple):
+    """Plan."""
+
+plan_meta = simple_meta._replace(
+    content_name='plan',
+    iresource=IPlan,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='plan',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IPlan,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class ITarget(ISimple):
+    """Target."""
+
+target_meta = simple_meta._replace(
+    content_name='target',
+    iresource=ITarget,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='target',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.ITarget,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class ITeam(ISimple):
+    """Team."""
+
+team_meta = simple_meta._replace(
+    content_name='team',
+    iresource=ITeam,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='team',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.ITeam,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IExtraInfo(ISimple):
+    """Extrainfo."""
+
+extrainfo_meta = simple_meta._replace(
+    content_name='extrainfo',
+    iresource=IExtraInfo,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='extrainfo',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IExtraInfo,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IConnectionCohesion(ISimple):
+    """Connectioncohesion."""
+
+connectioncohesion_meta = simple_meta._replace(
+    content_name='connectioncohesion',
+    iresource=IConnectionCohesion,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='connectioncohesion',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IConnectionCohesion,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IDifference(ISimple):
+    """Difference."""
+
+difference_meta = simple_meta._replace(
+    content_name='difference',
+    iresource=IDifference,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='difference',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IDifference,
+        adhocracy_core.sheets.comment.ICommentable),
+)
+
+
+class IPracticalRelevance(ISimple):
+    """Practicalrelevance."""
+
+practicalrelevance_meta = simple_meta._replace(
+    content_name='practicalrelevance',
+    iresource=IPracticalRelevance,
+    permission_create='create_proposal',
+    use_autonaming=True,
+    autonaming_prefix='practicalrelevance',
+    extended_sheets=(
+        adhocracy_mercator.sheets.mercator2.IPracticalRelevance,
         adhocracy_core.sheets.comment.ICommentable),
 )
 
@@ -110,8 +215,16 @@ proposal_meta = proposal.proposal_meta._replace(
     iresource=IMercatorProposal,
     element_types=(IPitch,
                    IPartners,
-                   IRoadToImpact,
-                   ISelectionCriteria),
+                   IDuration,
+                   IChallenge,
+                   IGoal,
+                   IPlan,
+                   ITarget,
+                   ITeam,
+                   IExtraInfo,
+                   IConnectionCohesion,
+                   IDifference,
+                   IPracticalRelevance,),
     after_creation=(
         add_commentsservice,
         add_ratesservice,
@@ -154,5 +267,12 @@ def includeme(config):
     add_resource_type_to_registry(pitch_meta, config)
     add_resource_type_to_registry(partners_meta, config)
     add_resource_type_to_registry(duration_meta, config)
-    add_resource_type_to_registry(road_to_impact_meta, config)
-    add_resource_type_to_registry(selection_criteria_meta, config)
+    add_resource_type_to_registry(challenge_meta, config)
+    add_resource_type_to_registry(goal_meta, config)
+    add_resource_type_to_registry(plan_meta, config)
+    add_resource_type_to_registry(target_meta, config)
+    add_resource_type_to_registry(team_meta, config)
+    add_resource_type_to_registry(extrainfo_meta, config)
+    add_resource_type_to_registry(connectioncohesion_meta, config)
+    add_resource_type_to_registry(difference_meta, config)
+    add_resource_type_to_registry(practicalrelevance_meta, config)

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator2.py
@@ -81,22 +81,22 @@ class TestDuration:
         assert meta.iresource.providedBy(res)
 
 
-class TestRoadToImpact:
+class TestChallenge:
 
     @fixture
     def meta(self):
-        from .mercator2 import road_to_impact_meta
-        return road_to_impact_meta
+        from .mercator2 import challenge_meta
+        return challenge_meta
 
     def test_meta(self, meta):
         import adhocracy_mercator.sheets.mercator2
         import adhocracy_core.sheets
         from adhocracy_mercator.resources import mercator2
-        assert meta.iresource == mercator2.IRoadToImpact
+        assert meta.iresource == mercator2.IChallenge
         assert meta.permission_create == 'create_proposal'
-        assert meta.autonaming_prefix == 'road_to_impact'
+        assert meta.autonaming_prefix == 'challenge'
         assert meta.extended_sheets == \
-            (adhocracy_mercator.sheets.mercator2.IRoadToImpact,
+            (adhocracy_mercator.sheets.mercator2.IChallenge,
              adhocracy_core.sheets.comment.ICommentable,)
 
     @mark.usefixtures('integration')
@@ -107,22 +107,22 @@ class TestRoadToImpact:
         assert meta.iresource.providedBy(res)
 
 
-class TestSelectionCriteria:
+class TestGoal:
 
     @fixture
     def meta(self):
-        from .mercator2 import selection_criteria_meta
-        return selection_criteria_meta
+        from .mercator2 import goal_meta
+        return goal_meta
 
     def test_meta(self, meta):
         import adhocracy_mercator.sheets.mercator2
         import adhocracy_core.sheets
         from adhocracy_mercator.resources import mercator2
-        assert meta.iresource == mercator2.ISelectionCriteria
+        assert meta.iresource == mercator2.IGoal
         assert meta.permission_create == 'create_proposal'
-        assert meta.autonaming_prefix == 'selection_criteria'
+        assert meta.autonaming_prefix == 'goal'
         assert meta.extended_sheets == \
-            (adhocracy_mercator.sheets.mercator2.ISelectionCriteria,
+            (adhocracy_mercator.sheets.mercator2.IGoal,
              adhocracy_core.sheets.comment.ICommentable,)
 
     @mark.usefixtures('integration')
@@ -131,6 +131,239 @@ class TestSelectionCriteria:
                                       parent=pool,
                                       )
         assert meta.iresource.providedBy(res)
+
+
+class TestPlan:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import plan_meta
+        return plan_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IPlan
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'plan'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IPlan,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestTarget:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import target_meta
+        return target_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.ITarget
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'target'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.ITarget,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestTeam:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import team_meta
+        return team_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.ITeam
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'team'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.ITeam,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestExtrainfo:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import extrainfo_meta
+        return extrainfo_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IExtraInfo
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'extrainfo'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IExtraInfo,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestConnectionCohesion:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import connectioncohesion_meta
+        return connectioncohesion_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IConnectionCohesion
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'connectioncohesion'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IConnectionCohesion,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestDifference:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import difference_meta
+        return difference_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IDifference
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'difference'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IDifference,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestPracticalrelevance:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import practicalrelevance_meta
+        return practicalrelevance_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IPracticalRelevance
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'practicalrelevance'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IPracticalRelevance,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+# class TestRoadToImpact:
+
+#     @fixture
+#     def meta(self):
+#         from .mercator2 import road_to_impact_meta
+#         return road_to_impact_meta
+
+#     def test_meta(self, meta):
+#         import adhocracy_mercator.sheets.mercator2
+#         import adhocracy_core.sheets
+#         from adhocracy_mercator.resources import mercator2
+#         assert meta.iresource == mercator2.IRoadToImpact
+#         assert meta.permission_create == 'create_proposal'
+#         assert meta.autonaming_prefix == 'road_to_impact'
+#         assert meta.extended_sheets == \
+#             (adhocracy_mercator.sheets.mercator2.IRoadToImpact,
+#              adhocracy_core.sheets.comment.ICommentable,)
+
+#     @mark.usefixtures('integration')
+#     def test_create(self, pool, meta, registry):
+#         res = registry.content.create(meta.iresource.__identifier__,
+#                                       parent=pool,
+#                                       )
+#         assert meta.iresource.providedBy(res)
+
+
+# class TestSelectionCriteria:
+
+#     @fixture
+#     def meta(self):
+#         from .mercator2 import selection_criteria_meta
+#         return selection_criteria_meta
+
+#     def test_meta(self, meta):
+#         import adhocracy_mercator.sheets.mercator2
+#         import adhocracy_core.sheets
+#         from adhocracy_mercator.resources import mercator2
+#         assert meta.iresource == mercator2.ISelectionCriteria
+#         assert meta.permission_create == 'create_proposal'
+#         assert meta.autonaming_prefix == 'selection_criteria'
+#         assert meta.extended_sheets == \
+#             (adhocracy_mercator.sheets.mercator2.ISelectionCriteria,
+#              adhocracy_core.sheets.comment.ICommentable,)
+
+#     @mark.usefixtures('integration')
+#     def test_create(self, pool, meta, registry):
+#         res = registry.content.create(meta.iresource.__identifier__,
+#                                       parent=pool,
+#                                       )
+#         assert meta.iresource.providedBy(res)
 
 
 class TestMercatorProposal:
@@ -151,9 +384,17 @@ class TestMercatorProposal:
         assert meta.iresource == mercator2.IMercatorProposal
         assert meta.element_types == (mercator2.IPitch,
                                       mercator2.IPartners,
-                                      mercator2.IRoadToImpact,
-                                      mercator2.ISelectionCriteria,
-                                      )
+                                      mercator2.IDuration,
+                                      mercator2.IChallenge,
+                                      mercator2.IGoal,
+                                      mercator2.IPlan,
+                                      mercator2.ITarget,
+                                      mercator2.ITeam,
+                                      mercator2.IExtraInfo,
+                                      mercator2.IConnectionCohesion,
+                                      mercator2.IDifference,
+                                      mercator2.IPracticalRelevance,
+        )
         assert meta.extended_sheets == \
             (adhocracy_core.sheets.badge.IBadgeable,
              adhocracy_core.sheets.title.ITitle,

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_mercator2.py
@@ -1,0 +1,207 @@
+from pytest import fixture
+from pytest import mark
+
+
+class TestPitch:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import pitch_meta
+        return pitch_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IPitch
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'pitch'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IPitch,
+             adhocracy_core.sheets.description.IDescription,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestPartners:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import partners_meta
+        return partners_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IPartners
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'partners'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IPartners,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestDuration:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import duration_meta
+        return duration_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IDuration
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'duration'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IDuration,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestRoadToImpact:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import road_to_impact_meta
+        return road_to_impact_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.IRoadToImpact
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'road_to_impact'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.IRoadToImpact,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestSelectionCriteria:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import selection_criteria_meta
+        return selection_criteria_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        assert meta.iresource == mercator2.ISelectionCriteria
+        assert meta.permission_create == 'create_proposal'
+        assert meta.autonaming_prefix == 'selection_criteria'
+        assert meta.extended_sheets == \
+            (adhocracy_mercator.sheets.mercator2.ISelectionCriteria,
+             adhocracy_core.sheets.comment.ICommentable,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestMercatorProposal:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import proposal_meta
+        return proposal_meta
+
+    def test_meta(self, meta):
+        import adhocracy_mercator.sheets.mercator2
+        import adhocracy_core.sheets
+        from adhocracy_mercator.resources import mercator2
+        from adhocracy_core.resources.comment import add_commentsservice
+        from adhocracy_core.resources.rate import add_ratesservice
+        from adhocracy_core.resources.logbook import add_logbook_service
+        from adhocracy_core.sheets.badge import IBadgeable
+        assert meta.iresource == mercator2.IMercatorProposal
+        assert meta.element_types == (mercator2.IPitch,
+                                      mercator2.IPartners,
+                                      mercator2.IRoadToImpact,
+                                      mercator2.ISelectionCriteria,
+                                      )
+        assert meta.extended_sheets == \
+            (adhocracy_core.sheets.badge.IBadgeable,
+             adhocracy_core.sheets.title.ITitle,
+             adhocracy_core.sheets.description.IDescription,
+             adhocracy_core.sheets.comment.ICommentable,
+             adhocracy_core.sheets.rate.IRateable,
+             adhocracy_core.sheets.image.IImageReference,
+             adhocracy_mercator.sheets.mercator2.IMercatorSubResources,
+             adhocracy_mercator.sheets.mercator2.IUserInfo,
+             adhocracy_mercator.sheets.mercator2.IOrganizationInfo,
+             adhocracy_mercator.sheets.mercator2.ITopic,
+             adhocracy_mercator.sheets.mercator2.ILocation,
+             adhocracy_mercator.sheets.mercator2.IStatus,
+             adhocracy_mercator.sheets.mercator2.IFinancialPlanning,
+             adhocracy_mercator.sheets.mercator2.IExtraFunding,
+             adhocracy_mercator.sheets.mercator2.ICommunity,
+             adhocracy_mercator.sheets.mercator2.IWinnerInfo)
+        assert meta.is_implicit_addable
+        assert add_ratesservice in meta.after_creation
+        assert add_commentsservice in meta.after_creation
+        assert add_logbook_service in meta.after_creation
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, meta, registry):
+        res = registry.content.create(meta.iresource.__identifier__,
+                                      parent=pool,
+                                      )
+        assert meta.iresource.providedBy(res)
+
+
+class TestProcess:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import process_meta
+        return process_meta
+
+    def test_meta(self, meta):
+        import adhocracy_core.resources.process
+        from adhocracy_core.resources.asset import add_assets_service
+        from .mercator2 import IProcess
+        from .mercator2 import IMercatorProposal
+        assert meta.iresource is IProcess
+        assert IProcess.isOrExtends(adhocracy_core.resources.process.IProcess)
+        assert meta.element_types == (IMercatorProposal,)
+        assert meta.workflow_name == 'mercator2'
+
+    @mark.usefixtures('integration')
+    def test_create(self, registry, meta):
+        res = registry.content.create(meta.iresource.__identifier__)
+        assert meta.iresource.providedBy(res)

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/__init__.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/__init__.py
@@ -4,3 +4,4 @@
 def includeme(config):
     """Include sheets."""
     config.include('.mercator')
+    config.include('.mercator2')

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
@@ -237,48 +237,147 @@ status_meta = sheet_meta._replace(
 )
 
 
-class IRoadToImpact(ISheet):
-    """Marker interface for the road to impact."""
+class IChallenge(ISheet):
+    """Marker interface for the challenge in the road to impact section."""
 
 
-class RoadToImpactSchema(colander.MappingSchema):
+class ChallengeSchema(colander.MappingSchema):
+    """Datastruct for the challenge field."""
+
     challenge = Text(missing=colander.required,
                      validator=colander.Length(min=3, max=500))
-    aim = Text(missing=colander.required,
-               validator=colander.Length(min=3, max=500))
-    plan = Text(missing=colander.required,
-                validator=colander.Length(min=3, max=800))
-    doing = Text(missing=colander.required,
-                 validator=colander.Length(min=3, max=500))
-    team = Text(missing=colander.required,
-                validator=colander.Length(min=3, max=800))
-    other = Text(missing=colander.required,
-                 validator=colander.Length(min=3, max=500))
 
-
-roadtoimpact_meta = sheet_meta._replace(
-    isheet=IRoadToImpact,
-    schema_class=RoadToImpactSchema,
+challenge_meta = sheet_meta._replace(
+    isheet=IChallenge,
+    schema_class=ChallengeSchema,
 )
 
 
-class ISelectionCriteria(ISheet):
-    """Marker interface for the selection criteria."""
+class IGoal(ISheet):
+    """Marker interface for the 'aiming for' in the road to impact section."""
 
 
-class SelectionCriteriaSchema(colander.MappingSchema):
-    connection_and_cohesion_europe = Text(
-        missing=colander.required,
-        validator=colander.Length(min=3, max=500))
-    difference = Text(missing=colander.required,
-                      validator=colander.Length(min=3, max=500))
-    practical_relevance = Text(missing=colander.required,
+class GoalSchema(colander.MappingSchema):
+    """Datastruct for the goal."""
+
+    goal = Text(missing=colander.required,
+                validator=colander.Length(min=3, max=500))
+
+goal_meta = sheet_meta._replace(
+    isheet=IGoal,
+    schema_class=GoalSchema,
+)
+
+
+class IPlan(ISheet):
+    """Marker interface for the 'plan' in the road to impact section."""
+
+
+class PlanSchema(colander.MappingSchema):
+    """Datastruct for the challenge field."""
+
+    plan = Text(missing=colander.required,
+                validator=colander.Length(min=3, max=800))
+
+plan_meta = sheet_meta._replace(
+    isheet=IPlan,
+    schema_class=PlanSchema,
+)
+
+
+class ITarget(ISheet):
+    """Marker interface for the 'target' in the road to impact section."""
+
+
+class TargetSchema(colander.MappingSchema):
+    """Datastruct for the challenge field."""
+
+    target = Text(missing=colander.required,
+                  validator=colander.Length(min=3, max=500))
+
+target_meta = sheet_meta._replace(
+    isheet=ITarget,
+    schema_class=TargetSchema,
+)
+
+
+class ITeam(ISheet):
+    """Marker interface for the 'team' in the road to impact section."""
+
+
+class TeamSchema(colander.MappingSchema):
+    """Datastruct for the challenge field."""
+
+    team = Text(missing=colander.required,
+                validator=colander.Length(min=3, max=800))
+
+team_meta = sheet_meta._replace(
+    isheet=ITeam,
+    schema_class=TeamSchema,
+)
+
+
+class IExtraInfo(ISheet):
+    """Marker interface for the 'extrainfo' in the road to impact section."""
+
+
+class ExtraInfoSchema(colander.MappingSchema):
+    """Datastruct for the challenge field."""
+
+    extrainfo = Text(missing=colander.required,
+                     validator=colander.Length(min=3, max=500))
+
+extrainfo_meta = sheet_meta._replace(
+    isheet=IExtraInfo,
+    schema_class=ExtraInfoSchema,
+)
+
+
+class IConnectionCohesion(ISheet):
+    """Marker iface for 'connection and cohesion' in the selection criteria."""
+
+
+class ConnectionCohesionSchema(colander.MappingSchema):
+    """Datastruct for the connection and cohesion field."""
+
+    connection_cohesion = Text(missing=colander.required,
                                validator=colander.Length(min=3, max=500))
 
+connectioncohesion_meta = sheet_meta._replace(
+    isheet=IConnectionCohesion,
+    schema_class=ConnectionCohesionSchema,
+)
 
-selectioncriteria_meta = sheet_meta._replace(
-    isheet=ISelectionCriteria,
-    schema_class=SelectionCriteriaSchema,
+
+class IDifference(ISheet):
+    """Marker interface for the 'difference' in the selection section."""
+
+
+class DifferenceSchema(colander.MappingSchema):
+    """Datastruct for the challenge field."""
+
+    difference = Text(missing=colander.required,
+                      validator=colander.Length(min=3, max=500))
+
+difference_meta = sheet_meta._replace(
+    isheet=IDifference,
+    schema_class=DifferenceSchema,
+)
+
+
+class IPracticalRelevance(ISheet):
+    """Marker for the 'practical relevance' in the selection criteria."""
+
+
+class PracticalRelevanceSchema(colander.MappingSchema):
+    """Datastruct for the challenge field."""
+
+    practicalrelevance = Text(missing=colander.required,
+                              validator=colander.Length(min=3, max=500))
+
+practicalrelevance_meta = sheet_meta._replace(
+    isheet=IPracticalRelevance,
+    schema_class=PracticalRelevanceSchema,
 )
 
 
@@ -368,47 +467,116 @@ class IMercatorSubResources(ISheet, ISheetReferenceAutoUpdateMarker):
 
 
 class PitchReference(SheetToSheet):
+    """Reference to pitch."""
+
     source_isheet = IMercatorSubResources
     source_isheet_field = 'pitch'
     target_isheet = IPitch
 
 
 class PartnersReference(SheetToSheet):
+    """Reference to partners."""
+
     source_isheet = IMercatorSubResources
     source_isheet_field = 'partners'
     target_isheet = IPartners
 
 
 class DurationReference(SheetToSheet):
+    """Reference to duration."""
+
     source_isheet = IMercatorSubResources
     source_isheet_field = 'duration'
     target_isheet = IDuration
 
 
-class LocationReference(SheetToSheet):
+class ChallengeReference(SheetToSheet):
+    """Reference to challenge."""
+
     source_isheet = IMercatorSubResources
-    source_isheet_field = 'duration'
-    target_isheet = ILocation
+    source_isheet_field = 'challenge'
+    target_isheet = IChallenge
 
 
-class RoadToImpactReference(SheetToSheet):
+class GoalReference(SheetToSheet):
+    """Reference to goal."""
+
     source_isheet = IMercatorSubResources
-    source_isheet_field = 'road_to_impact'
-    target_isheet = IStatus
+    source_isheet_field = 'goal'
+    target_isheet = IGoal
 
 
-class SelectionCriteriaReference(SheetToSheet):
+class PlanReference(SheetToSheet):
+    """Reference to plan."""
+
     source_isheet = IMercatorSubResources
-    source_isheet_field = 'selection_criteria'
-    target_isheet = ISelectionCriteria
+    source_isheet_field = 'plan'
+    target_isheet = IPlan
+
+
+class TargetReference(SheetToSheet):
+    """Reference to target."""
+
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'target'
+    target_isheet = ITarget
+
+
+class TeamReference(SheetToSheet):
+    """Reference to team."""
+
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'team'
+    target_isheet = ITeam
+
+
+class ExtraInfoReference(SheetToSheet):
+    """Reference to extrainfo."""
+
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'extrainfo'
+    target_isheet = IExtraInfo
+
+
+class ConnectionCohesionReference(SheetToSheet):
+    """Reference to connectioncohesion."""
+
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'connectioncohesion'
+    target_isheet = IConnectionCohesion
+
+
+class DifferenceReference(SheetToSheet):
+    """Reference to difference."""
+
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'difference'
+    target_isheet = IDifference
+
+
+class PracticalRelevanceReference(SheetToSheet):
+    """Reference to practical relevance."""
+
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'difference'
+    target_isheet = IPracticalRelevance
 
 
 class MercatorSubResourcesSchema(colander.MappingSchema):
+    """Subresources of mercator."""
+
     pitch = Reference(reftype=PitchReference)
     partners = Reference(reftype=PartnersReference)
     duration = Reference(reftype=DurationReference)
-    road_to_impact = Reference(reftype=RoadToImpactReference)
-    selection_criteria = Reference(reftype=SelectionCriteriaReference)
+    challenge = Reference(reftype=ChallengeReference)
+    goal = Reference(reftype=GoalReference)
+    plan = Reference(reftype=PlanReference)
+    target = Reference(reftype=TargetReference)
+    team = Reference(reftype=TeamReference)
+    extrainfo = Reference(reftype=ExtraInfoReference)
+    connectioncohesion = Reference(reftype=ConnectionCohesionReference)
+    difference = Reference(reftype=DifferenceReference)
+    practicalrelevance = Reference(reftype=PracticalRelevanceReference)
 
 
 mercator_subresources_meta = sheet_meta._replace(
@@ -426,8 +594,15 @@ def includeme(config):
     add_sheet_to_registry(duration_meta, config.registry)
     add_sheet_to_registry(location_meta, config.registry)
     add_sheet_to_registry(status_meta, config.registry)
-    add_sheet_to_registry(roadtoimpact_meta, config.registry)
-    add_sheet_to_registry(selectioncriteria_meta, config.registry)
+    add_sheet_to_registry(challenge_meta, config.registry)
+    add_sheet_to_registry(goal_meta, config.registry)
+    add_sheet_to_registry(plan_meta, config.registry)
+    add_sheet_to_registry(target_meta, config.registry)
+    add_sheet_to_registry(team_meta, config.registry)
+    add_sheet_to_registry(extrainfo_meta, config.registry)
+    add_sheet_to_registry(connectioncohesion_meta, config.registry)
+    add_sheet_to_registry(difference_meta, config.registry)
+    add_sheet_to_registry(practicalrelevance_meta, config.registry)
     add_sheet_to_registry(financialplanning_meta, config.registry)
     add_sheet_to_registry(extra_funding_meta, config.registry)
     add_sheet_to_registry(community_meta, config.registry)

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
@@ -185,8 +185,8 @@ class ILocation(ISheet):
 
 
 class LocationSchema(colander.MappingSchema):
-    city = Text(missing=colander.required)
-    country = ISOCountryCode(missing=colander.required)
+    location = SingleLine(missing=colander.required)
+    is_online = Boolean()
     has_link_to_ruhr = Boolean(missing=colander.required, default=False)
     link_to_ruhr = Text()
 

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
@@ -1,0 +1,435 @@
+"""Sheets for Mercator 2 proposals."""
+import colander
+
+from adhocracy_core.interfaces import ISheet
+from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
+from adhocracy_core.interfaces import SheetToSheet
+from adhocracy_core.schema import AdhocracySchemaNode
+from adhocracy_core.schema import Boolean
+from adhocracy_core.schema import CurrencyAmount
+from adhocracy_core.schema import DateTime
+from adhocracy_core.schema import Email
+from adhocracy_core.schema import ISOCountryCode
+from adhocracy_core.schema import Integer
+from adhocracy_core.schema import Reference
+from adhocracy_core.schema import SingleLine
+from adhocracy_core.schema import Text
+from adhocracy_core.schema import URL
+from adhocracy_core.sheets import add_sheet_to_registry
+from adhocracy_core.sheets import sheet_meta
+
+
+class IUserInfo(ISheet):
+    """Marker interface for information about the proposal submitter."""
+
+
+class UserInfoSchema(colander.MappingSchema):
+    """Information about the proposal submitter."""
+
+    first_name = SingleLine(missing=colander.required)
+    last_name = SingleLine(missing=colander.required)
+
+userinfo_meta = sheet_meta._replace(isheet=IUserInfo,
+                                    schema_class=UserInfoSchema)
+
+
+class IOrganizationInfo(ISheet):
+    """Marker interface for organizational information."""
+
+
+class OrganizationStatusEnum(AdhocracySchemaNode):
+    """Enum of organizational statuses."""
+
+    schema_type = colander.String
+    default = 'other'
+    missing = colander.required
+    validator = colander.OneOf(['registered_nonprofit',
+                                'planned_nonprofit',
+                                'support_needed',
+                                'other',
+                                ])
+
+
+class OrganizationInfoSchema(colander.MappingSchema):
+    """Data structure for organizational information."""
+
+    name = SingleLine(missing=colander.required)
+    city = SingleLine(missing=colander.required)
+    country = ISOCountryCode(missing=colander.required)
+    help_request = Text(validator=colander.Length(max=300))
+    registration_date = DateTime(missing=colander.required, default=None)
+    website = URL(missing=colander.drop)
+    contact_email = Email(missing=colander.required)
+    status = OrganizationStatusEnum(missing=colander.required)
+    status_other = Text(validator=colander.Length(max=300))
+
+    def validator(self, node, value):
+        """Extra validation depending on the status of the organisation.
+
+        Make `status_other` required if `status` == `other` and
+        `help_request` required if `status` == `support_needed`.
+        """
+        status = value.get('status', None)
+        if status == 'support_needed':
+            if not value.get('help_request', None):
+                help_request = node['help_request']
+                raise colander.Invalid(
+                    help_request,
+                    msg='Required iff status == support_needed')
+        elif status == 'other':
+            if not value.get('status_other', None):
+                status_other = node['status_other']
+                raise colander.Invalid(status_other,
+                                       msg='Required iff status == other')
+
+
+organizationinfo_meta = sheet_meta._replace(
+    isheet=IOrganizationInfo,
+    schema_class=OrganizationInfoSchema)
+
+
+class IPitch(ISheet):
+    """Marker interface for the pitch."""
+
+
+class PitchSchema(colander.MappingSchema):
+    pitch = Text(missing=colander.required,
+                 validator=colander.Length(min=3, max=100))
+
+
+pitch_meta = sheet_meta._replace(
+    isheet=IPitch, schema_class=PitchSchema)
+
+
+class IPartners(ISheet):
+    """Marker interface for the partner description."""
+
+
+class PartnersSchema(colander.MappingSchema):
+    has_partners = Boolean()
+    partner1_name = SingleLine()
+    partner1_website = URL()
+    partner1_country = ISOCountryCode()
+    partner2_name = SingleLine()
+    partner2_website = URL()
+    partner2_country = ISOCountryCode()
+    partner3_name = SingleLine()
+    partner3_website = URL()
+    partner3_country = ISOCountryCode()
+    other_partners = Text()
+
+
+partners_meta = sheet_meta._replace(
+    isheet=IPartners, schema_class=PartnersSchema)
+
+
+class TopicEnum(AdhocracySchemaNode):
+    """Enum of topic domains."""
+
+    schema_type = colander.String
+    default = 'other'
+    missing = colander.required
+    validator = colander.OneOf(['democracy_and_participation',
+                                'arts_and_cultural_activities',
+                                'environment',
+                                'social_inclusion',
+                                'migration',
+                                'communities',
+                                'urban_development',
+                                'education',
+                                'other',
+                                ])
+
+
+class ITopic(ISheet):
+    """Marker interface for the topic (ex: democracy, art, environment etc)."""
+
+
+class TopicSchema(colander.MappingSchema):
+    topic = TopicEnum(missing=colander.required)
+    other = Text()
+
+    def validator(self, node, value):
+        """Extra validation depending on the status of the topic.
+
+        Make `other` required if `topic` == `other`.
+        """
+        topic = value.get('topic', None)
+        if topic == 'other':
+            if not value.get('other', None):
+                other = node['other']
+                raise colander.Invalid(
+                    other,
+                    msg='Required iff topic == other')
+
+topic_meta = sheet_meta._replace(
+    isheet=ITopic,
+    schema_class=TopicSchema)
+
+
+class IDuration(ISheet):
+    """Marker interface for the duration."""
+
+
+class DurationSchema(colander.MappingSchema):
+    duration = Integer(missing=colander.required)
+
+
+duration_meta = sheet_meta._replace(
+    isheet=IDuration,
+    schema_class=DurationSchema)
+
+
+class ILocation(ISheet):
+    """Marker interface for the location."""
+
+
+class LocationSchema(colander.MappingSchema):
+    city = Text(missing=colander.required)
+    country = ISOCountryCode(missing=colander.required)
+    has_link_to_ruhr = Boolean(missing=colander.required, default=False)
+    link_to_ruhr = Text()
+
+    def validator(self, node, value):
+        """Extra validation depending on the status of the location.
+
+        Make `link_to_ruhr` required if `has_link_to_ruhr` == `True`.
+        """
+        has_link_to_ruhr = value.get('has_link_to_ruhr', None)
+        if has_link_to_ruhr:
+            if not value.get('link_to_ruhr', None):
+                link_to_ruhr = node['link_to_ruhr']
+                raise colander.Invalid(
+                    link_to_ruhr,
+                    msg='Required iff has_link_to_ruhr == True')
+
+
+location_meta = sheet_meta._replace(
+    isheet=ILocation,
+    schema_class=LocationSchema,
+)
+
+
+class IStatus(ISheet):
+    """Marker interface for the project status."""
+
+
+class ProjectStatusEnum(AdhocracySchemaNode):
+    """Enum of organizational statuses."""
+
+    schema_type = colander.String
+    default = 'other'
+    missing = colander.required
+    validator = colander.OneOf(['starting',
+                                'developping',
+                                'scaling',
+                                'other',
+                                ])
+
+
+class StatusSchema(colander.MappingSchema):
+    status = ProjectStatusEnum(missing=colander.required)
+
+
+status_meta = sheet_meta._replace(
+    isheet=IStatus,
+    schema_class=StatusSchema,
+)
+
+
+class IRoadToImpact(ISheet):
+    """Marker interface for the road to impact."""
+
+
+class RoadToImpactSchema(colander.MappingSchema):
+    challenge = Text(missing=colander.required,
+                     validator=colander.Length(min=3, max=500))
+    aim = Text(missing=colander.required,
+               validator=colander.Length(min=3, max=500))
+    plan = Text(missing=colander.required,
+                validator=colander.Length(min=3, max=800))
+    doing = Text(missing=colander.required,
+                 validator=colander.Length(min=3, max=500))
+    team = Text(missing=colander.required,
+                validator=colander.Length(min=3, max=800))
+    other = Text(missing=colander.required,
+                 validator=colander.Length(min=3, max=500))
+
+
+roadtoimpact_meta = sheet_meta._replace(
+    isheet=IRoadToImpact,
+    schema_class=RoadToImpactSchema,
+)
+
+
+class ISelectionCriteria(ISheet):
+    """Marker interface for the selection criteria."""
+
+
+class SelectionCriteriaSchema(colander.MappingSchema):
+    connection_and_cohesion_europe = Text(
+        missing=colander.required,
+        validator=colander.Length(min=3, max=500))
+    difference = Text(missing=colander.required,
+                      validator=colander.Length(min=3, max=500))
+    practical_relevance = Text(missing=colander.required,
+                               validator=colander.Length(min=3, max=500))
+
+
+selectioncriteria_meta = sheet_meta._replace(
+    isheet=ISelectionCriteria,
+    schema_class=SelectionCriteriaSchema,
+)
+
+
+class IFinancialPlanning(ISheet):
+    """Marker interface for the financial planning."""
+
+
+class FinancialPlanningSchema(colander.MappingSchema):
+    budget = CurrencyAmount(missing=colander.required)
+    requested_funding = CurrencyAmount(
+        missing=colander.required,
+        validator=colander.Range(min=1, max=50000))
+    major_expenses = Text(missing=colander.required)
+
+
+class IExtraFunding(ISheet):
+    """Marker interface for the 'other sources of income' fie."""
+
+
+class ExtraFundingSchema(colander.MappingSchema):
+    other_sources = Text()
+    secured = Boolean(default=False)
+
+
+extra_funding_meta = sheet_meta._replace(
+    isheet=IExtraFunding,
+    schema_class=ExtraFundingSchema,
+    permission_view='view_mercator2_extra_funding',
+)
+
+
+financialplanning_meta = sheet_meta._replace(
+    isheet=IFinancialPlanning,
+    schema_class=FinancialPlanningSchema,
+)
+
+
+class ICommunity(ISheet):
+    """Marker interface for the community information."""
+
+
+class HeardFromEnum(AdhocracySchemaNode):
+    """Enum of organizational statuses."""
+
+    schema_type = colander.String
+    default = 'other'
+    missing = colander.required
+    validator = colander.OneOf(['personal_contact',
+                                'website',
+                                'facebook',
+                                'twitter',
+                                'newsletter',
+                                'other',
+                                ])
+
+
+class CommunitySchema(colander.MappingSchema):
+    expected_feedback = Text(missing=colander.required)
+    heard_from = HeardFromEnum(missing=colander.required)
+    heard_from_other = Text()
+
+
+community_meta = sheet_meta._replace(
+    isheet=ICommunity,
+    schema_class=CommunitySchema,
+)
+
+
+class IWinnerInfo(ISheet):
+    """Marker interface for the winner information."""
+
+
+class WinnerInfoSchema(colander.MappingSchema):
+    explanation = Text()
+    funding = Integer()
+
+winnerinfo_meta = sheet_meta._replace(
+    isheet=IWinnerInfo,
+    schema_class=WinnerInfoSchema,
+    permission_view='view_mercator2_winnerinfo',
+    permission_edit='edit_mercator2_winnerinfo',
+)
+
+
+class IMercatorSubResources(ISheet, ISheetReferenceAutoUpdateMarker):
+    """Marker interface for commentable subresources of MercatorProposal."""
+
+
+class PitchReference(SheetToSheet):
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'pitch'
+    target_isheet = IPitch
+
+
+class PartnersReference(SheetToSheet):
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'partners'
+    target_isheet = IPartners
+
+
+class DurationReference(SheetToSheet):
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'duration'
+    target_isheet = IDuration
+
+
+class LocationReference(SheetToSheet):
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'duration'
+    target_isheet = ILocation
+
+
+class RoadToImpactReference(SheetToSheet):
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'road_to_impact'
+    target_isheet = IStatus
+
+
+class SelectionCriteriaReference(SheetToSheet):
+    source_isheet = IMercatorSubResources
+    source_isheet_field = 'selection_criteria'
+    target_isheet = ISelectionCriteria
+
+
+class MercatorSubResourcesSchema(colander.MappingSchema):
+    pitch = Reference(reftype=PitchReference)
+    partners = Reference(reftype=PartnersReference)
+    duration = Reference(reftype=DurationReference)
+    road_to_impact = Reference(reftype=RoadToImpactReference)
+    selection_criteria = Reference(reftype=SelectionCriteriaReference)
+
+
+mercator_subresources_meta = sheet_meta._replace(
+    isheet=IMercatorSubResources,
+    schema_class=MercatorSubResourcesSchema)
+
+
+def includeme(config):
+    """Register sheets."""
+    add_sheet_to_registry(userinfo_meta, config.registry)
+    add_sheet_to_registry(organizationinfo_meta, config.registry)
+    add_sheet_to_registry(pitch_meta, config.registry)
+    add_sheet_to_registry(partners_meta, config.registry)
+    add_sheet_to_registry(topic_meta, config.registry)
+    add_sheet_to_registry(duration_meta, config.registry)
+    add_sheet_to_registry(location_meta, config.registry)
+    add_sheet_to_registry(status_meta, config.registry)
+    add_sheet_to_registry(roadtoimpact_meta, config.registry)
+    add_sheet_to_registry(selectioncriteria_meta, config.registry)
+    add_sheet_to_registry(financialplanning_meta, config.registry)
+    add_sheet_to_registry(extra_funding_meta, config.registry)
+    add_sheet_to_registry(community_meta, config.registry)
+    add_sheet_to_registry(winnerinfo_meta, config.registry)
+    add_sheet_to_registry(mercator_subresources_meta, config.registry)

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
@@ -454,45 +454,36 @@ class TestStatusSheet:
         assert get_sheet(context, meta.isheet)
 
 
-class TestRoadToImpactSchema:
+class TestChallengeSchema:
 
     @fixture
     def inst(self):
-        from .mercator2 import RoadToImpactSchema
-        return RoadToImpactSchema()
+        from .mercator2 import ChallengeSchema
+        return ChallengeSchema()
 
     @fixture
     def cstruct_required(self):
-        return {'challenge': 'the challenge',
-                'aim': 'the aim',
-                'plan': 'the plan',
-                'doing': 'the actions',
-                'team': 'the team',
-                'other': 'extra'}
+        return {'challenge': 'reduce pollution in Europe'}
 
     def test_deserialize_empty(self, inst):
         from colander import Invalid
         cstruct = {}
         with raises(Invalid) as error:
             inst.deserialize(cstruct)
-        assert error.value.asdict() == {'aim': 'Required',
-                                        'challenge': 'Required',
-                                        'doing': 'Required',
-                                        'other': 'Required',
-                                        'plan': 'Required',
-                                        'team': 'Required'}
+        assert error.value.asdict() == {'challenge': 'Required'}
 
     def test_deserialize_with_required(self, inst, cstruct_required):
         wanted = cstruct_required
-        assert inst.deserialize(cstruct_required) == cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'challenge': 'reduce pollution in Europe'}
 
 
-class TestRoadToImpactSheet:
+class TestChallengeSheet:
 
     @fixture
     def meta(self):
-        from .mercator2 import roadtoimpact_meta
-        return roadtoimpact_meta
+        from .mercator2 import challenge_meta
+        return challenge_meta
 
     @fixture
     def context(self):
@@ -500,11 +491,11 @@ class TestRoadToImpactSheet:
         return testing.DummyResource(__provides__=IItem)
 
     def test_create_valid(self, meta, context):
-        from adhocracy_mercator.sheets.mercator2 import IRoadToImpact
-        from adhocracy_mercator.sheets.mercator2 import RoadToImpactSchema
+        from adhocracy_mercator.sheets.mercator2 import IChallenge
+        from adhocracy_mercator.sheets.mercator2 import ChallengeSchema
         inst = meta.sheet_class(meta, context)
-        assert inst.meta.isheet == IRoadToImpact
-        assert inst.meta.schema_class == RoadToImpactSchema
+        assert inst.meta.isheet == IChallenge
+        assert inst.meta.schema_class == ChallengeSchema
 
     @mark.usefixtures('integration')
     def test_includeme(self, meta):
@@ -513,40 +504,36 @@ class TestRoadToImpactSheet:
         assert get_sheet(context, meta.isheet)
 
 
-class TestSelectionCriteriaSchema:
+class TestGoalSchema:
 
     @fixture
     def inst(self):
-        from .mercator2 import SelectionCriteriaSchema
-        return SelectionCriteriaSchema()
+        from .mercator2 import GoalSchema
+        return GoalSchema()
 
     @fixture
     def cstruct_required(self):
-        return {'connection_and_cohesion_europe': 'content connection',
-                'difference': 'content difference',
-                'practical_relevance': 'content relevance'}
+        return {'goal': 'free bicycle for everyone'}
 
     def test_deserialize_empty(self, inst):
         from colander import Invalid
         cstruct = {}
         with raises(Invalid) as error:
             inst.deserialize(cstruct)
-        assert error.value.asdict() == \
-            {'connection_and_cohesion_europe': 'Required',
-             'difference': 'Required',
-             'practical_relevance': 'Required'}
+        assert error.value.asdict() == {'goal': 'Required'}
 
     def test_deserialize_with_required(self, inst, cstruct_required):
         wanted = cstruct_required
-        assert inst.deserialize(cstruct_required) == cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'goal': 'free bicycle for everyone'}
 
 
-class TestSelectionCriteriaSheet:
+class TestGoalSheet:
 
     @fixture
     def meta(self):
-        from .mercator2 import selectioncriteria_meta
-        return selectioncriteria_meta
+        from .mercator2 import goal_meta
+        return goal_meta
 
     @fixture
     def context(self):
@@ -554,11 +541,361 @@ class TestSelectionCriteriaSheet:
         return testing.DummyResource(__provides__=IItem)
 
     def test_create_valid(self, meta, context):
-        from adhocracy_mercator.sheets.mercator2 import ISelectionCriteria
-        from adhocracy_mercator.sheets.mercator2 import SelectionCriteriaSchema
+        from adhocracy_mercator.sheets.mercator2 import IGoal
+        from adhocracy_mercator.sheets.mercator2 import GoalSchema
         inst = meta.sheet_class(meta, context)
-        assert inst.meta.isheet == ISelectionCriteria
-        assert inst.meta.schema_class == SelectionCriteriaSchema
+        assert inst.meta.isheet == IGoal
+        assert inst.meta.schema_class == GoalSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestPlanSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import PlanSchema
+        return PlanSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'plan': '3D-printed bicycle'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'plan': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'plan': '3D-printed bicycle'}
+
+
+class TestPlanSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import plan_meta
+        return plan_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IPlan
+        from adhocracy_mercator.sheets.mercator2 import PlanSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IPlan
+        assert inst.meta.schema_class == PlanSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestTargetSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import TargetSchema
+        return TargetSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'target': 'everyone'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'target': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'target': 'everyone'}
+
+
+class TestTargetSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import target_meta
+        return target_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import ITarget
+        from adhocracy_mercator.sheets.mercator2 import TargetSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == ITarget
+        assert inst.meta.schema_class == TargetSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestTeamSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import TeamSchema
+        return TeamSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'team': 'Ana'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'team': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'team': 'Ana'}
+
+
+class TestTeamSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import team_meta
+        return team_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import ITeam
+        from adhocracy_mercator.sheets.mercator2 import TeamSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == ITeam
+        assert inst.meta.schema_class == TeamSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestExtraInfoSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import ExtraInfoSchema
+        return ExtraInfoSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'extrainfo': 'Was successful in XYZ.'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'extrainfo': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'extrainfo': 'Was successful in XYZ.'}
+
+
+class TestExtraInfoSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import extrainfo_meta
+        return extrainfo_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IExtraInfo
+        from adhocracy_mercator.sheets.mercator2 import ExtraInfoSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IExtraInfo
+        assert inst.meta.schema_class == ExtraInfoSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestConnectionCohesionSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import ConnectionCohesionSchema
+        return ConnectionCohesionSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'connection_cohesion': 'Reducing pollution reduces social problems.'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'connection_cohesion': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'connection_cohesion': 'Reducing pollution reduces social problems.'}
+
+
+class TestConnectionCohesionSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import connectioncohesion_meta
+        return connectioncohesion_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IConnectionCohesion
+        from adhocracy_mercator.sheets.mercator2 import ConnectionCohesionSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IConnectionCohesion
+        assert inst.meta.schema_class == ConnectionCohesionSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestDifferenceSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import DifferenceSchema
+        return DifferenceSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'difference': 'Designs of bicycles are open-sourced.'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'difference': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'difference': 'Designs of bicycles are open-sourced.'}
+
+
+class TestDifferenceSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import difference_meta
+        return difference_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IDifference
+        from adhocracy_mercator.sheets.mercator2 import DifferenceSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IDifference
+        assert inst.meta.schema_class == DifferenceSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestPracticalRelevanceSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import PracticalRelevanceSchema
+        return PracticalRelevanceSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'practicalrelevance': 'Designs of bicycles are open-sourced.'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'practicalrelevance': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+        {'practicalrelevance': 'Designs of bicycles are open-sourced.'}
+
+
+class TestPracticalRelevanceSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import practicalrelevance_meta
+        return practicalrelevance_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IPracticalRelevance
+        from adhocracy_mercator.sheets.mercator2 import PracticalRelevanceSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IPracticalRelevance
+        assert inst.meta.schema_class == PracticalRelevanceSchema
 
     @mark.usefixtures('integration')
     def test_includeme(self, meta):

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
@@ -21,12 +21,9 @@ class TestUserInfoSheet:
 
     def test_create_valid(self, meta, context):
         from zope.interface.verify import verifyObject
-        from adhocracy_core.interfaces import IResourceSheet
         from adhocracy_mercator.sheets.mercator2 import IUserInfo
         from adhocracy_mercator.sheets.mercator2 import UserInfoSchema
         inst = meta.sheet_class(meta, context)
-        assert IResourceSheet.providedBy(inst)
-        assert verifyObject(IResourceSheet, inst)
         assert inst.meta.isheet == IUserInfo
         assert inst.meta.schema_class == UserInfoSchema
 
@@ -52,12 +49,9 @@ class TestOrganizationInfoSheet:
 
     def test_create_valid(self, meta, context):
         from zope.interface.verify import verifyObject
-        from adhocracy_core.interfaces import IResourceSheet
         from adhocracy_mercator.sheets.mercator2 import IOrganizationInfo
         from adhocracy_mercator.sheets.mercator2 import OrganizationInfoSchema
         inst = meta.sheet_class(meta, context)
-        assert IResourceSheet.providedBy(inst)
-        assert verifyObject(IResourceSheet, inst)
         assert inst.meta.isheet == IOrganizationInfo
         assert inst.meta.schema_class == OrganizationInfoSchema
 

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
@@ -1,0 +1,778 @@
+from datetime import datetime
+from datetime import timedelta
+
+from pyramid import testing
+from pytest import fixture
+from pytest import mark
+from pytest import raises
+
+
+class TestUserInfoSheet:
+
+    @fixture
+    def meta(self):
+        from adhocracy_mercator.sheets.mercator2 import userinfo_meta
+        return userinfo_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from zope.interface.verify import verifyObject
+        from adhocracy_core.interfaces import IResourceSheet
+        from adhocracy_mercator.sheets.mercator2 import IUserInfo
+        from adhocracy_mercator.sheets.mercator2 import UserInfoSchema
+        inst = meta.sheet_class(meta, context)
+        assert IResourceSheet.providedBy(inst)
+        assert verifyObject(IResourceSheet, inst)
+        assert inst.meta.isheet == IUserInfo
+        assert inst.meta.schema_class == UserInfoSchema
+
+    def test_get_empty(self, meta, context):
+        inst = meta.sheet_class(meta, context)
+        wanted = {'first_name': '',
+                  'last_name': '',
+                  }
+        assert inst.get() == wanted
+
+
+class TestOrganizationInfoSheet:
+
+    @fixture
+    def meta(self):
+        from adhocracy_mercator.sheets.mercator2 import organizationinfo_meta
+        return organizationinfo_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from zope.interface.verify import verifyObject
+        from adhocracy_core.interfaces import IResourceSheet
+        from adhocracy_mercator.sheets.mercator2 import IOrganizationInfo
+        from adhocracy_mercator.sheets.mercator2 import OrganizationInfoSchema
+        inst = meta.sheet_class(meta, context)
+        assert IResourceSheet.providedBy(inst)
+        assert verifyObject(IResourceSheet, inst)
+        assert inst.meta.isheet == IOrganizationInfo
+        assert inst.meta.schema_class == OrganizationInfoSchema
+
+    def test_get_empty(self, meta, context):
+        inst = meta.sheet_class(meta, context)
+        wanted = {'name': '',
+                  'city': '',
+                  'country': 'DE',
+                  'help_request': '',
+                  'registration_date': None,
+                  'website': '',
+                  'contact_email': '',
+                  'status': 'other',
+                  'status_other': '',
+                  }
+        assert inst.get() == wanted
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestOrganizationInfoSchema:
+
+    @fixture
+    def inst(self):
+        from adhocracy_mercator.sheets.mercator2 import OrganizationInfoSchema
+        return OrganizationInfoSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'country': 'DE',
+                'name': 'Name',
+                'status': 'planned_nonprofit',
+                'contact_email': 'anna@example.com',
+                'registration_date': '2015-02-18T14:17:24+00:00',
+                'city': 'Berlin',
+                }
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'city': 'Required',
+                                        'contact_email': 'Required',
+                                        'country': 'Required',
+                                        'name': 'Required',
+                                        'registration_date': 'Required',
+                                        'status': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        from pytz import UTC
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+            {'country': 'DE',
+             'name': 'Name',
+             'status': 'planned_nonprofit',
+             'contact_email': 'anna@example.com',
+             'registration_date': datetime(2015, 2, 18,
+                                           14, 17, 24, 0, tzinfo=UTC),
+             'city': 'Berlin',
+            }
+
+    def test_deserialize_with_status_other_and_no_description(
+            self, inst, cstruct_required):
+        from colander import Invalid
+        cstruct = cstruct_required
+        cstruct['status'] = 'other'
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'status_other':
+                                        'Required iff status == other'}
+
+    def test_deserialize_with_status_support_needed_and_no_help_request(
+            self, inst, cstruct_required):
+        from colander import Invalid
+        cstruct = cstruct_required
+        cstruct['status'] = 'support_needed'
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'help_request':
+                                        'Required iff status == support_needed'}
+
+class TestPitchSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import PitchSchema
+        return PitchSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'pitch': 'something'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'pitch': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+            {'pitch': 'something'}
+
+
+class TestPitchSheet:
+
+    @fixture
+    def meta(self):
+        from adhocracy_mercator.sheets.mercator2 import pitch_meta
+        return pitch_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IPitch
+        from adhocracy_mercator.sheets.mercator2 import PitchSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IPitch
+        assert inst.meta.schema_class == PitchSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestPartnersSheet:
+
+    @fixture
+    def meta(self):
+        from adhocracy_mercator.sheets.mercator2 import partners_meta
+        return partners_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IPartners
+        from adhocracy_mercator.sheets.mercator2 import PartnersSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IPartners
+        assert inst.meta.schema_class == PartnersSchema
+
+    def test_get_empty(self, meta, context):
+        inst = meta.sheet_class(meta, context)
+        wanted = {'partner1_name': '',
+                  'partner1_website': '',
+                  'partner1_country': 'DE',
+                  'partner2_name': '',
+                  'partner2_website': '',
+                  'partner2_country': 'DE',
+                  'partner3_name': '',
+                  'partner3_website': '',
+                  'partner3_country': 'DE',
+                  'other_partners': '',
+                  'has_partners': False}
+        assert inst.get() == wanted
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+class TestTopicSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import TopicSchema
+        return TopicSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'topic': 'urban_development'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'topic': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+            {'topic': 'urban_development'}
+
+    def test_deserialize_with_status_other_and_no_text(
+            self, inst, cstruct_required):
+        from colander import Invalid
+        cstruct = cstruct_required
+        cstruct['topic'] = 'other'
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'other':
+                                        'Required iff topic == other'}
+
+class TestTopicSheet:
+
+    @fixture
+    def meta(self):
+        from adhocracy_mercator.sheets.mercator2 import topic_meta
+        return topic_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import ITopic
+        from adhocracy_mercator.sheets.mercator2 import TopicSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == ITopic
+        assert inst.meta.schema_class == TopicSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestDurationSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import DurationSchema
+        return DurationSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'duration': '6'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'duration': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+            {'duration': 6}
+
+
+class TestDurationSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import duration_meta
+        return duration_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IDuration
+        from adhocracy_mercator.sheets.mercator2 import DurationSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IDuration
+        assert inst.meta.schema_class == DurationSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestLocationSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import LocationSchema
+        return LocationSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'city': 'Berlin',
+                'country': 'DE',
+                'has_link_to_ruhr': 'false',
+                'link_to_ruhr': ''
+        }
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'city': 'Required',
+                                        'country': 'Required',
+                                        'has_link_to_ruhr': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+              {'city': 'Berlin',
+               'country': 'DE',
+               'has_link_to_ruhr': False}
+
+    def test_deserialize_with_link_to_ruhr_but_no_text(self,
+                                                       inst,
+                                                       cstruct_required):
+        from colander import Invalid
+        cstruct = cstruct_required
+        cstruct['has_link_to_ruhr'] = True
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'link_to_ruhr':
+                                        'Required iff has_link_to_ruhr == True'}
+
+class TestLocationSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import location_meta
+        return location_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import ILocation
+        from adhocracy_mercator.sheets.mercator2 import LocationSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == ILocation
+        assert inst.meta.schema_class == LocationSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestStatusSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import StatusSchema
+        return StatusSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'status': 'other'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'status': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == {'status': 'other'}
+
+
+class TestStatusSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import status_meta
+        return status_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IStatus
+        from adhocracy_mercator.sheets.mercator2 import StatusSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IStatus
+        assert inst.meta.schema_class == StatusSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestRoadToImpactSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import RoadToImpactSchema
+        return RoadToImpactSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'challenge': 'the challenge',
+                'aim': 'the aim',
+                'plan': 'the plan',
+                'doing': 'the actions',
+                'team': 'the team',
+                'other': 'extra'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == {'aim': 'Required',
+                                        'challenge': 'Required',
+                                        'doing': 'Required',
+                                        'other': 'Required',
+                                        'plan': 'Required',
+                                        'team': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == cstruct_required
+
+
+class TestRoadToImpactSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import roadtoimpact_meta
+        return roadtoimpact_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IRoadToImpact
+        from adhocracy_mercator.sheets.mercator2 import RoadToImpactSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IRoadToImpact
+        assert inst.meta.schema_class == RoadToImpactSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestSelectionCriteriaSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import SelectionCriteriaSchema
+        return SelectionCriteriaSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'connection_and_cohesion_europe': 'content connection',
+                'difference': 'content difference',
+                'practical_relevance': 'content relevance'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == \
+            {'connection_and_cohesion_europe': 'Required',
+             'difference': 'Required',
+             'practical_relevance': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == cstruct_required
+
+
+class TestSelectionCriteriaSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import selectioncriteria_meta
+        return selectioncriteria_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import ISelectionCriteria
+        from adhocracy_mercator.sheets.mercator2 import SelectionCriteriaSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == ISelectionCriteria
+        assert inst.meta.schema_class == SelectionCriteriaSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestFinancialPlanningSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import FinancialPlanningSchema
+        return FinancialPlanningSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'budget': '10000',
+                'requested_funding': '500',
+                'major_expenses': 'travel'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == \
+            {'budget': 'Required',
+             'major_expenses': 'Required',
+             'requested_funding': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+            {'budget': 10000,
+             'requested_funding': 500,
+             'major_expenses': 'travel'}
+
+
+class TestFinancialPlanningSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import financialplanning_meta
+        return financialplanning_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IFinancialPlanning
+        from adhocracy_mercator.sheets.mercator2 import FinancialPlanningSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IFinancialPlanning
+        assert inst.meta.schema_class == FinancialPlanningSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+class TestExtraFundingSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import ExtraFundingSchema
+        return ExtraFundingSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'other_sources': 'XYZ grant',
+                'secured': 'False'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+            {'other_sources': 'XYZ grant',
+             'secured': False}
+
+
+class TestExtraFundingSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import extra_funding_meta
+        return extra_funding_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IExtraFunding
+        from adhocracy_mercator.sheets.mercator2 import ExtraFundingSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IExtraFunding
+        assert inst.meta.schema_class == ExtraFundingSchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestCommunitySchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import CommunitySchema
+        return CommunitySchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'expected_feedback': 'Nice comments',
+                'heard_from': 'website'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        with raises(Invalid) as error:
+            inst.deserialize(cstruct)
+        assert error.value.asdict() == \
+            {'expected_feedback': 'Required',
+             'heard_from': 'Required'}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == cstruct_required
+
+
+class TestCommunitySheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import community_meta
+        return community_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import ICommunity
+        from adhocracy_mercator.sheets.mercator2 import CommunitySchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == ICommunity
+        assert inst.meta.schema_class == CommunitySchema
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
+
+
+class TestWinnerInfoSchema:
+
+    @fixture
+    def inst(self):
+        from .mercator2 import WinnerInfoSchema
+        return WinnerInfoSchema()
+
+    @fixture
+    def cstruct_required(self):
+        return {'explanation': 'Relevant project',
+                'funding': '10000'}
+
+    def test_deserialize_empty(self, inst):
+        from colander import Invalid
+        cstruct = {}
+        assert inst.deserialize(cstruct) == {}
+
+    def test_deserialize_with_required(self, inst, cstruct_required):
+        wanted = cstruct_required
+        assert inst.deserialize(cstruct_required) == \
+            {'explanation': 'Relevant project',
+             'funding': 10000}
+
+
+class TestWinnerInfoSheet:
+
+    @fixture
+    def meta(self):
+        from .mercator2 import winnerinfo_meta
+        return winnerinfo_meta
+
+    @fixture
+    def context(self):
+        from adhocracy_core.interfaces import IItem
+        return testing.DummyResource(__provides__=IItem)
+
+    def test_create_valid(self, meta, context):
+        from adhocracy_mercator.sheets.mercator2 import IWinnerInfo
+        from adhocracy_mercator.sheets.mercator2 import WinnerInfoSchema
+        inst = meta.sheet_class(meta, context)
+        assert inst.meta.isheet == IWinnerInfo
+        assert inst.meta.schema_class == WinnerInfoSchema
+        assert inst.meta.permission_view == 'view_mercator2_winnerinfo'
+        assert inst.meta.permission_edit == 'edit_mercator2_winnerinfo'
+
+    @mark.usefixtures('integration')
+    def test_includeme(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
@@ -352,9 +352,9 @@ class TestLocationSchema:
 
     @fixture
     def cstruct_required(self):
-        return {'city': 'Berlin',
-                'country': 'DE',
+        return {'location': 'Berlin',
                 'has_link_to_ruhr': 'false',
+                'is_online': 'false',
                 'link_to_ruhr': ''
         }
 
@@ -363,16 +363,16 @@ class TestLocationSchema:
         cstruct = {}
         with raises(Invalid) as error:
             inst.deserialize(cstruct)
-        assert error.value.asdict() == {'city': 'Required',
-                                        'country': 'Required',
+        assert error.value.asdict() == {'location': 'Required',
                                         'has_link_to_ruhr': 'Required'}
 
     def test_deserialize_with_required(self, inst, cstruct_required):
         wanted = cstruct_required
         assert inst.deserialize(cstruct_required) == \
-              {'city': 'Berlin',
-               'country': 'DE',
-               'has_link_to_ruhr': False}
+              {'location': 'Berlin',
+               'is_online': False,
+               'has_link_to_ruhr': False,
+               'is_online': False}
 
     def test_deserialize_with_link_to_ruhr_but_no_text(self,
                                                        inst,

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from pytz import UTC
 
 from pyramid import testing
 from pytest import fixture
@@ -106,7 +107,6 @@ class TestOrganizationInfoSchema:
                                         'status': 'Required'}
 
     def test_deserialize_with_required(self, inst, cstruct_required):
-        from pytz import UTC
         wanted = cstruct_required
         assert inst.deserialize(cstruct_required) == \
             {'country': 'DE',
@@ -127,6 +127,41 @@ class TestOrganizationInfoSchema:
             inst.deserialize(cstruct)
         assert error.value.asdict() == {'status_other':
                                         'Required iff status == other'}
+
+    def test_deserialize_with_status_other(
+            self, inst, cstruct_required):
+        from colander import Invalid
+        cstruct = cstruct_required
+        cstruct['status'] = 'other'
+        cstruct['status_other'] = 'Blabla'
+        assert inst.deserialize(cstruct) == \
+            {'country': 'DE',
+             'name': 'Name',
+             'status': 'other',
+             'status_other': 'Blabla',
+             'contact_email': 'anna@example.com',
+             'registration_date': datetime(2015, 2, 18,
+                                           14, 17, 24, 0, tzinfo=UTC),
+             'city': 'Berlin',
+            }
+
+    def test_deserialize_with_status_support_needed(
+            self, inst, cstruct_required):
+        from colander import Invalid
+        cstruct = cstruct_required
+        cstruct['status'] = 'support_needed'
+        cstruct['help_request'] = 'Blabla'
+        assert inst.deserialize(cstruct) == \
+            {'country': 'DE',
+             'name': 'Name',
+             'status': 'support_needed',
+             'help_request': 'Blabla',
+             'contact_email': 'anna@example.com',
+             'registration_date': datetime(2015, 2, 18,
+                                           14, 17, 24, 0, tzinfo=UTC),
+             'city': 'Berlin',
+            }
+
 
     def test_deserialize_with_status_support_needed_and_no_help_request(
             self, inst, cstruct_required):
@@ -261,6 +296,17 @@ class TestTopicSchema:
         assert error.value.asdict() == {'other':
                                         'Required iff topic == other'}
 
+    def test_deserialize_with_status_other(
+            self, inst, cstruct_required):
+        from colander import Invalid
+        cstruct = cstruct_required
+        cstruct['topic'] = 'other'
+        cstruct['other'] = 'Blabla'
+        assert inst.deserialize(cstruct_required) == \
+            {'topic': 'other',
+             'other': 'Blabla'}
+
+
 class TestTopicSheet:
 
     @fixture
@@ -378,6 +424,19 @@ class TestLocationSchema:
             inst.deserialize(cstruct)
         assert error.value.asdict() == {'link_to_ruhr':
                                         'Required iff has_link_to_ruhr == True'}
+
+    def test_deserialize_with_link_to_ruhr(self,
+                                           inst,
+                                           cstruct_required):
+        from colander import Invalid
+        cstruct = cstruct_required
+        cstruct['has_link_to_ruhr'] = True
+        cstruct['link_to_ruhr'] = 'Blabla'
+        assert inst.deserialize(cstruct) == \
+            {'has_link_to_ruhr': True,
+             'is_online': False,
+             'link_to_ruhr': 'Blabla',
+             'location': 'Berlin'}
 
 class TestLocationSheet:
 

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/__init__.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/__init__.py
@@ -35,3 +35,4 @@ mercator_meta = standard_meta \
 def includeme(config):
     """Add workflow."""
     add_workflow(config.registry, mercator_meta, 'mercator')
+    config.include('.mercator2')

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator2.py
@@ -1,0 +1,49 @@
+"""Workflow for Mercator2."""
+
+# flake8: noqa
+
+from adhocracy_core.workflows import add_workflow
+from adhocracy_core.workflows.standard import standard_meta
+
+mercator2_meta = standard_meta \
+                 .transform(('states', 'participate', 'acm'),
+                            {'principals':                    ['participant', 'moderator', 'creator', 'initiator'],
+                             'permissions':
+                             [['create_proposal',              'Allow',        None,        None,     'Allow'],
+                              ['edit_proposal',                 None,          None,       'Allow',    None],
+                              ['create_comment',               'Allow',       'Allow',      None,     'Allow'],
+                              ['edit_comment',                  None,          None,       'Allow',    None],
+                              ['create_rate',                  'Allow',        None,        None,      None],
+                              ['edit_rate',                     None,          None,       'Allow',    None],
+                              ['view_mercator2_extra_funding', 'Deny',        'Allow',     'Allow',    None],
+                              ['view_mercator2_winnerinfo',    'Deny',        'Deny',       None,      None],
+                              ['edit_mercator2_winnerinfo',    'Deny',        'Deny',       None,      None]
+                             ]}) \
+                 .transform(('states', 'evaluate', 'acm'),
+                            {'principals':                    ['participant', 'moderator', 'creator', 'initiator'],
+                             'permissions':
+                             [['edit',                          None,          None,       'Deny',     None],
+                              ['view_mercator2_extra_funding', 'Deny',        'Allow',      None,      None],
+                              ['view_mercator2_winnerinfo',    'Deny',        'Allow',      None,      None],
+                              ['edit_mercator2_winnerinfo',    'Deny',        'Allow',      None,      None]
+                             ]}) \
+                 .transform(('states', 'result', 'acm'),
+                            {'principals':                    ['participant', 'moderator', 'creator', 'initiator'],
+                             'permissions':
+                             [['edit',                          None,          None,       'Deny',     None],
+                              ['view_mercator2_extra_funding', 'Deny',        'Allow',      None,      None],
+                              ['view_mercator2_winnerinfo',    'Allow',       'Allow',      None,      None],
+                              ['edit_mercator2_winnerinfo',    'Deny',        'Allow',      None,      None],
+                              ['create_document',               None,          None,       'Allow',    None],
+                              ['edit_document',                 None,          None,       'Allow',    None],
+                             ]}) \
+                 .transform(('states', 'closed', 'acm'),
+                            {'principals':                      ['participant', 'moderator', 'creator', 'initiator'],
+                             'permissions':
+                             [['edit',                            None,          None,       'Deny',     None],
+                             ]})
+
+
+def includeme(config):
+    """Add workflow."""
+    add_workflow(config.registry, mercator2_meta, 'mercator2')

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator2.py
@@ -15,6 +15,7 @@ mercator2_meta = standard_meta \
                               ['edit_comment',                  None,          None,       'Allow',    None],
                               ['create_rate',                  'Allow',        None,        None,      None],
                               ['edit_rate',                     None,          None,       'Allow',    None],
+                              ['create_badge_assignment',      'Allow',        None,        None,      None],
                               ['view_mercator2_extra_funding', 'Deny',        'Allow',     'Allow',    None],
                               ['view_mercator2_winnerinfo',    'Deny',        'Deny',       None,      None],
                               ['edit_mercator2_winnerinfo',    'Deny',        'Deny',       None,      None]

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2.py
@@ -1,0 +1,270 @@
+from pyramid import testing
+from pytest import mark
+from pytest import fixture
+from webtest import TestResponse
+
+from adhocracy_core.utils.testing import add_resources
+from adhocracy_core.utils.testing import do_transition_to
+
+@fixture
+def integration(config):
+    config.include('adhocracy_core.events')
+    config.include('adhocracy_core.content')
+    config.include('adhocracy_mercator.workflows')
+
+
+def _post_proposal(app_user, path='/') -> TestResponse:
+    from adhocracy_mercator.resources.mercator2 import IMercatorProposal
+    resp = app_user.post_resource(path, IMercatorProposal, {})
+    return resp
+
+
+def _post_comment_item(app_user, path='') -> TestResponse:
+    from adhocracy_core.resources.comment import IComment
+    resp = app_user.post_resource(path, IComment, {})
+    return resp
+
+
+@mark.functional
+class TestMercator2:
+
+    @fixture
+    def process_url(self):
+        return '/organisation/advocate-europe2'
+
+    @fixture
+    def proposal0_url(self):
+        return '/organisation/advocate-europe2/proposal_0000000'
+
+
+    def test_create_resources(self,
+                              registry,
+                              datadir,
+                              process_url,
+                              app,
+                              app_admin):
+        json_file = str(datadir.join('resources.json'))
+        add_resources(app, json_file)
+        resp = app_admin.get(process_url)
+        assert resp.status_code == 200
+
+    def test_set_participate_state(self, registry, app, process_url, app_admin):
+        resp = app_admin.get(process_url)
+        assert resp.status_code == 200
+
+        resp = do_transition_to(app_admin,
+                                process_url,
+                                'announce')
+        assert resp.status_code == 200
+
+        resp = do_transition_to(app_admin,
+                                process_url,
+                                'participate')
+        assert resp.status_code == 200
+
+    def test_participate_participant_creates_proposal(self,
+                                                      registry,
+                                                      app,
+                                                      process_url,
+                                                      app_participant):
+        resp = _post_proposal(app_participant, path=process_url)
+        assert resp.status_code == 200
+
+    def test_participate_participant_can_read_extrafunding(self,
+                                                           registry,
+                                                           app,
+                                                           process_url,
+                                                           app_participant,
+                                                           proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import IExtraFunding
+        resp = app_participant.get(proposal0_url)
+        data = resp.json_body['data']
+        assert IExtraFunding.__identifier__ in data
+
+    def test_participate_participant2_cannot_read_extrafunding(self,
+                                                               registry,
+                                                               app,
+                                                               process_url,
+                                                               app_participant2,
+                                                               proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import IExtraFunding
+        resp = app_participant2.get(proposal0_url)
+        data = resp.json_body['data']
+        assert IExtraFunding.__identifier__ not in data
+
+    def test_participate_participant_can_edit_topic(self,
+                                                    registry,
+                                                    app,
+                                                    process_url,
+                                                    app_participant,
+                                                    proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import ITopic
+        resp = app_participant.options(proposal0_url)
+        data = resp.json_body['PUT']['request_body']['data']
+        assert ITopic.__identifier__ in data
+
+    def test_participate_participant_creates_comment(self,
+                                                     registry,
+                                                     app,
+                                                     app_participant,
+                                                     proposal0_url):
+        path = proposal0_url +  '/comments'
+        resp = _post_comment_item(app_participant, path=path)
+        assert resp.status_code == 200
+
+    def test_participate_participant_cannot_update_winnerinfo(self,
+                                                              registry,
+                                                              app,
+                                                              process_url,
+                                                              app_participant,
+                                                              proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import IWinnerInfo
+        resp = app_participant.options(proposal0_url)
+        data = resp.json_body['PUT']['request_body']['data']
+        assert IWinnerInfo not in data
+
+    def test_set_evaluate_state(self, registry, app, process_url, app_admin):
+        resp = do_transition_to(app_admin,
+                                process_url,
+                                'evaluate')
+        assert resp.status_code == 200
+
+    def test_evaluate_participant_cannot_creates_proposal(self,
+                                                          registry,
+                                                          app,
+                                                          process_url,
+                                                          app_participant):
+        from adhocracy_mercator.resources.mercator2 import IMercatorProposal
+        postable_types = app_participant.get_postable_types(process_url)
+        assert IMercatorProposal not in postable_types
+
+    def test_evaluate_participant_cannot_comment(self,
+                                                 registry,
+                                                 app,
+                                                 process_url,
+                                                 app_participant,
+                                                 proposal0_url):
+        from adhocracy_core.resources.comment import ICommentVersion
+        url = proposal0_url + '/comments'
+        postable_types = app_participant.get_postable_types(url)
+        assert ICommentVersion not in postable_types
+
+    def test_evaluate_participant_cannot_edit_topic(self,
+                                                    registry,
+                                                    app,
+                                                    process_url,
+                                                    app_participant,
+                                                    proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import ITopic
+        resp = app_participant.options(proposal0_url)
+        data = resp.json_body['PUT']['request_body']['data']
+        assert ITopic.__identifier__ not in data
+
+    def test_evaluate_moderator_can_update_winnerinfo(self,
+                                                      registry,
+                                                      app,
+                                                      process_url,
+                                                      app_moderator,
+                                                      proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import IWinnerInfo
+        resp = app_moderator.options(proposal0_url)
+        data = resp.json_body['PUT']['request_body']['data']
+        assert IWinnerInfo.__identifier__ in data
+
+    def test_evaluate_participant_cannot_view_winnerinfo(self,
+                                                         registry,
+                                                         app,
+                                                         process_url,
+                                                         app_participant,
+                                                         proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import IWinnerInfo
+        resp = app_participant.options(proposal0_url)
+        data = resp.json_body['GET']['response_body']['data']
+        assert IWinnerInfo.__identifier__ not in data
+
+
+    def test_evaluate_moderator_can_assign_badge(self,
+                                                 registry,
+                                                 app,
+                                                 process_url,
+                                                 app_moderator,
+                                                 proposal0_url):
+        from adhocracy_core.resources.badge import IBadgeAssignment
+        url = proposal0_url + '/badge_assignments'
+        postable_types = app_moderator.get_postable_types(url)
+        assert IBadgeAssignment in postable_types
+
+    def test_set_result_state(self, registry, app, process_url, app_admin):
+        resp = do_transition_to(app_admin,
+                                process_url,
+                                'result')
+        assert resp.status_code == 200
+
+    def test_result_participant_can_view_winnerinfo(self,
+                                                    registry,
+                                                    app,
+                                                    process_url,
+                                                    app_participant,
+                                                    proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import IWinnerInfo
+        resp = app_participant.options(proposal0_url)
+        data = resp.json_body['GET']['response_body']['data']
+        assert IWinnerInfo.__identifier__ in data
+
+    def test_result_participant_cannot_creates_proposal(self,
+                                                        registry,
+                                                        app,
+                                                        process_url,
+                                                        app_participant):
+        from adhocracy_mercator.resources.mercator2 import IMercatorProposal
+        postable_types = app_participant.get_postable_types(process_url)
+        assert IMercatorProposal not in postable_types
+
+    def test_result_participant_cannot_comment(self,
+                                               registry,
+                                               app,
+                                               process_url,
+                                               app_participant,
+                                               proposal0_url):
+        from adhocracy_core.resources.comment import ICommentVersion
+        url = proposal0_url + '/comments'
+        postable_types = app_participant.get_postable_types(url)
+        assert ICommentVersion not in postable_types
+
+    def test_result_participant_cannot_edit_topic(self,
+                                                  registry,
+                                                  app,
+                                                  process_url,
+                                                  app_participant,
+                                                  proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import ITopic
+        resp = app_participant.options(proposal0_url)
+        data = resp.json_body['PUT']['request_body']['data']
+        assert ITopic.__identifier__ not in data
+
+    def test_result_participant_can_create_logbook(self,
+                                                   registry,
+                                                   app,
+                                                   process_url,
+                                                   app_participant,
+                                                   proposal0_url):
+        from adhocracy_core.resources.document import IDocument
+        postable_types = app_participant.get_postable_types(proposal0_url + '/logbook')
+        assert IDocument in postable_types
+
+    def test_set_closed_state(self, registry, app, process_url, app_admin):
+        resp = do_transition_to(app_admin,
+                                process_url,
+                                'closed')
+        assert resp.status_code == 200
+
+    def test_closed_participant_cannot_edit_topic(self,
+                                                  registry,
+                                                  app,
+                                                  process_url,
+                                                  app_participant,
+                                                  proposal0_url):
+        from adhocracy_mercator.sheets.mercator2 import ITopic
+        resp = app_participant.options(proposal0_url)
+        data = resp.json_body['PUT']['request_body']['data']
+        assert ITopic.__identifier__ not in data

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2.py
@@ -123,6 +123,19 @@ class TestMercator2:
         data = resp.json_body['PUT']['request_body']['data']
         assert IWinnerInfo not in data
 
+
+    def test_participate_participant_can_assign_badge(self,
+                                                 registry,
+                                                 app,
+                                                 process_url,
+                                                 app_participant,
+                                                 proposal0_url):
+        from adhocracy_core.resources.badge import IBadgeAssignment
+        url = proposal0_url + '/badge_assignments'
+        postable_types = app_participant.get_postable_types(url)
+        assert IBadgeAssignment in postable_types
+
+
     def test_set_evaluate_state(self, registry, app, process_url, app_admin):
         resp = do_transition_to(app_admin,
                                 process_url,

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2/resources.json
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2/resources.json
@@ -1,0 +1,13 @@
+[ {"path": "/",
+   "content_type": "adhocracy_core.resources.organisation.IOrganisation",
+   "data": {"adhocracy_core.sheets.name.IName":
+            {"name": "organisation"}
+           }},
+  {"path": "/organisation",
+   "content_type": "adhocracy_mercator.resources.mercator2.IProcess",
+   "data": {"adhocracy_core.sheets.name.IName":
+            {"name": "advocate-europe2"},
+            "adhocracy_core.sheets.title.ITitle":
+            {"title": "Sample mercator2 process"}
+           }}
+]


### PR DESCRIPTION
Modelling for mercator 2 so far. I assumed that "road to impact" and "selection criteria" are each commented in block. This may still change as the requirements for that were not clear.

A JSON resource file is available in `src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2/resources.json`.