### PR TITLE
Revert "Parse URLs instead of doing string slicing that breaks in the presence of small variations in the URL"

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -1,7 +1,6 @@
 """Authentication with support for token http headers."""
 import hashlib
 from datetime import datetime
-import urllib
 
 from colander import Invalid
 from persistent.dict import PersistentDict
@@ -126,7 +125,12 @@ def _get_raw_x_user_headers(request: Request) -> tuple:
     # well with the pyramid authentication system. We don't have the
     # a context or root object to resolve the resource path when processing
     # the unauthenticated_userid and effective_principals methods.
-    user_path = urllib.parse.urlparse(user_url).path.rstrip('/') or None
+    app_url_length = len(request.application_url)
+    user_path = None
+    if user_url.startswith('/'):
+        user_path = user_url
+    elif len(user_url) >= app_url_length:
+        user_path = user_url[app_url_length:][:-1]
     token = request.headers.get('X-User-Token', None)
     return user_path, token
 

--- a/src/adhocracy_core/adhocracy_core/schema/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/schema/__init__.py
@@ -6,7 +6,6 @@ import decimal
 import io
 import os
 import re
-import urllib
 
 from pyramid.path import DottedNameResolver
 from pyramid.traversal import find_resource
@@ -476,7 +475,7 @@ class ResourceObject(colander.SchemaType):
             if application_url_len > len(str(value)):
                 raise KeyError
             # Fixme: This does not work with :term:`virtual hosting`
-            path = urllib.parse.urlparse(value).path
+            path = value[application_url_len:]
             return find_resource(request.root, path)
 
 


### PR DESCRIPTION
Reverts liqd/adhocracy3#1798

Unfortunately this breaks installations which make use of `SCRIPT_NAME`, which all our productive installation do (`SCRIPT_NAME = /api`).

@joka proposes to revert instead of fixing as this requires some further thoughts (e.g. the websocket server also uses the code in `schema`); also it might not be necessary for Thentos anymore.