### PR TITLE
Fix acceptance test "cannot login with short password"

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
@@ -45,14 +45,6 @@ describe("user login", function() {
         expect(UserPages.isLoggedIn()).toBe(false);
     });
 
-    it("cannot login with short password", function() {
-        var page = new UserPages.LoginPage().get();
-        page.loginInput.sendKeys("abc");
-        page.passwordInput.sendKeys("abc");
-        page.submitButton.click();
-        expect(element(by.css(".form-error")).getText()).toContain("Short");
-    });
-
     it("login is persistent", function() {
         UserPages.login(UserPages.participantName, UserPages.participantPassword);
         expect(UserPages.isLoggedIn()).toBe(true);

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserLoginSpec.js
@@ -45,6 +45,13 @@ describe("user login", function() {
         expect(UserPages.isLoggedIn()).toBe(false);
     });
 
+    it("cannot login with short password", function() {
+        var page = new UserPages.LoginPage().get();
+        page.loginInput.sendKeys("abc");
+        page.passwordInput.sendKeys("abc");
+        expect(page.submitButton.getAttribute("disabled")).toBe("true");
+    });
+
     it("login is persistent", function() {
         UserPages.login(UserPages.participantName, UserPages.participantPassword);
         expect(UserPages.isLoggedIn()).toBe(true);


### PR DESCRIPTION
After #1794, the password field is validated in the frontend. This
removes the broken acceptance test.