### PR TITLE
Restrict images types to JPEG

### DIFF
--- a/src/adhocracy_core/adhocracy_core/sheets/image.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/image.py
@@ -19,7 +19,7 @@ class IImageMetadata(IAssetMetadata):
     """Marker interface for images."""
 
 
-image_mime_type_validator = OneOf(('image/gif', 'image/jpeg', 'image/png'))
+image_mime_type_validator = OneOf(('image/jpeg'))
 
 
 class ImageMetadataSchema(AssetMetadataSchema):

--- a/src/adhocracy_core/adhocracy_core/sheets/test_image.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_image.py
@@ -27,7 +27,7 @@ class TestImageMetadataSheet:
     def test_validate_mime_type(self, meta, context):
         inst = meta.sheet_class(meta, context)
         validator = inst.schema['mime_type'].validator
-        assert validator.choices == ('image/gif', 'image/jpeg', 'image/png')
+        assert validator.choices == ('image/jpeg')
 
     @mark.usefixtures('integration')
     def test_includeme_register(self, meta):


### PR DESCRIPTION
This is done for performance reason and to reduce the size of the DB.