### PR TITLE
revert revert empty first versions for batch request,  Fix #1735

### DIFF
--- a/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
@@ -81,7 +81,7 @@ def add_changelog_followed(event):
         return
     _add_changelog(event.registry, event.object, key='followed_by',
                    value=event.new_version)
-    item = find_interface(event.object, IItem)
+    item = find_interface(event.new_version, IItem)
     _add_changelog(event.registry, item, key='last_version',
                    value=event.new_version)
 

--- a/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
@@ -36,6 +36,15 @@ def test_add_changelog_created_with_parent(event, pool, changelog):
     assert changelog['parent'].modified is True
 
 
+def test_add_changelog_followed_with_item_parent(event, item, changelog):
+    from .subscriber import add_changelog_followed
+    new_version = testing.DummyResource()
+    item['version_0'] = new_version
+    event.new_version = new_version
+    add_changelog_followed(event)
+    assert changelog['/'].last_version == new_version
+
+
 def test_add_changelog_followed_with_has_no_follows(event, changelog):
     from .subscriber import add_changelog_followed
     event.new_version = None
@@ -48,6 +57,7 @@ def test_add_changelog_followed_with_has_follows(event, changelog):
     event.new_version = testing.DummyResource()
     add_changelog_followed(event)
     assert changelog['/'].followed_by is event.new_version
+
 
 
 class TestAddChangelogModified:

--- a/src/adhocracy_core/adhocracy_core/content/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/content/__init__.py
@@ -13,11 +13,9 @@ from zope.interface.interfaces import IInterface
 
 from adhocracy_core.exceptions import RuntimeConfigurationError
 from adhocracy_core.interfaces import ISheet
-from adhocracy_core.interfaces import IItemVersion
-from adhocracy_core.interfaces import IItem
+from adhocracy_core.interfaces import IPool
 from adhocracy_core.interfaces import ResourceMetadata
 from adhocracy_core.utils import get_iresource
-from adhocracy_core.utils import has_annotation_sheet_data
 
 
 resolver = DottedNameResolver()
@@ -59,41 +57,16 @@ class ResourceContentRegistry(ContentRegistry):
         addables = self.resources_meta_addable[iresource]
         addables_allowed = []
         for resource_meta in addables:
-            if self._can_add_resource(request, resource_meta, context):
+            if self.can_add_resource(request, resource_meta, context):
                 addables_allowed.append(resource_meta)
         return addables_allowed
 
-    def _can_add_resource(self, request, resource_meta, context):
-        allowed = False
-        if self._only_empty_version_zero_exists(context, resource_meta):
-            allowed = self._can_add_version_one(request, context)
-        else:
-            permission = resource_meta.permission_create
-            allowed = request.has_permission(permission, context)
+    def can_add_resource(self, request: Request, meta: ResourceMetadata,
+                         context: IPool) -> bool:
+        """Check that the resource type in `meta` is addable to `context`."""
+        permission = meta.permission_create
+        allowed = request.has_permission(permission, context)
         return allowed
-
-    def _can_add_version_one(self, request, context):
-        iresource = get_iresource(context)
-        # since there is only an empty version zero, the permission of
-        # the item is checked instead of the one from the itemversion
-        permission = self.resources_meta[iresource].permission_create
-        allow = request.has_permission(permission, context)
-        return allow
-
-    def _only_empty_version_zero_exists(self, context: object, meta:
-                                        ResourceMetadata) -> bool:
-        only_first_version = False
-        is_empty_first_version = False
-        is_item_version = meta.iresource.isOrExtends(IItemVersion)
-        has_item_parent = IItem.providedBy(context)
-        if has_item_parent and is_item_version:
-            children = context.values()
-            versions = [x for x in children if IItemVersion.providedBy(x)]
-            if len(versions) == 1:
-                only_first_version = True
-                is_empty_first_version = not has_annotation_sheet_data(
-                    versions[0])
-        return only_first_version and is_empty_first_version
 
     @reify
     def resources_meta_addable(self):

--- a/src/adhocracy_core/adhocracy_core/content/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/content/test_init.py
@@ -198,67 +198,6 @@ class TestResourceContentRegistry:
         config.testing_securitypolicy(userid='hank', permissive=False)
         assert inst.get_resources_meta_addable(context, request_) == []
 
-    def test_get_resources_meta_addable_only_first_version_exists_has_permission(
-            self, inst, item, config, request_, resource_meta, mock_authpolicy):
-        from adhocracy_core.interfaces import IItem
-        from adhocracy_core.interfaces import IItemVersion
-        version0 = testing.DummyResource(__provides__=IItemVersion)
-        item['VERSION_0000000'] = version0
-        item_meta = resource_meta._replace(iresource=IItem,
-                                           permission_create='create_xyz')
-        version_meta = resource_meta._replace(iresource=IItemVersion,
-                                               permission_create='edit_xyz')
-        inst.resources_meta = {IItem: item_meta}
-        inst.resources_meta_addable = {IItem: [version_meta]}
-        effective_principals = ['authenticated']
-        mock_authpolicy.effective_principals.return_value = effective_principals
-        mock_authpolicy.permits.return_value = True
-        assert inst.get_resources_meta_addable(item, request_) == [version_meta]
-        mock_authpolicy.permits.assert_called_once_with(item,
-                                                        effective_principals,
-                                                        'create_xyz')
-
-    def test_get_resources_meta_addable_only_first_version_exists_has_permission_but_is_not_empty(
-            self, inst, item, config, request_, resource_meta, mock_authpolicy):
-        from adhocracy_core.interfaces import IItem
-        from adhocracy_core.interfaces import IItemVersion
-        version0 = testing.DummyResource(__provides__=IItemVersion)
-        version0._sheet_dummy = {}
-        item['VERSION_0000000'] = version0
-        item_meta = resource_meta._replace(iresource=IItem,
-                                           permission_create='create_xyz')
-        version_meta = resource_meta._replace(iresource=IItemVersion,
-                                               permission_create='edit_xyz')
-        inst.resources_meta = {IItem: item_meta}
-        inst.resources_meta_addable = {IItem: [version_meta]}
-        effective_principals = ['authenticated']
-        mock_authpolicy.effective_principals.return_value = effective_principals
-        mock_authpolicy.permits.return_value = True
-        assert inst.get_resources_meta_addable(item, request_) == [version_meta]
-        mock_authpolicy.permits.assert_called_once_with(item,
-                                                        effective_principals,
-                                                        'edit_xyz')
-
-    def test_get_resources_meta_addable_only_first_version_exists_no_permission(
-            self, inst, item, config, request_, resource_meta, mock_authpolicy):
-        from adhocracy_core.interfaces import IItem
-        from adhocracy_core.interfaces import IItemVersion
-        version0 = testing.DummyResource(__provides__=IItemVersion)
-        item['VERSION_0000000'] = version0
-        item_meta = resource_meta._replace(iresource=IItem,
-                                           permission_create='create_xyz')
-        version_meta = resource_meta._replace(iresource=IItemVersion,
-                                               permission_create='edit_xyz')
-        inst.resources_meta = {IItem: item_meta}
-        inst.resources_meta_addable = {IItem: [version_meta]}
-        effective_principals = ['authenticated']
-        mock_authpolicy.effective_principals.return_value = effective_principals
-        mock_authpolicy.permits.return_value = False
-        assert inst.get_resources_meta_addable(item, request_) == []
-        mock_authpolicy.permits.assert_called_once_with(item,
-                                                        effective_principals,
-                                                        'create_xyz')
-
     def test_permissions_resource_permission_create_defined(
             self, inst, resource_meta, mock_registry):
         simple_meta = resource_meta._replace(

--- a/src/adhocracy_core/adhocracy_core/content/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/content/test_init.py
@@ -218,6 +218,27 @@ class TestResourceContentRegistry:
                                                         effective_principals,
                                                         'create_xyz')
 
+    def test_get_resources_meta_addable_only_first_version_exists_has_permission_but_is_not_empty(
+            self, inst, item, config, request_, resource_meta, mock_authpolicy):
+        from adhocracy_core.interfaces import IItem
+        from adhocracy_core.interfaces import IItemVersion
+        version0 = testing.DummyResource(__provides__=IItemVersion)
+        version0._sheet_dummy = {}
+        item['VERSION_0000000'] = version0
+        item_meta = resource_meta._replace(iresource=IItem,
+                                           permission_create='create_xyz')
+        version_meta = resource_meta._replace(iresource=IItemVersion,
+                                               permission_create='edit_xyz')
+        inst.resources_meta = {IItem: item_meta}
+        inst.resources_meta_addable = {IItem: [version_meta]}
+        effective_principals = ['authenticated']
+        mock_authpolicy.effective_principals.return_value = effective_principals
+        mock_authpolicy.permits.return_value = True
+        assert inst.get_resources_meta_addable(item, request_) == [version_meta]
+        mock_authpolicy.permits.assert_called_once_with(item,
+                                                        effective_principals,
+                                                        'edit_xyz')
+
     def test_get_resources_meta_addable_only_first_version_exists_no_permission(
             self, inst, item, config, request_, resource_meta, mock_authpolicy):
         from adhocracy_core.interfaces import IItem

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -6,13 +6,13 @@ from BTrees.Length import Length
 from persistent.mapping import PersistentMapping
 from pyramid.registry import Registry
 from pyramid.threadlocal import get_current_registry
-from zope.interface.interfaces import IInterface
-from zope.interface import alsoProvides
-from zope.interface import noLongerProvides
-from zope.interface import directlyProvides
 from substanced.evolution import add_evolution_step
-from substanced.util import find_service
 from substanced.interfaces import IFolder
+from substanced.util import find_service
+from zope.interface import alsoProvides
+from zope.interface import directlyProvides
+from zope.interface import noLongerProvides
+from zope.interface.interfaces import IInterface
 
 from adhocracy_core.catalog import ICatalogsService
 from adhocracy_core.interfaces import IItem
@@ -21,12 +21,12 @@ from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import ISimple
 from adhocracy_core.interfaces import ResourceMetadata
 from adhocracy_core.interfaces import search_query
-from adhocracy_core.resources.asset import IPoolWithAssets
 from adhocracy_core.resources.asset import IAsset
+from adhocracy_core.resources.asset import IPoolWithAssets
+from adhocracy_core.resources.asset import add_assets_service
 from adhocracy_core.resources.badge import IBadgeAssignmentsService
 from adhocracy_core.resources.badge import add_badge_assignments_service
 from adhocracy_core.resources.badge import add_badges_service
-from adhocracy_core.resources.asset import add_assets_service
 from adhocracy_core.resources.comment import ICommentVersion
 from adhocracy_core.resources.pool import IBasicPool
 from adhocracy_core.resources.principal import IUser
@@ -48,7 +48,7 @@ from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.utils import get_sheet
 from adhocracy_core.utils import get_sheet_field
-
+from adhocracy_core.utils import has_annotation_sheet_data
 
 logger = logging.getLogger(__name__)
 
@@ -458,21 +458,12 @@ def remove_empty_first_versions(root):  # pragma: no cover
         if 'VERSION_0000000' not in item:
             continue
         first_version = item['VERSION_0000000']
-        is_empty = _is_version_without_data(first_version)
+        has_sheet_data = has_annotation_sheet_data(first_version)\
+            or hasattr(first_version, 'rate')
         has_follower = _has_follower(first_version, registry)
-        if is_empty and has_follower:
+        if not has_sheet_data and has_follower:
             logger.info('Delete empty version {0}.'.format(first_version))
             del item['VERSION_0000000']
-
-
-def _is_version_without_data(version: IItemVersion) -> bool:
-    for attribute in version.__dict__:
-        if attribute.startswith('_sheet_'):
-            return False
-        if attribute == 'rate':
-            return False
-    else:
-        return True
 
 
 def _has_follower(version: IItemVersion, registry: Registry) -> bool:

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -523,6 +523,7 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(move_sheet_annotation_data_to_attributes)
     config.add_evolution_step(migrate_rate_sheet_to_attribute_storage)
     config.add_evolution_step(move_autoname_last_counters_to_attributes)
+    config.add_evolution_step(remove_empty_first_versions)
     config.add_evolution_step(make_proposalversions_polarizable)
     config.add_evolution_step(add_icanpolarize_sheet_to_comments)
     config.add_evolution_step(add_image_reference_to_users)

--- a/src/adhocracy_core/adhocracy_core/resources/itemversion.py
+++ b/src/adhocracy_core/adhocracy_core/resources/itemversion.py
@@ -46,6 +46,9 @@ def notify_new_itemversion_created(context, registry, options):
                                                         registry,
                                                         creator,
                                                         is_batchmode)
+    if follows == []:
+        _notify_itemversion_has_new_version(None, new_version, registry,
+                                            creator)
 
 
 def _notify_itemversion_has_new_version(old_version, new_version, registry,

--- a/src/adhocracy_core/adhocracy_core/resources/test_itemversion.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_itemversion.py
@@ -61,18 +61,19 @@ class TestItemVersion:
         version_0 = self.make_one(config, context)
         assert IItemVersion.providedBy(version_0)
 
-    def test_create_new_version(self, config, context):
+    def test_create_first_and_send_version_added_event(self, config, context):
         events = create_event_listener(config, IItemVersionNewVersionAdded)
-        creator = self.make_one(config, context)
-
         version_0 = self.make_one(config, context)
-        version_1 = self.make_one(config, context,
-                                   follows=[version_0], creator=creator)
+        assert events[0].object == None
+        assert events[0].new_version == version_0
 
-        assert len(events) == 1
+    def test_create_followoing_and_send_version_added_event(self, config,
+                                                            context):
+        version_0 = self.make_one(config, context)
+        events = create_event_listener(config, IItemVersionNewVersionAdded)
+        version_1 = self.make_one(config, context, follows=[version_0])
         assert events[0].object == version_0
         assert events[0].new_version == version_1
-        assert events[0].creator == creator
 
     def test_create_new_version_with_referencing_resources(self, config,
                                                            context):

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -819,6 +819,7 @@ class TestItemRESTView:
 
     def test_post_valid_itemversion_batchmode_last_version_in_transaction_exists(
             self, request_, context, mock_sheet):
+        from copy import deepcopy
         from adhocracy_core.interfaces import IItemVersion
         context['last_new_version'] = testing.DummyResource(__provides__=
                                                             IItemVersion)
@@ -828,6 +829,9 @@ class TestItemRESTView:
                              'root_versions': [],
                              '_last_new_version_in_transaction':\
                                  context['last_new_version']}
+        versions_sheet = deepcopy(mock_sheet)
+        versions_sheet.get.return_value = {'follows': []}
+        request_.registry.content.get_sheet.return_value = versions_sheet
         request_.registry.content.get_sheets_create.return_value = [mock_sheet]
         inst = self.make_one(context, request_)
         response = inst.post()

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -896,6 +896,13 @@ def app_god(app):
     return AppUser(app, header=god_header)
 
 
+@fixture(scope='class')
+def mailer(app) -> TestApp:
+    """Return :class:`pyramid_mailer.mailer.DummyMailer` of `app` fixture."""
+    mailer = app.registry.messenger.mailer
+    return mailer
+
+
 @fixture
 def datadir(tmpdir, request):
     """Fixture to access tests data.

--- a/src/adhocracy_core/adhocracy_core/utils/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/utils/__init__.py
@@ -503,3 +503,12 @@ def load_json(filename):
     """Load a json file from the disk."""
     with open(filename, 'r') as f:
         return json.load(f)
+
+
+def has_annotation_sheet_data(resource: IResource) -> bool:
+    """Check if `resource` has no data stored in AnnotationResourceSheets."""
+    for attribute in resource.__dict__:
+        if attribute.startswith('_sheet_'):
+            return True
+    else:
+        return False

--- a/src/adhocracy_core/adhocracy_core/utils/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/utils/test_init.py
@@ -563,3 +563,14 @@ class TestLoadJson:
     def teardown_method(self, method):
         if hasattr(self, 'tempfd'):
             os.close(self._tempfd)
+
+
+def test_has_annotation_sheet_data_resource_without_data(context):
+    from . import has_annotation_sheet_data
+    assert has_annotation_sheet_data(context) is False
+
+
+def test_has_annotation_sheet_data_resource_with_data(context):
+    from . import has_annotation_sheet_data
+    context._sheet_xcv = {}
+    assert has_annotation_sheet_data(context) is True

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -1220,32 +1220,35 @@ omitted::
      'code': 200}
     >>> pprint(batch_resp['responses'][1])
     {'body': {'content_type': 'adhocracy_core.resources.paragraph.IParagraphVersion',
-              'path': '.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000001/'},
+              'path': '.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/'},
      'code': 200}
     >>> pprint(batch_resp['responses'][2])
     {'body': {'content_type': 'adhocracy_core.resources.paragraph.IParagraphVersion',
               'data': {...},
-              'path': '.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000001/'},
+              'path': '.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/'},
      'code': 200}
      >>> batch_resp['responses'][2]['body']['data']['adhocracy_core.sheets.document.IParagraph']['text']
      'sein blick ist vom vorüberziehn der stäbchen'
 
 
-Now the first, empty paragraph version should contain the newly
-created paragraph version as its only successor ::
+New Versions are only created once within one batch request. That means the second
+subrequest does not create a second version, but updates the existing first version:
 
-    .. >>> v1 = batch_resp[2]['body']['data']['adhocracy_core.sheets.versions.IVersionable']['followed_by']
-    .. >>> v2 = [batch_resp[1]['path']]
-    .. >>> v1 == v2
-    .. True
-    .. >>> print(v1, v2)
-    .. ...
+    >>> v0 = batch_resp['responses'][0]['body']['first_version_path']
+    >>> v0_again = batch_resp['responses'][1]['body']['path']
+    >>> v0 == v0_again
+    True
 
-The LAST tag should point to the version we created within the batch request::
+The follow reference points to None:
+
+    >>> batch_resp['responses'][2]['body']['data']['adhocracy_core.sheets.versions.IVersionable']['follows']
+    []
+
+The LAST tag should point to the last version we created within the batch request::
 
     >>> resp_data = testapp.get(rest_url + "/Documents/document_0000000/PARAGRAPH_0000002/LAST").json
     >>> resp_data['data']['adhocracy_core.sheets.tags.ITag']['elements']
-    ['.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000001/']
+    ['.../Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/']
 
 All creation and modification dates are equal for one batch request:
 
@@ -1539,7 +1542,7 @@ versions of all documents::
     >>> pprint(resp_data['data']['adhocracy_core.sheets.pool.IPool']['elements'])
     ['http://localhost/Documents/document_0000000/PARAGRAPH_0000000/VERSION_0000001/',
      'http://localhost/Documents/document_0000000/PARAGRAPH_0000001/VERSION_0000001/',
-     'http://localhost/Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000001/']
+     'http://localhost/Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/']
 
 Valid query comparables: 'eq', 'noteq', 'any', 'notany'
 
@@ -1591,7 +1594,20 @@ custom filters:
 *<package.sheets.sheet.ISheet:FieldName>* filters: you can add arbitrary custom
 filters that refer to sheet fields with references. The key is the name of
 the isheet plus the field name separated by ':' The value is the wanted
-reference target. ::
+reference target.
+
+First we create more paragraphs versions::
+
+    >>> pvrs0_path = 'http://localhost/Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/'
+    >>> pvrs = {'content_type': 'adhocracy_core.resources.paragraph.IParagraphVersion',
+    ...         'data': {'adhocracy_core.sheets.versions.IVersionable': {
+    ...                  'follows': [pvrs0_path]}},
+    ...          'root_versions': [pvrs0_path]}
+    >>> resp = testapp.post_json('http://localhost/Documents/document_0000000/PARAGRAPH_0000002',
+    ...                           pvrs, headers=god_header)
+    >>> pvrs1_path = resp.json["path"]
+
+Now we can search references::
 
     >>> resp_data = testapp.get('/Documents/document_0000000',
     ...     params={'content_type': 'adhocracy_core.resources.paragraph.IParagraphVersion',
@@ -1608,7 +1624,7 @@ not a reference field, the backend responds with an error::
 
     >>> resp_data = testapp.get('/Documents/document_0000000',
     ...     params={'adhocracy_core.sheets.NoSuchSheet:nowhere':
-    ...             'http://localhost/Documents/document_0000000/kapitel2/VERSION_0000000/'},
+    ...             'http://localhost/Documents/document_0000000/PARAGRAPH_0000002/VERSION_0000000/'},
     ...     status=400).json
     >>> resp_data['errors'][0]['description']
     'No such sheet or field'

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/__init__.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/__init__.py
@@ -11,6 +11,7 @@ def includeme(config):
     # commit to allow overriding pyramid config
     config.commit()
     # include custom resource types
+    config.include('adhocracy_meinberlin.content')
     config.include('adhocracy_meinberlin.workflows')
     config.include('adhocracy_meinberlin.resources')
     config.include('adhocracy_meinberlin.sheets')

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/conftest.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/conftest.py
@@ -23,4 +23,5 @@ def integration(integration):
     integration.include('adhocracy_meinberlin.sheets')
     integration.include('adhocracy_meinberlin.resources')
     integration.include('adhocracy_meinberlin.workflows')
+    integration.include('adhocracy_meinberlin.content')
     return integration

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/content/__init__.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/content/__init__.py
@@ -19,7 +19,7 @@ class MeinBerlinResourceContentRegistry(ResourceContentRegistry):
         the item create permission instead of the version create permission if
         the first version is empty (without sheet data).
         """
-        if self._is_bplan_and_first_version_empty(meta, context):
+        if self._is_bplan_and_has_no_version_with_sheet_data(meta, context):
             from adhocracy_core.utils import get_iresource
             iresource = get_iresource(context)
             permission = self.resources_meta[iresource].permission_create
@@ -28,8 +28,9 @@ class MeinBerlinResourceContentRegistry(ResourceContentRegistry):
         allowed = request.has_permission(permission, context)
         return allowed
 
-    def _is_bplan_and_first_version_empty(self, meta: ResourceMetadata,
-                                          context: IPool) -> bool:
+    def _is_bplan_and_has_no_version_with_sheet_data(self,
+                                                     meta: ResourceMetadata,
+                                                     context: IPool) -> bool:
         is_bplan_version = meta.iresource.isOrExtends(IProposalVersion)
         if not is_bplan_version:
             return False

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/content/__init__.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/content/__init__.py
@@ -1,0 +1,47 @@
+"""Create resources, get sheets/metadata, permission checks."""
+from pyramid.request import Request
+from adhocracy_core.content import ResourceContentRegistry
+from adhocracy_core.interfaces import ResourceMetadata
+from adhocracy_core.interfaces import IPool
+from adhocracy_core.utils import has_annotation_sheet_data
+from adhocracy_meinberlin.resources.bplan import IProposalVersion
+
+
+class MeinBerlinResourceContentRegistry(ResourceContentRegistry):
+    """Extend content registry to allow anonymous to post bplan versions."""
+
+    def can_add_resource(self, request: Request, meta: ResourceMetadata,
+                         context: IPool) -> bool:
+        """Check that the resource type in `meta` is addable to `context`.
+
+        For the `bplan` process we want anonymous to create proposal items
+        and the first non empty version. To make this work we check
+        the item create permission instead of the version create permission if
+        the first version is empty (without sheet data).
+        """
+        if self._is_bplan_and_first_version_empty(meta, context):
+            from adhocracy_core.utils import get_iresource
+            iresource = get_iresource(context)
+            permission = self.resources_meta[iresource].permission_create
+        else:
+            permission = meta.permission_create
+        allowed = request.has_permission(permission, context)
+        return allowed
+
+    def _is_bplan_and_first_version_empty(self, meta: ResourceMetadata,
+                                          context: IPool) -> bool:
+        is_bplan_version = meta.iresource.isOrExtends(IProposalVersion)
+        if not is_bplan_version:
+            return False
+        versions_with_data = [x for x in context.values()
+                              if IProposalVersion.providedBy(x)
+                              and has_annotation_sheet_data(x)]
+        return versions_with_data == []
+
+
+def includeme(config):  # pragma: no cover
+    """Override content registry."""
+    old_content = config.registry.content
+    new_content = MeinBerlinResourceContentRegistry(config.registry)
+    new_content.__dict__.update(old_content.__dict__)
+    config.registry.content = new_content

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/content/test_init.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/content/test_init.py
@@ -1,0 +1,99 @@
+from pytest import fixture
+from pyramid import testing
+
+
+class TestMeinBerlinResourceContentRegistry:
+
+    def test_create(self):
+        from adhocracy_core.content import ResourceContentRegistry
+        from . import MeinBerlinResourceContentRegistry
+        inst = MeinBerlinResourceContentRegistry(object())
+        assert isinstance(inst, ResourceContentRegistry)
+
+    def test_includeme_overrides_content_registry(self, config, registry):
+        from . import includeme
+        from . import MeinBerlinResourceContentRegistry
+        old_content = testing.DummyResource(dummy_attribute='a')
+        registry.content = old_content
+        includeme(config)
+        new_content = registry.content
+        assert isinstance(new_content, MeinBerlinResourceContentRegistry)
+        assert new_content.dummy_attribute == old_content.dummy_attribute
+
+
+class TestMeinBerlinResourceContentRegistryCanAddResource:
+
+    @fixture
+    def resource_meta(self, resource_meta):
+        return resource_meta._replace(permission_create='create')
+
+    @fixture
+    def version_meta(self, resource_meta):
+        from adhocracy_meinberlin.resources.bplan import IProposalVersion
+        return resource_meta._replace(iresource=IProposalVersion,
+                                      permission_create='create_version')
+
+    @fixture
+    def item_meta(self, resource_meta):
+        from adhocracy_meinberlin.resources.bplan import IProposal
+        return resource_meta._replace(iresource=IProposal,
+                                      permission_create='create_item')
+
+    @fixture
+    def inst(self, registry, resource_meta, item_meta, version_meta):
+        from . import MeinBerlinResourceContentRegistry
+        inst = MeinBerlinResourceContentRegistry(registry)
+        item_meta = resource_meta._replace(iresource=item_meta.iresource,
+                                           permission_create='create_item')
+        version_meta = resource_meta._replace(iresource=version_meta.iresource,
+                                              permission_create='create_version')
+        inst.resources_meta = {item_meta.iresource: item_meta}
+        inst.resources_meta_addable = {version_meta.iresource: [version_meta]}
+        return inst
+
+    @fixture
+    def item(self):
+        from adhocracy_meinberlin.resources.bplan import IProposal
+        return testing.DummyResource(__provides__=IProposal)
+
+    @fixture
+    def version(self):
+        from adhocracy_meinberlin.resources.bplan import IProposalVersion
+        return testing.DummyResource(__provides__=IProposalVersion)
+
+    def test_true_if_create_permission(self, inst, context, request_,
+                                       resource_meta, mock):
+        request_.has_permission = mock.MagicMock(return_value=True)
+        assert inst.can_add_resource(request_, resource_meta, context)
+        request_.has_permission.assert_called_with('create', context)
+
+    def test_false_if_no_create_permission(self, inst, context, request_,
+                                           resource_meta, mock):
+        request_.has_permission = mock.MagicMock(return_value=False)
+        assert not inst.can_add_resource(request_, resource_meta, context)
+        request_.has_permission.assert_called_with('create', context)
+
+    def test_true_if_create_permission_item_and_only_empty_version(
+            self, inst, item, version, request_, mock, item_meta, version_meta):
+        request_.has_permission = mock.MagicMock(return_value=True)
+        item['VERSION_0'] = version
+        assert inst.can_add_resource(request_, version_meta, item)
+        request_.has_permission.assert_called_with('create_item', item)
+
+    def test_false_if_create_permission_item_and_only_non_empty_version(
+            self, inst, item, version, request_, mock, version_meta, resource_meta):
+        request_.has_permission = mock.MagicMock(return_value=False)
+        item['VERSION_0'] = version
+        item['VERSION_0']._sheet_dummy = {}
+        assert not inst.can_add_resource(request_, version_meta, item)
+        request_.has_permission.assert_called_with('create_version', item)
+
+    def test_false_if_create_permission_item_and_empty_version(
+            self, inst, item, version, request_, mock, version_meta, resource_meta):
+        request_.has_permission = mock.MagicMock(return_value=False)
+        item['VERSION_0'] = version
+        item['VERSION_1'] = version.clone(__provides__=version.__provides__,
+                                          _sheet_dummy={})
+        assert not inst.can_add_resource(request_, version_meta, item)
+        request_.has_permission.assert_called_with('create_version', item)
+

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/subscriber.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/subscriber.py
@@ -7,6 +7,7 @@ from adhocracy_core.interfaces import IResourceCreatedAndAdded
 from adhocracy_core.authorization import set_acms_for_app_root
 from adhocracy_core.resources.root import root_acm
 from adhocracy_core.utils import get_sheet
+from adhocracy_core.utils import has_annotation_sheet_data
 from adhocracy_meinberlin.resources.root import meinberlin_acm
 from adhocracy_meinberlin.resources.bplan import IProposalVersion
 from adhocracy_meinberlin.resources.bplan import IProposal
@@ -14,7 +15,8 @@ from adhocracy_meinberlin import sheets
 from adhocracy_meinberlin import resources
 
 
-def _send_bplan_submission_confirmation_email_subscriber(event):
+def send_bplan_submission_confirmation_email(event):
+    """Notify office worker and creator about created bplan version."""
     if not hasattr(event.registry, 'messenger'):  # ease testing
         return
     messenger = event.registry.messenger
@@ -65,8 +67,10 @@ def _get_appstruct(proposal_version):
 
 def _is_proposal_creation_finished(proposal_version):
     proposal_item = find_interface(proposal_version, IProposal)
-    return len([version for version in proposal_item.values() if
-                IProposalVersion.providedBy(version)]) == 2
+    versions_with_data = [x for x in proposal_item.values()
+                          if IProposalVersion.providedBy(x)
+                          and has_annotation_sheet_data(x)]
+    return len(versions_with_data) == 1
 
 
 def set_root_acms(event):
@@ -77,6 +81,6 @@ def set_root_acms(event):
 def includeme(config):
     """Register subscribers."""
     config.add_subscriber(set_root_acms, ApplicationCreated)
-    config.add_subscriber(_send_bplan_submission_confirmation_email_subscriber,
+    config.add_subscriber(send_bplan_submission_confirmation_email,
                           IResourceCreatedAndAdded,
                           object_iface=IProposalVersion)

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_bplan.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_bplan.py
@@ -123,6 +123,16 @@ class TestBPlanWorkflow:
         resp = _post_proposal_itemversion(app_anonymous, path='/bplan/proposal_0000000')
         assert resp.status_code == 200
 
+    def test_participate_anonymous_gets_notification(self, mailer):
+        msg = mailer.outbox[-2]
+        assert msg.subject.startswith('Ihre Stellungnahme')
+        assert msg.recipients == ['test@test.de']
+
+    def test_participate_office_worker_gets_notificationl(self, mailer):
+        msg = mailer.outbox[-1]
+        assert msg.subject.startswith('Ihre Stellungnahme')
+        assert msg.recipients == ['sysadmin@test.de']
+
     def test_participate_anonymous_cannot_edit_proposal_version1(self, app_anonymous):
         from adhocracy_meinberlin.resources.bplan import IProposalVersion
         assert IProposalVersion not in app_anonymous.get_postable_types(

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_bplan.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_bplan.py
@@ -119,8 +119,10 @@ class TestBPlanWorkflow:
         resp = _post_proposal_item(app_anonymous, path='/bplan')
         assert resp.status_code == 200
 
-    def test_participate_anonymous_edits_proposal_version0(self, app_anonymous):
-        resp = _post_proposal_itemversion(app_anonymous, path='/bplan/proposal_0000000')
+    def test_participate_anonymous_edits_proposal_version0(self,
+                                                           app_anonymous):
+        resp = _post_proposal_itemversion(app_anonymous,
+                                          path='/bplan/proposal_0000000')
         assert resp.status_code == 200
 
     def test_participate_anonymous_gets_notification(self, mailer):
@@ -128,12 +130,13 @@ class TestBPlanWorkflow:
         assert msg.subject.startswith('Ihre Stellungnahme')
         assert msg.recipients == ['test@test.de']
 
-    def test_participate_office_worker_gets_notificationl(self, mailer):
+    def test_participate_office_worker_gets_notification(self, mailer):
         msg = mailer.outbox[-1]
         assert msg.subject.startswith('Ihre Stellungnahme')
         assert msg.recipients == ['sysadmin@test.de']
 
-    def test_participate_anonymous_cannot_edit_proposal_version1(self, app_anonymous):
+    def test_participate_anonymous_cannot_edit_proposal_version1(self,
+                                                                 app_anonymous):
         from adhocracy_meinberlin.resources.bplan import IProposalVersion
         assert IProposalVersion not in app_anonymous.get_postable_types(
             '/bplan/proposal_0000000')

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_bplan.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_bplan.py
@@ -68,8 +68,15 @@ def _post_proposal_item(app_user, path='') -> TestResponse:
 
 
 def _post_proposal_itemversion(app_user, path='') -> TestResponse:
+    from adhocracy_meinberlin.sheets.bplan import IProposal
     from adhocracy_meinberlin.resources.bplan import IProposalVersion
-    resp = app_user.post_resource(path, IProposalVersion, {})
+    appstructs = {IProposal.__identifier__: {'name': 'test',
+                                             'street_number': '1',
+                                             'postal_code_city': '1',
+                                             'email': 'test@test.de',
+                                             'statement': 'buh',
+                                             }}
+    resp = app_user.post_resource(path, IProposalVersion, appstructs)
     return resp
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/test_init.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/test_init.py
@@ -197,7 +197,7 @@ class TestMercatorWorkflow:
                       )
         resp = app_participant.get('/', params=params).json
         assert resp['data'][IPool.__identifier__]['elements'] == \
-             ['http://localhost/mercator/proposal_0000001/VERSION_0000002/']
+            ['http://localhost/mercator/proposal_0000001/VERSION_0000001/']
 
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/test_init.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/test_init.py
@@ -134,8 +134,8 @@ class TestMercatorWorkflow:
         """
         resp = app_participant.batch(create_proposal_batch)
         resp = app_participant.batch(update_proposal_batch)
-        assert app_participant.get('/proposal_0000001/VERSION_0000002').json_body['data']['adhocracy_mercator.sheets.mercator.IUserInfo']['personal_name'] == 'pita Updated'
-        assert "VERSION_0000002" in app_participant.get('/proposal_0000001/VERSION_0000002').json_body['data']['adhocracy_mercator.sheets.mercator.IMercatorSubResources']['organization_info']
+        assert app_participant.get('/proposal_0000001/VERSION_0000001').json_body['data']['adhocracy_mercator.sheets.mercator.IUserInfo']['personal_name'] == 'pita Updated'
+        assert "VERSION_0000001" in app_participant.get('/proposal_0000001/VERSION_0000001').json_body['data']['adhocracy_mercator.sheets.mercator.IMercatorSubResources']['organization_info']
 
     def test_participate_cannot_edit_other_users_proposal(self, app_participant, app_god):
         resp = _post_proposal_item(app_god, path='/')

--- a/src/mercator/mercator/tests/fixtures/fixturesMercatorProposals1.py
+++ b/src/mercator/mercator/tests/fixtures/fixturesMercatorProposals1.py
@@ -268,7 +268,7 @@ update_proposal_batch = \
                         ".IOrganizationInfoVersion",
         "data": {"adhocracy_core.sheets.versions.IVersionable": {"follows": [
             "http://localhost/mercator/proposal_0000001/info_0000000"
-            "/VERSION_0000001/"]},
+            "/VERSION_0000000/"]},
             "adhocracy_core.sheets.metadata.IMetadata": {"deleted": false,
                                                          "preliminaryNames":
                                                              {"state": 77}},


### PR DESCRIPTION
API EXTENSION:

- Update first version instead of creating a new version within a batch request. This prevents creating an empty first version for every item we create.

- migration script to delete existing first versions hat have no sheet data.

INTERNAL CHANGES:

- fixed issues (#1729 and #1723) caused be reverted merge #1657 
- add test fixture 'mailer' to access send emails in functional test
- refactor code allowing anonymous to post one bplan item/version, more tests
