### PR TITLE
optimize file size of png and jpeg image scales

### DIFF
--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -465,7 +465,8 @@ def remove_empty_first_versions(root):  # pragma: no cover
             del item['VERSION_0000000']
 
 
-def _is_version_without_data(version: IItemVersion) -> bool:
+def _is_version_without_data(version: IItemVersion)\
+        -> bool:  # pragma: no cover
     for attribute in version.__dict__:
         if attribute.startswith('_sheet_'):
             return False
@@ -475,7 +476,8 @@ def _is_version_without_data(version: IItemVersion) -> bool:
         return True
 
 
-def _has_follower(version: IItemVersion, registry: Registry) -> bool:
+def _has_follower(version: IItemVersion,
+                  registry: Registry) -> bool:  # pragma: no cover
     followed_by = get_sheet_field(version, IVersionable, 'followed_by',
                                   registry=registry)
     return followed_by != []
@@ -506,6 +508,30 @@ def update_asset_download_children(root):  # pragma: no cover
             logger.warn('Asset {} has no downloads to migrate.'.format(asset))
 
 
+@log_migration
+def migrate_all_image_size_downloads_to_jpeg(root):  # pragma: no cover
+    """Migrate all image size downloads to jpeg images.
+
+    This happens automatically if we recreate them.
+    """
+    from adhocracy_core.sheets.asset import IAssetMetadata
+    from adhocracy_core.sheets.image import IImageMetadata
+    from adhocracy_core.resources.image import add_image_size_downloads
+    from adhocracy_core.resources.image import IImageDownload
+    registry = get_current_registry(root)
+    catalogs = find_service(root, 'catalogs')
+    assets = _search_for_interfaces(catalogs, IAssetMetadata)
+    images = [x for x in assets if IImageMetadata.providedBy(x)]
+    count = len(images)
+    for index, image in enumerate(images):
+        logger.info('Migrating resource {0} of {1}'.format(index + 1, count))
+        for old_download in image.values():
+            if IImageDownload.providedBy(old_download):
+                del image[old_download.__name__]
+        add_image_size_downloads(image, registry)
+        catalogs.reindex_index(image, 'interfaces')  # we missed reindexing
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -527,3 +553,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(add_icanpolarize_sheet_to_comments)
     config.add_evolution_step(add_image_reference_to_users)
     config.add_evolution_step(update_asset_download_children)
+    config.add_evolution_step(migrate_all_image_size_downloads_to_jpeg)

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -509,11 +509,8 @@ def update_asset_download_children(root):  # pragma: no cover
 
 
 @log_migration
-def migrate_all_image_size_downloads_to_jpeg(root):  # pragma: no cover
-    """Migrate all image size downloads to jpeg images.
-
-    This happens automatically if we recreate them.
-    """
+def recreate_all_image_size_downloads(root):  # pragma: no cover
+    """Recreate all image size downloads to optimize file size."""
     from adhocracy_core.sheets.asset import IAssetMetadata
     from adhocracy_core.sheets.image import IImageMetadata
     from adhocracy_core.resources.image import add_image_size_downloads
@@ -553,4 +550,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(add_icanpolarize_sheet_to_comments)
     config.add_evolution_step(add_image_reference_to_users)
     config.add_evolution_step(update_asset_download_children)
-    config.add_evolution_step(migrate_all_image_size_downloads_to_jpeg)
+    config.add_evolution_step(recreate_all_image_size_downloads)

--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -61,7 +61,11 @@ class ImageDownload(File, AssetDownload):
             cropped = crop(image, self.dimensions)
             resized = cropped.resize(self.dimensions, Image.ANTIALIAS)
             bytestream = io.BytesIO()
-            resized.convert('RGB').save(bytestream, 'jpeg')
+            resized.convert('RGB').save(bytestream,
+                                        'jpeg',
+                                        progressive=True,
+                                        quality=80,
+                                        optimize=True)
             bytestream.seek(0)
         self.upload(bytestream)
         self.mimetype = 'image/jpeg'

--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -80,6 +80,7 @@ class ImageDownload(File, AssetDownload):
                              image.format)
             bytestream.seek(0)
         self.upload(bytestream)
+        self.mimetype = original.mimetype
 
 
 def crop(image: Image, dimensions: Dimensions) -> Image:

--- a/src/adhocracy_core/adhocracy_core/resources/test_image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_image.py
@@ -94,7 +94,7 @@ class TestImageDownload:
         from substanced.file import File
         blob = Mock()
         blob.open.return_value = io.BytesIO(b'dummy blob')
-        original = Mock(spec=File, mimetype= 'image/png', blob=blob)
+        original = Mock(spec=File, mimetype='image/png', blob=blob)
         mock_image = Mock(size=(840, 700))
         mock_crop = Mock()
         mock_image.crop.return_value = mock_crop
@@ -103,7 +103,7 @@ class TestImageDownload:
         inst.upload = Mock()
         inst.dimensions = dimensions
         inst._upload_crop_and_resize(original)
-        assert inst.mimetype == original.mimetype
+        assert inst.mimetype == 'image/jpeg'
         assert mock_crop.resize.call_args[0] == (dimensions, Image.ANTIALIAS)
         resized = inst.upload.call_args[0][0]
         assert isinstance(resized, io.BytesIO)

--- a/src/adhocracy_core/adhocracy_core/resources/test_image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_image.py
@@ -142,6 +142,7 @@ class TestImageDownload:
         assert isinstance(file_resized, io.BytesIO)
         assert inst.upload.call_args[0][0] == file_resized
         assert mock_resized.save.call_args[0][1] == mock_original.format
+        assert inst.mimetype == mock_file.mimetype
 
     def test_upload_crop_and_resize_jpeg(self, inst, mock_crop, mock_original,
                                          mock_resized, mock_file):


### PR DESCRIPTION
Motivation:

Optimize  file size of jpeg and png image scale downloads

Internal Changes:

- jepg scales are saved with optimize and interlace flag
- jepge scales image quality  increased from 75% to 80%
- png scales are reduces to 128 colors (reduces files size ~ 60%) 
- migration script to recreate existing image scales

Tested with mercator database.

