### PR TITLE
check assign badge permission

### DIFF
--- a/src/adhocracy_core/adhocracy_core/schema/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/schema/__init__.py
@@ -21,7 +21,6 @@ from zope.interface.interfaces import IInterface
 import colander
 import pytz
 
-from adhocracy_core.interfaces import ILocation
 from adhocracy_core.utils import normalize_to_tuple
 from adhocracy_core.exceptions import RuntimeConfigurationError
 from adhocracy_core.utils import get_sheet
@@ -511,7 +510,8 @@ class ResourcePathAndContentSchema(ResourcePathSchema):
                                default={})
 
 
-def _validate_reftype(node: colander.SchemaNode, value: ILocation):
+def validate_reftype(node: colander.SchemaNode, value: IResource):
+    """Raise if `value` doesn`t provide the ISheet set by `node.reftype`."""
     reftype = node.reftype
     isheet = reftype.getTaggedValue('target_isheet')
     if not isheet.providedBy(value):
@@ -538,7 +538,7 @@ class Reference(Resource):
 
     reftype = SheetReference
     backref = False
-    validator = colander.All(_validate_reftype)
+    validator = colander.All(validate_reftype)
 
 
 class Resources(AdhocracySequenceNode):
@@ -551,7 +551,7 @@ class Resources(AdhocracySequenceNode):
 
 def _validate_reftypes(node: colander.SchemaNode, value: Sequence):
     for resource in value:
-        _validate_reftype(node, resource)
+        validate_reftype(node, resource)
 
 
 class References(Resources):

--- a/src/adhocracy_core/adhocracy_core/schema/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/schema/test_init.py
@@ -479,11 +479,11 @@ class ReferenceUnitTest(unittest.TestCase):
 
     def test_create(self):
         from adhocracy_core.interfaces import SheetReference
-        from adhocracy_core.schema import _validate_reftype
+        from adhocracy_core.schema import validate_reftype
         inst = self.make_one()
         assert inst.backref is False
         assert inst.reftype == SheetReference
-        assert inst.validator.validators == (_validate_reftype,)
+        assert inst.validator.validators == (validate_reftype,)
 
     def test_with_backref(self):
         inst = self.make_one(backref=True)

--- a/src/adhocracy_core/adhocracy_core/sheets/test_badge.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_badge.py
@@ -7,13 +7,6 @@ from pytest import mark
 from unittest.mock import Mock
 
 
-@fixture
-def integration(config):
-    config.include('adhocracy_core.content')
-    config.include('adhocracy_core.catalog')
-    config.include('adhocracy_core.sheets.badge')
-
-
 class TestBadgeableSheet:
 
     @fixture
@@ -92,8 +85,8 @@ class TestCreateUniqueBadgeAssignmentValidator:
         monkeypatch.setattr(badge, 'find_service', mock)
         return mock
 
-    def test_raise_if_assignment_already_exists(
-            self, node, context, registry, mock_sheet):
+    def test_raise_if_assignment_already_exists(self, node, context, registry,
+                                                mock_sheet):
         import colander
         from .badge import IBadge
         from .badge import IBadgeAssignment
@@ -110,10 +103,7 @@ class TestCreateUniqueBadgeAssignmentValidator:
             validator(node, {'badge': badge,
                              'object': node['object']})
 
-
-    def test_no_raise_if_updating(
-            self, node, context, registry, mock_sheet):
-        import colander
+    def test_no_raise_if_updating(self, node, context, registry, mock_sheet):
         from .badge import IBadge
         from .badge import IBadgeAssignment
         badge = testing.DummyResource(__provides__=IBadge)
@@ -163,10 +153,8 @@ class TestCreateUniqueBadgeAssignmentValidator:
             validator(node, {'badge': badge,
                              'object': node['object2']})
 
-
-    def test_no_raise_if_object_different(
-            self, node, context, registry, mock_sheet):
-        import colander
+    def test_no_raise_if_object_different(self, node, context,
+                                          registry, mock_sheet):
         from .badge import IBadge
         from .badge import IBadgeAssignment
         badge = testing.DummyResource(__provides__=IBadge)
@@ -178,11 +166,10 @@ class TestCreateUniqueBadgeAssignmentValidator:
         validator = self.call_fut(node['badge'], node['object'], kw)
         assign0 = testing.DummyResource(__provides__=IBadgeAssignment)
         context['badge_assignments']['assign0'] = assign0
-        assert validator(node, {'badge': badge, 'object': testing.DummyResource()}) is None
+        assert validator(node, {'badge': badge,
+                                'object': testing.DummyResource()}) is None
 
-    def test_valid(
-            self, node, context, registry, mock_sheet):
-        import colander
+    def test_valid(self, node, context, registry, mock_sheet):
         from .badge import IBadge
         from .badge import IBadgeAssignment
         from copy import deepcopy
@@ -193,13 +180,15 @@ class TestCreateUniqueBadgeAssignmentValidator:
         mock_sheet2.get.return_value = {'badge': badge,
                                         'object': testing.DummyResource()}
         mock_sheet3.get.return_value = {'name': 'badge1'}
-        registry.content.get_sheet.side_effect = [mock_sheet, mock_sheet2, mock_sheet3]
+        registry.content.get_sheet.side_effect = [mock_sheet, mock_sheet2,
+                                                  mock_sheet3]
         kw = {'registry': registry, 'context': context}
         validator = self.call_fut(node['badge'], node['object'], kw)
         assign0 = testing.DummyResource(__provides__=IBadgeAssignment)
         context['badge_assignments']['assign0'] = assign0
         assert validator(node, {'badge': badge,
                                 'object': testing.DummyResource()}) is None
+
 
 class TestBadgeAssignmentsSheet:
 
@@ -213,17 +202,18 @@ class TestBadgeAssignmentsSheet:
         return meta.sheet_class(meta, context)
 
     @fixture
-    def mock_create_post_pool_validator(self, monkeypatch):
+    def mock_create_post_validator(self, monkeypatch):
         from . import badge
         mock = Mock(spec=badge.create_post_pool_validator)
         monkeypatch.setattr(badge, 'create_post_pool_validator', mock)
         return mock
 
     @fixture
-    def mock_create_unique_badge_assignment_validator(self, monkeypatch):
+    def mock_create_assignment_validator(self, monkeypatch):
         from . import badge
         mock = Mock(spec=badge.create_unique_badge_assignment_validator)
-        monkeypatch.setattr(badge, 'create_unique_badge_assignment_validator', mock)
+        monkeypatch.setattr(badge, 'create_unique_badge_assignment_validator',
+                            mock)
         return mock
 
     def test_meta(self, meta):
@@ -247,14 +237,13 @@ class TestBadgeAssignmentsSheet:
                               }
 
     def test_validate_object_post_pool(self, inst,
-                                       mock_create_post_pool_validator,
-                                       mock_create_unique_badge_assignment_validator):
+                                       mock_create_post_validator,
+                                       mock_create_assignment_validator):
         inst.schema.validator(inst.schema, {})
-        mock_create_post_pool_validator.assert_called_with(inst.schema['object'],
-                                                           {})
-        mock_create_unique_badge_assignment_validator.assert_called_with(inst.schema['badge'],
-                                                                         inst.schema['object'],
-                                                                         {})
+        mock_create_post_validator.assert_called_with(inst.schema['object'],
+                                                      {})
+        mock_create_assignment_validator\
+            .assert_called_with(inst.schema['badge'], inst.schema['object'], {})
 
     @mark.usefixtures('integration')
     def test_includeme_register(self, meta):
@@ -372,17 +361,16 @@ class TestGetAssignableBadges:
         context_without_badges_service = testing.DummyResource()
         assert self.call_fut(context_without_badges_service, request_) == []
 
-    def test_all_badges_inside_badges_service(self,
-            mock_catalogs, search_result, query, mock_badges, context, request_):
+    def test_all_badges_inside_badges_service(
+            self, mock_catalogs, search_result, query, mock_badges, context,
+            request_):
         from .badge import IBadge
         badge = testing.DummyResource()
-        mock_catalogs.search.return_value = search_result._replace(elements=[badge])
+        mock_catalogs.search.return_value = search_result\
+            ._replace(elements=[badge])
         assert self.call_fut(context, request_) == [badge]
         assert mock_catalogs.search.call_args[0][0] == query._replace(
             root=mock_badges,
             interfaces=IBadge,
             allows=(request_.effective_principals, 'assign_badge')
             )
-
-
-


### PR DESCRIPTION
API Extensions:

- If a user creates an IBadgeAssignment he need the `badge_assignment` permission for the referenced 
IBadge resource.