### PR TITLE
[RFC] thentos-adhocracy eggs for a3

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -6,6 +6,7 @@ extends =
     src/adhocracy_core/checkcode.cfg
     src/adhocracy_core/sphinx.cfg
     src/adhocracy_core/wheels.cfg
+    src/adhocracy_core/thentos_adhocracy.cfg
 #    src/adhocracy_core/varnish.cfg
     src/adhocracy_frontend/sources.cfg
     src/adhocracy_frontend/base.cfg
@@ -29,6 +30,7 @@ develop =
     src/spd
     src/s1
     src/euth
+    src/thentos_adhocracy
 # enable script to build wheels for adhocracy packages
 parts +=
     make_wheels

--- a/buildout-mercator.cfg
+++ b/buildout-mercator.cfg
@@ -15,9 +15,9 @@ static_directories = src/mercator/mercator/static ${adhocracy:frontend.core.stat
 
 [supervisor]
 groups =
-    10 adhocracy zeo_auditing,zeo,autobahn,backend,frontend
+    10 adhocracy zeo_auditing,zeo,autobahn,backend,frontend,thentos_adhocracy
 #    10 adhocracy zeo,autobahn,backend,varnish,frontend
-    20 adhocracy_test test_zeo_auditing,test_zeo,test_autobahn,test_backend,test_frontend
+    20 adhocracy_test test_zeo_auditing,test_zeo,test_autobahn,test_backend,test_frontend,thentos_adhocracy
 
 [varnish]
 port = 8088
@@ -27,5 +27,6 @@ vcl = ${buildout:directory}/etc/varnish.vcl
 wheels +=
        src/adhocracy_frontend
        src/adhocracy_mercator
+       src/thentos_adhocracy
        src/mercator
 platform = mercator

--- a/etc/thentos_adhocracy.yaml.in
+++ b/etc/thentos_adhocracy.yaml.in
@@ -1,0 +1,78 @@
+# Sample config for running A3 with Thentos in proxy mode.
+# Used ports: A3 frontend on 6551, Thentos proxy on 6546, A3 backend on 6541.
+# Required changes in the A3 config:
+#
+# * Change the following line in etc/frontend_development.ini.in:
+#
+#       adhocracy.frontend.rest_url = http://localhost:6546
+#
+# * Change the following lines in etc/development.ini.in:
+#
+#       adhocracy.skip_registration_mail = true
+#       adhocracy.validate_user_token = false
+#
+# * Call bin/buildout
+
+backend:
+    bind_port: 6546
+    bind_host: localhost
+
+frontend:
+    bind_port: 6551
+    bind_host: localhost
+
+proxy:
+    service_id: qlX4MP7xEgtRng+8iNvMIcSo
+    endpoint: http://localhost:6541
+
+smtp:
+    sender_name: "Thentos"
+    sender_address: "thentos@thentos.org"
+    sendmail_path: "/usr/sbin/sendmail"    # (built-in default)
+    sendmail_args: ["-t"]                  # (built-in default)
+
+#default_user:
+#    name: "god"
+#    password: "god"
+#    email: "postmaster@localhost"
+#    roles: ["roleAdmin", "roleUser", "roleServiceAdmin", "roleUserAdmin"]
+
+user_reg_expiration: 1d
+pw_reset_expiration: 1d
+email_change_expiration: 1d
+captcha_expiration: 1h
+gc_interval: 30m
+
+log:
+    path: var/log/thentos_adhocracy.log
+    level: INFO
+#    level: DEBUG
+
+database:
+    name: "thentos_adhocracy"
+
+email_templates:
+    account_verification:
+        subject: "Thentos: Aktivierung Ihres Nutzerkontos"
+        # Supported variables: {{user_name}}, {{activation_url}}
+        body: |
+            Hallo {{user_name}},
+
+            vielen Dank für Ihre Registrierung bei Thentos.
+
+            Diese E-Mail dient der Validierung Ihrer Identität. Bitte
+            nutzen Sie den folgenden Link um das Nutzerkonto zu aktivieren.
+
+            {{activation_url}}
+
+            Wir wünschen Ihnen viel Spaß und Inspiration!
+
+            Das Thentos-Team
+    user_exists:
+        subject: "Thentos: Attempted Signup"
+        body: |
+            Someone tried to sign up to Thentos with your email address.
+
+            This is a reminder that you already have a Thentos account. If you
+            haven't tried to sign up to Thentos, you can just ignore this email.
+            If you have, you are hereby reminded that you already have an account.

--- a/src/adhocracy_core/thentos_adhocracy.cfg
+++ b/src/adhocracy_core/thentos_adhocracy.cfg
@@ -1,6 +1,5 @@
 [buildout]
 allow-hosts += thentos-dev-frontend4.liqd.net
-extends = buildout.cfg
 parts += thentos_adhocracy.yaml thentos_adhocracy
 
 [thentos_adhocracy.yaml]

--- a/src/adhocracy_mercator/setup.py
+++ b/src/adhocracy_mercator/setup.py
@@ -9,6 +9,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 
 requires = ['adhocracy_core',
+            'thentos_adhocracy',
             ]
 
 test_requires = ['adhocracy_core[test]',

--- a/thentos.cfg
+++ b/thentos.cfg
@@ -1,0 +1,8 @@
+[buildout]
+allow-hosts += thentos-dev-frontend4.liqd.net
+extends = buildout.cfg
+parts += thentos_adhocracy
+
+[thentos_adhocracy]
+recipe = zc.recipe.egg:scripts
+index = https://thentos-dev-frontend4.liqd.net/eggs

--- a/thentos.cfg
+++ b/thentos.cfg
@@ -11,3 +11,7 @@ output = ${buildout:directory}/etc/thentos_adhocracy.yaml
 [thentos_adhocracy]
 recipe = zc.recipe.egg:scripts
 index = https://thentos-dev-frontend4.liqd.net/eggs
+
+[supervisor]
+programs +=
+    32 thentos_adhocracy (autostart=false stdout_logfile=var/log/thentos_adhocracy.stdout stderr_logfile=NONE startsecs=3 stopwaitsecs=3) ${buildout:bin-directory}/thentos_adhocracy [--config ${buildout:directory}/etc/thentos_adhocracy.yaml] ${buildout:directory} true

--- a/thentos.cfg
+++ b/thentos.cfg
@@ -1,7 +1,12 @@
 [buildout]
 allow-hosts += thentos-dev-frontend4.liqd.net
 extends = buildout.cfg
-parts += thentos_adhocracy
+parts += thentos_adhocracy.yaml thentos_adhocracy
+
+[thentos_adhocracy.yaml]
+recipe = collective.recipe.template
+input = ${buildout:directory}/etc/thentos_adhocracy.yaml.in
+output = ${buildout:directory}/etc/thentos_adhocracy.yaml
 
 [thentos_adhocracy]
 recipe = zc.recipe.egg:scripts


### PR DESCRIPTION
It is *probably* ok to use this in production as is (perhaps except for the thentos egg version that contains known bugs), but I would like to talk about it a bit more first.

In particular:

- instead of the top-level `thentos.cfg`, would you prefer a snippet that can be used elsewhere in `extends` clauses?
- which directory should `thentos.cfg` live in?
- is it ok that the platform (amd64) is not explicit in the egg, i.e. if you try to install the egg on other platforms, you will get runtime errors from supervisor about broken executables?
- the supervisor entry does not belong to any group.  is that ok and should be configured on a per-deployment basis?  if not, how do you extend existing groups in the supervisor builout recipe?