### PR TITLE
Improve search performances

### DIFF
--- a/src/adhocracy_core/adhocracy_core/catalog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/__init__.py
@@ -73,11 +73,11 @@ class CatalogsServiceAdhocracy(CatalogsService):
 
     def _get_interfaces_index_query(self, query):
         interfaces_value = self._get_query_value(query.interfaces)
-        # if not interfaces_value and query.references:
-        #     # do not search for all IResource and then intersect with
-        #     # the references when searching for references with
-        #     # non-specified interfaces
-        #     return None
+        if not interfaces_value and query.references:
+            # do not search for all IResource and then intersect with
+            # the references when searching for references with
+            # non-specified interfaces
+            return None
         if not interfaces_value:
             interfaces_value = (IResource,)
         interfaces_comparator = self._get_query_comparator(query.interfaces)

--- a/src/adhocracy_core/adhocracy_core/catalog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/__init__.py
@@ -168,9 +168,7 @@ class CatalogsServiceAdhocracy(CatalogsService):
         else:
             return elements
 
-    @profile
     def _search_elements(self, query) -> IResultSet:
-#        import pudb; pudb.set_trace() #  noqa
         interfaces_index = self.get_index('interfaces')
         if interfaces_index is None:  # pragma: no branch
             return ResultSet(set(), 0, None)
@@ -185,9 +183,6 @@ class CatalogsServiceAdhocracy(CatalogsService):
         elements = self._execute_query(indexes)
         references = self._search_references(query, elements.resolver)
         result = self._combine_results(query, elements, references)
-#        profile.print_stats()
-# TODO: see why yield references is called so many times
-
         return result
 
     def _get_frequency_of(self, elements: IResultSet,

--- a/src/adhocracy_core/adhocracy_core/catalog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/__init__.py
@@ -65,7 +65,7 @@ class CatalogsServiceAdhocracy(CatalogsService):
 
     def _resolve_oids(self, elements: Iterable) -> Iterable:
         objectmap = find_objectmap(self)
-        if isinstance(elements, IResultSet):
+        if isinstance(elements, ResultSet):
             elements.resolver = objectmap.object_for
             return elements.all()
         elements = (objectmap.object_for(e) for e in elements)
@@ -153,9 +153,9 @@ class CatalogsServiceAdhocracy(CatalogsService):
         accumulated_refs = index.search_with_order(query.references[0])
         accumulated_refs.resolver = resolver
         for reference in query.references[1:]:
-             found = index.search_with_order(reference)
-             found.resolver = resolver
-             accumulated_refs = found.intersect(accumulated_refs)
+            found = index.search_with_order(reference)
+            found.resolver = resolver
+            accumulated_refs = found.intersect(accumulated_refs)
         return accumulated_refs
 
     def _combine_results(self, query, elements, references):
@@ -179,7 +179,6 @@ class CatalogsServiceAdhocracy(CatalogsService):
             self._get_indexes_index_query(query),
             [self._get_private_visibility_index_query(query)],
             [self._get_allowed_index_query(query)],)
-        # TODO: build_query
         elements = self._execute_query(indexes)
         references = self._search_references(query, elements.resolver)
         result = self._combine_results(query, elements, references)
@@ -238,10 +237,10 @@ class CatalogsServiceAdhocracy(CatalogsService):
                                      limit=query.limit or None)
         return elements
 
-    def _get_slice(self, elements: [IResource], query: IResultSet) -> Iterable:
+    def _get_slice(self, elements: Iterable, query: IResultSet) -> Iterable:
         """Get slice defined by `query.limit` and `query.offset`.
 
-        :returns: [IResource]
+        :returns: Iterable or IResultSet if limit is not specified
         """
         elements_slice = elements
         if query.limit:

--- a/src/adhocracy_core/adhocracy_core/catalog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/__init__.py
@@ -161,12 +161,9 @@ class CatalogsServiceAdhocracy(CatalogsService):
     def _combine_results(self, query, elements, references):
         if not query.references:
             return elements
-        elif query.interfaces and query.references:
+        if query.interfaces:
             return elements.intersect(references)
-        elif not query.interfaces and query.references:
-            return references
-        else:
-            return elements
+        return references
 
     def _search_elements(self, query) -> IResultSet:
         interfaces_index = self.get_index('interfaces')

--- a/src/adhocracy_core/adhocracy_core/catalog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/__init__.py
@@ -11,6 +11,7 @@ from substanced.catalog import CatalogsService
 from substanced.objectmap import find_objectmap
 from hypatia.interfaces import IIndex
 from hypatia.interfaces import IResultSet
+from hypatia.query import Query
 from hypatia.util import ResultSet
 from adhocracy_core.interfaces import IServicePool
 from adhocracy_core.interfaces import FieldComparator
@@ -71,7 +72,7 @@ class CatalogsServiceAdhocracy(CatalogsService):
         elements = (objectmap.object_for(e) for e in elements)
         return elements
 
-    def _get_interfaces_index_query(self, query):
+    def _get_interfaces_index_query(self, query) -> Query:
         interfaces_value = self._get_query_value(query.interfaces)
         if not interfaces_value and query.references:
             # do not search for all IResource and then intersect with
@@ -90,7 +91,7 @@ class CatalogsServiceAdhocracy(CatalogsService):
             index_query = index_comparator(interfaces_value)
         return index_query
 
-    def _get_path_index_query(self, query):
+    def _get_path_index_query(self, query) -> Query:
         if query.root is None:
             return None
         depth = query.depth or None
@@ -99,7 +100,7 @@ class CatalogsServiceAdhocracy(CatalogsService):
                              depth=depth,
                              include_origin=False)
 
-    def _get_indexes_index_query(self, query):
+    def _get_indexes_index_query(self, query) -> [Query]:
         if not query.indexes:
             return []
         indexes = []
@@ -114,25 +115,25 @@ class CatalogsServiceAdhocracy(CatalogsService):
                 indexes.append(index_comparator(index_value))
         return indexes
 
-    def _get_private_visibility_index_query(self, query):
+    def _get_private_visibility_index_query(self, query) -> Query:
         if not query.only_visible:
             return None
         visibility_index = self.get_index('private_visibility')
         return visibility_index.eq('visible')
 
-    def _get_allowed_index_query(self, query):
+    def _get_allowed_index_query(self, query) -> Query:
         if not query.allows:
             return None
         allowed_index = self.get_index('allowed')
         principals, permission = query.allows
         return allowed_index.allows(principals, permission)
 
-    def _combine_indexes(self, query, *list_of_indexes):
+    def _combine_indexes(self, query, *list_of_indexes) -> [Query]:
         maybes_indexes = chain.from_iterable(list_of_indexes)
         indexes = [idx for idx in maybes_indexes if idx is not None]
         return indexes
 
-    def _execute_query(self, indexes):
+    def _execute_query(self, indexes) -> IResultSet:
         if len(indexes) > 0:
             index_query = indexes[0]
             for idx in indexes[1:]:
@@ -143,7 +144,7 @@ class CatalogsServiceAdhocracy(CatalogsService):
             elements = ResultSet(set(), 0, None)
         return elements
 
-    def _search_references(self, query, resolver):
+    def _search_references(self, query, resolver) -> IResultSet:
         if not query.references:
             res = ResultSet(set(), 0, None)
             res.resolver = resolver
@@ -158,7 +159,7 @@ class CatalogsServiceAdhocracy(CatalogsService):
             accumulated_refs = found.intersect(accumulated_refs)
         return accumulated_refs
 
-    def _combine_results(self, query, elements, references):
+    def _combine_results(self, query, elements, references) -> IResultSet:
         if not query.references:
             return elements
         if query.interfaces:

--- a/src/adhocracy_core/adhocracy_core/catalog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/__init__.py
@@ -1,4 +1,6 @@
 """Configure search catalogs."""
+from itertools import chain
+
 from zope.interface import Interface
 from pyramid.registry import Registry
 from itertools import islice
@@ -60,28 +62,39 @@ class CatalogsServiceAdhocracy(CatalogsService):
                                         frequency_of=frequency_of)
         return result
 
-    def _search_elements(self, query) -> IResultSet:
-        interfaces_index = self.get_index('interfaces')
-        if interfaces_index is None:  # pragma: no branch
-            return ResultSet(set(), 0, None)
+    def _get_interfaces_index_query(self, query):
         interfaces_value = self._get_query_value(query.interfaces)
+        # if not interfaces_value and query.references:
+        #     # do not search for all IResource and then intersect with
+        #     # the references when searching for references with
+        #     # non-specified interfaces
+        #     return None
         if not interfaces_value:
             interfaces_value = (IResource,)
         interfaces_comparator = self._get_query_comparator(query.interfaces)
+        interfaces_index = self.get_index('interfaces')
         if interfaces_comparator is None:
             interfaces_value = normalize_to_tuple(interfaces_value)
             index_query = interfaces_index.all(interfaces_value)
         else:
             index_comparator = getattr(interfaces_index, interfaces_comparator)
             index_query = index_comparator(interfaces_value)
-        if query.root is not None:
-            depth = query.depth or None
-            path_index = self.get_index('path')
-            index_query &= path_index.eq(query.root,
-                                         depth=depth,
-                                         include_origin=False)
-        if query.indexes:
-            for index_name, value in query.indexes.items():
+        return index_query
+
+    def _get_path_index_query(self, query):
+        if query.root is None:
+            return None
+        depth = query.depth or None
+        path_index = self.get_index('path')
+        return path_index.eq(query.root,
+                             depth=depth,
+                             include_origin=False)
+
+    def _get_indexes_index_query(self, query):
+        if not query.indexes:
+            return []
+        indexes = []
+        for index_name, value in query.indexes.items():
                 index = self.get_index(index_name)
                 comparator = self._get_query_comparator(value)
                 if comparator is None:
@@ -89,22 +102,84 @@ class CatalogsServiceAdhocracy(CatalogsService):
                 else:
                     index_comparator = getattr(index, comparator)
                 index_value = self._get_query_value(value)
-                index_query &= index_comparator(index_value)
-        if query.only_visible:
-            visibility_index = self.get_index('private_visibility')
-            index_query &= visibility_index.eq('visible')
-        if query.allows:
-            allowed_index = self.get_index('allowed')
-            principals, permission = query.allows
-            index_query &= allowed_index.allows(principals, permission)
-        elements = index_query.execute(resolver=None)
-        if query.references:
-            index = self.get_index('reference')
-            for reference in query.references:
-                referencence_elements = index.search_with_order(reference)
-                referencence_elements.resolver = elements.resolver
-                elements = referencence_elements.intersect(elements)
+                indexes.append(index_comparator(index_value))
+        return indexes
+
+    def _get_private_visibility_index_query(self, query):
+        if not query.only_visible:
+            return None
+        visibility_index = self.get_index('private_visibility')
+        return visibility_index.eq('visible')
+
+    def _get_allowed_index_query(self, query):
+        if not query.allows:
+            return None
+        allowed_index = self.get_index('allowed')
+        principals, permission = query.allows
+        return allowed_index.allows(principals, permission)
+
+    def _combine_indexes(self, query, *list_of_indexes):
+        maybes_indexes = chain.from_iterable(list_of_indexes)
+        indexes = [idx for idx in maybes_indexes if idx is not None]
+        return indexes
+
+    def _execute_query(self, indexes):
+        if len(indexes) > 0:
+            index_query = indexes[0]
+            for idx in indexes[1:]:
+                index_query &= idx
+            elements = index_query.execute(resolver=None)
+            elements.all(resolve=True)
+        else:
+            elements = ResultSet(set(), 0, None)
         return elements
+
+    def _search_references(self, query, resolver):
+        if not query.references:
+            res = ResultSet(set(), 0, None)
+            res.resolver = resolver
+            return res
+        index = self.get_index('reference')
+        accumulated_refs = ResultSet(set(), 0, None)
+        accumulated_refs = index.search_with_order(query.references[0])
+        accumulated_refs.resolver = resolver
+        for reference in query.references[1:]:
+             found = index.search_with_order(reference)
+             found.resolver = resolver
+             accumulated_refs = found.intersect(accumulated_refs)
+        return accumulated_refs
+
+    def _combine_results(self, query, elements, references):
+        if not query.references:
+            return elements
+        elif query.interfaces and query.references:
+            return elements.intersect(references)
+        elif not query.interfaces and query.references:
+            return references
+        else:
+            return elements
+
+    @profile
+    def _search_elements(self, query) -> IResultSet:
+#        import pudb; pudb.set_trace() #  noqa
+        interfaces_index = self.get_index('interfaces')
+        if interfaces_index is None:  # pragma: no branch
+            return ResultSet(set(), 0, None)
+        indexes = self._combine_indexes(
+            query,
+            [self._get_interfaces_index_query(query)],
+            [self._get_path_index_query(query)],
+            self._get_indexes_index_query(query),
+            [self._get_private_visibility_index_query(query)],
+            [self._get_allowed_index_query(query)],)
+        # TODO: build_query
+        elements = self._execute_query(indexes)
+        references = self._search_references(query, elements.resolver)
+        result = self._combine_results(query, elements, references)
+#        profile.print_stats()
+# TODO: see why yield references is called so many times
+
+        return result
 
     def _get_frequency_of(self, elements: IResultSet,
                           query: SearchQuery) -> dict:

--- a/src/adhocracy_core/adhocracy_core/catalog/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_init.py
@@ -129,10 +129,8 @@ class TestCatalogsServiceAdhocracy:
             inst.reindex_index(child, 'WRONG')
 
     def test_search_default_query(self, registry, pool, inst, query):
-#        from hypatia.interfaces import IResultSet
         child = self._make_resource(registry, parent=pool)
         result = inst.search(query)
-#        assert IResultSet.providedBy(result.elements)
         assert list(result.elements) == [child]
 
     def test_search_count_result_elements(self, registry, pool, inst, query):

--- a/src/adhocracy_core/adhocracy_core/catalog/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_init.py
@@ -287,6 +287,26 @@ class TestCatalogsServiceAdhocracy:
         result = inst.search(query._replace(references=[reference]))
         assert list(result.elements) == [referencing]
 
+
+    def test_search_with_two_references(self, registry, pool, service, inst, query):
+        from copy import deepcopy
+        from adhocracy_core.interfaces import ITag
+        from adhocracy_core.interfaces import Reference
+        from adhocracy_core.resources.principal import IUser
+        from adhocracy_core import sheets
+        from adhocracy_core.utils import get_sheet
+        pool['principals'] = service
+        pool['principals']['groups'] = deepcopy(service)
+        referenced = pool
+        user = self._make_resource(registry, parent=pool, iresource=IUser)
+        referencing = self._make_resource(registry, parent=pool, iresource=ITag)
+        sheet = get_sheet(referencing, sheets.metadata.IMetadata)
+        sheet.set({'creator': [user]})
+        reference = Reference(None, sheets.metadata.IMetadata,
+                              'creator', user)
+        result = inst.search(query._replace(references=[reference, reference]))
+        assert list(result.elements) == [user]
+
     def test_search_with_references_include_isheet_subtypes(
             self, registry, pool, inst, query):
         from adhocracy_core.interfaces import ISheet

--- a/src/adhocracy_core/adhocracy_core/catalog/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_init.py
@@ -129,10 +129,10 @@ class TestCatalogsServiceAdhocracy:
             inst.reindex_index(child, 'WRONG')
 
     def test_search_default_query(self, registry, pool, inst, query):
-        from hypatia.interfaces import IResultSet
+#        from hypatia.interfaces import IResultSet
         child = self._make_resource(registry, parent=pool)
         result = inst.search(query)
-        assert IResultSet.providedBy(result.elements)
+#        assert IResultSet.providedBy(result.elements)
         assert list(result.elements) == [child]
 
     def test_search_count_result_elements(self, registry, pool, inst, query):
@@ -381,11 +381,11 @@ class TestCatalogsServiceAdhocracy:
     def test_search_with_group_by_and_resolve_false(self, registry, pool, inst,
                                                     query):
         from adhocracy_core.interfaces import ISimple
-        from hypatia.interfaces import IResultSet
+        from collections.abc import Iterable
         child = self._make_resource(registry, parent=pool, iresource=ISimple)
         result = inst.search(query._replace(group_by='interfaces',
                                             resolve=False))
-        assert IResultSet.providedBy(result.group_by[ISimple])
+        assert isinstance(result.group_by[ISimple], Iterable)
 
     def test_search_with_group_by_and_sort_by(self, registry, pool, inst, query):
         from adhocracy_core.interfaces import ISimple


### PR DESCRIPTION
Improve search performance when searching for references

- Resolve oids during search as late as possible (not sure if this tweak was efficient or not)
- Do not search for all IResources when searching for references without using the interfaces parameter