### PR TITLE
added hide-user attribute for space switcher, implemented in mercator…

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -501,7 +501,10 @@ export var spaceSwitch = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/templates/" + "SpaceSwitch.html",
-        link: (scope) => {
+        scope: {
+            hideUser: "@"
+        },
+        link: (scope, element, attr) => {
             scope.$on("$destroy", adhTopLevelState.bind("space", scope, "currentSpace"));
             scope.setSpace = (space : string) => {
                 if (scope.currentSpace === space) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/templates/SpaceSwitch.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/templates/SpaceSwitch.html
@@ -9,9 +9,11 @@
             title="{{ 'TR__SPACE_CONTENT' | translate }}"
     ></i></a><span
         class="separator"
+        ng-if="!hideUser"
     ></span><a
         href=""
         class="space-switch-user"
+        ng-if="!hideUser"
         data-ng-click="setSpace('user')"
         data-ng-class="{'is-active': currentSpace === 'user'}"
         ><i

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Context/header.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Context/header.html
@@ -8,7 +8,8 @@
             data-ng-href="{{ processUrl | adhResourceUrl:'create_proposal' }}">{{ "TR__PROPOSAL_ADD" | translate }}</a>
     </div>
     <div class="l-header-center">
-        <adh-space-switch></adh-space-switch>
+        <adh-space-switch
+            data-hide-user="true"></adh-space-switch>
     </div>
     <div class="l-header-right">
         <adh-user-indicator></adh-user-indicator>


### PR DESCRIPTION
Hi I don't know how to activate the 2016 context locally (can someone show me how please?) but I sufficiently tested this by overwriting the core header (and reverting)

it's quite simple so this should be self-explanatory