### PR TITLE
Remove explanation field in the WinnerInfoSchema

### DIFF
--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
@@ -480,7 +480,6 @@ class IWinnerInfo(ISheet):
 
 
 class WinnerInfoSchema(colander.MappingSchema):
-    explanation = Text()
     funding = Integer()
 
 winnerinfo_meta = sheet_meta._replace(

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
@@ -1141,8 +1141,7 @@ class TestWinnerInfoSchema:
 
     @fixture
     def cstruct_required(self):
-        return {'explanation': 'Relevant project',
-                'funding': '10000'}
+        return {'funding': '10000'}
 
     def test_deserialize_empty(self, inst):
         cstruct = {}
@@ -1150,8 +1149,7 @@ class TestWinnerInfoSchema:
 
     def test_deserialize_with_required(self, inst, cstruct_required):
         assert inst.deserialize(cstruct_required) == \
-            {'explanation': 'Relevant project',
-             'funding': 10000}
+            {'funding': 10000}
 
 
 class TestWinnerInfoSheet:

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -266,7 +266,6 @@ var fill = (data : IFormData, resource) => {
                 picture: data.introduction.picture
             });
             resource.data[SIWinnerInfo.nick] = new SIWinnerInfo.Sheet({
-                explanation: null,  // FIXME
                 funding: null  // FIXME
             });
             break;


### PR DESCRIPTION
The explanation can be stored in the badge assignment when assigning the
'winner' badge.