### PR TITLE
Rename Topic 'other' text field to 'topic_other'

### DIFF
--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
@@ -155,14 +155,14 @@ class ITopic(ISheet):
 
 class TopicSchema(colander.MappingSchema):
     topic = TopicEnums(validator=colander.Length(min=1, max=2))
-    other = Text()
+    topic_other = Text()
 
     def validator(self, node: colander.SchemaNode, value: dict):
         """Extra validation depending on the status of the topic."""
         topics = value.get('topic', [])
         if 'other' in topics:
-            if not value.get('other', None):
-                raise colander.Invalid(node['other'],
+            if not value.get('topic_other', None):
+                raise colander.Invalid(node['topic_other'],
                                        msg='Required if "other" in topic')
         if _has_duplicates(topics):
             raise colander.Invalid(node['topic'],

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
@@ -265,7 +265,7 @@ class TestTopicSchema:
 
     def test_serialize_empty(self, inst):
         assert inst.bind().serialize() == {'topic': [],
-                                           'other': ''}
+                                           'topic_other': ''}
 
     def test_deserialize_empty(self, inst):
         from colander import Invalid
@@ -299,7 +299,7 @@ class TestTopicSchema:
         cstruct['topic'] = ['other', 'urban_development']
         with raises(Invalid) as error:
             inst.deserialize(cstruct)
-        assert error.value.asdict() == {'other':
+        assert error.value.asdict() == {'topic_other':
                                         'Required if "other" in topic'}
 
 
@@ -307,10 +307,10 @@ class TestTopicSchema:
             self, inst, cstruct_required):
         cstruct = cstruct_required
         cstruct['topic'] = ['other', 'urban_development']
-        cstruct['other'] = 'Blabla'
+        cstruct['topic_other'] = 'Blabla'
         assert inst.deserialize(cstruct_required) == \
             {'topic': ['other', 'urban_development'],
-             'other': 'Blabla'}
+             'topic_other': 'Blabla'}
 
 
 class TestTopicSheet:


### PR DESCRIPTION
This is at the request of @local-girl as the simple 'other' name was confusing in the frontend code.

Frontend needs adaptation.