### PR TITLE
 add comments_count  field  to ICommentable sheet

### DIFF
--- a/src/adhocracy_core/adhocracy_core/catalog/index.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/index.py
@@ -73,24 +73,37 @@ class ReferenceIndex(SDIndex, BaseIndexMixin, Persistent):
         """Read interface."""
         return self._not_indexed
 
-    def eq(self, reference: Reference) -> hypatia.query.Eq:
-        """Eq operator to concatenate queries.."""
-        query = {'reference': reference}
+    def eq(self, query: dict) -> hypatia.query.Eq:
+        """Concatenate reference `query`.
+
+        :param query:
+
+            reference (Reference): reference with target or source
+            traverse (bool): traverse all references with same type, starting
+                             with the given target or source.
+        """
         return hypatia.query.Eq(self, query)
 
     def apply(self, query: dict) -> BTrees.family64.IF.TreeSet:
-        """Apply `query` ({reference: Reference}) and return result."""
-        reference = query['reference']
-        return self._search(reference)
+        """Apply reference `query`.
+
+        :param query:
+
+            reference (Reference): reference with target or source
+            traverse (bool): traverse all references with same type, starting
+                             with the given target or source.
+        """
+        if 'traverse' not in query:
+            query['traverse'] = False
+        return self._search(query)
 
     def applyAll(self, queries: [dict]) -> BTrees.family64.IF.TreeSet:  # noqa
-        """Apply multiple `queries` ({reference: Reference}) and return result.
+        """Apply multiple reference `queries`.
 
         The result sets are combined with `intersection`.
         """
-        references = [q['reference'] for q in queries]
-        result_all = set(self._search(references[0]))
-        for reference in references[1:]:
+        result_all = set(self._search(queries[0]))
+        for reference in queries[1:]:
             result = set(self._search(reference))
             result_all = result_all.intersection(result)
         return result_all
@@ -100,33 +113,36 @@ class ReferenceIndex(SDIndex, BaseIndexMixin, Persistent):
 
     def search_with_order(self, reference: Reference) -> ResultSet:
         """"Search target or source resources ids of `reference` with order."""
-        oids = [x for x in self._search_target_or_source_ids(reference)]
+        query = {'reference': reference,
+                 'traverse': False}
+        oids = [x for x in self._search_target_or_source_ids(query)]
         result = ResultSet(oids, len(oids), None)
         return result
 
-    def _search(self, reference: Reference) -> BTrees.LFBTree.TreeSet:
-        """"Search target or soruce resources of `reference` without order.
-
-        This helper function is to fullfill the IIndex interface.
-        """
-        oids = self._search_target_or_source_ids(reference)
+    def _search(self, query: dict) -> BTrees.LFBTree.TreeSet:
+        """"Search target or source resources of `reference` without order."""
+        oids = self._search_target_or_source_ids(query)
         result = self.family.IF.TreeSet(oids)
         return result
 
-    def _search_target_or_source_ids(self, reference) -> [int]:
-        source, isheet, isheet_field, target = reference
+    def _search_target_or_source_ids(self, query: dict) -> [int]:
+        source, isheet, isheet_field, target = query['reference']
         if source is None and target is None:
             raise ValueError('You have to add a source or target resource')
         elif source is not None and target is not None:
             raise ValueError('Either source or target has to be None')
+        traverse = query['traverse']
         if source is None:
-            oids = self._resource_ids(target, isheet, isheet_field, 'sources')
+            oids = self._resource_ids(target, isheet, isheet_field, 'sources',
+                                      traverse=traverse)
         else:
-            oids = self._resource_ids(source, isheet, isheet_field, 'targets')
+            oids = self._resource_ids(source, isheet, isheet_field, 'targets',
+                                      traverse=traverse)
         return oids
 
     def _resource_ids(self, resource, isheet=ISheet, isheet_field='',
-                      orientation='') -> set:
+                      orientation='',
+                      traverse=False) -> set:
         """Get OIDs from references with `orientation` targets or sources."""
         if orientation == 'sources':
             get_resources_ids = self._objectmap.sourceids
@@ -136,4 +152,10 @@ class ReferenceIndex(SDIndex, BaseIndexMixin, Persistent):
             if isheet_field and field != isheet_field:
                 continue
             for oid in get_resources_ids(resource, reftype):
+                if traverse:
+                    yield from self._resource_ids(oid,
+                                                  isheet=isheet,
+                                                  isheet_field=isheet_field,
+                                                  orientation=orientation,
+                                                  traverse=traverse)
                 yield oid

--- a/src/adhocracy_core/adhocracy_core/catalog/test_index.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_index.py
@@ -95,17 +95,19 @@ class TestReference:
          from adhocracy_core.interfaces import Reference
          from adhocracy_core.interfaces import ISheet
          inst = self.make_one()
-         reference = Reference(None, ISheet, '', None)
+         query = {'reference':  Reference(None, ISheet, '', None),
+                  'traverse': False}
          with raises(ValueError):
-            inst._search(reference)
+            inst._search(query)
 
     def test_search_raise_if_source_and_target_is_not_none(self):
          from adhocracy_core.interfaces import Reference
          from adhocracy_core.interfaces import ISheet
          inst = self.make_one()
-         reference = Reference(object(), ISheet, '', object())
+         query = {'reference': Reference(object(), ISheet, '', object()),
+                  'traverse': False}
          with raises(ValueError):
-            inst._search(reference)
+            inst._search(query)
 
     def test_search_sources(self, mock_graph, mock_objectmap):
         from adhocracy_core.interfaces import ISheet
@@ -118,8 +120,9 @@ class TestReference:
         oid1, oid2 = 1, 2
         mock_objectmap.sourceids.return_value = [oid2, oid1]
         inst._objectmap = mock_objectmap
-        reference = Reference(None, ISheet, '', target)
-        result = inst._search(reference)
+        query = {'reference': Reference(None, ISheet, '', target),
+                 'traverse': False}
+        result = inst._search(query)
         mock_objectmap.sourceids.assert_called_with(target, SheetToSheet)
         assert list(result) == [oid1, oid2]  # order is not preserved
 
@@ -134,8 +137,9 @@ class TestReference:
         oid1, oid2 = 1, 2
         mock_objectmap.targetids.return_value = [oid2, oid1]
         inst._objectmap = mock_objectmap
-        reference = Reference(source, ISheet, '', None)
-        result = inst._search(reference)
+        query = {'reference': Reference(source, ISheet, '', None),
+                 'traverse': False}
+        result = inst._search(query)
         mock_objectmap.targetids.assert_called_with(source, SheetToSheet)
         assert list(result) == [oid1, oid2]  # order is not preserver
 
@@ -171,7 +175,7 @@ class TestReference:
         mock_objectmap.sourceids.assert_called_with(target, SheetToSheet)
         assert list(result) == [oid2, oid1]
 
-    def test_apply_with_valid_query(self, mock_graph, mock_objectmap):
+    def test_apply(self, mock_graph, mock_objectmap):
         from adhocracy_core.interfaces import ISheet
         from adhocracy_core.interfaces import Reference
         from adhocracy_core.interfaces import SheetToSheet
@@ -186,7 +190,39 @@ class TestReference:
         result = inst.apply(query)
         assert list(result) == [1]
 
-    def test_apply_with_invalid_query(self):
+    def test_apply_without_traverse(self, mock_graph, mock_objectmap):
+        from adhocracy_core.interfaces import ISheet
+        from adhocracy_core.interfaces import Reference
+        from adhocracy_core.interfaces import SheetToSheet
+        mock_objectmap.sourceids.return_value = set([1])
+        inst = self.make_one()
+        inst._objectmap = mock_objectmap
+        mock_graph.get_reftypes.return_value = [(ISheet, '', SheetToSheet)]
+        inst.__graph__ = mock_graph
+        target = testing.DummyResource()
+        reference = Reference(None, ISheet, '', target)
+        query = {'reference': reference,
+                 'traverse': False}
+        result = inst.apply(query)
+        assert list(result) == [1]
+
+    def test_apply_with_traverse(self, mock_graph, mock_objectmap):
+        from adhocracy_core.interfaces import ISheet
+        from adhocracy_core.interfaces import Reference
+        from adhocracy_core.interfaces import SheetToSheet
+        mock_objectmap.sourceids.side_effect = [{1, 2}, {12}]
+        inst = self.make_one()
+        inst._objectmap = mock_objectmap
+        mock_graph.get_reftypes.return_value = [(ISheet, '', SheetToSheet)]
+        inst.__graph__ = mock_graph
+        target = testing.DummyResource()
+        reference = Reference(None, ISheet, '', target)
+        query = {'reference': reference,
+                 'traverse': True}
+        result = inst.apply(query)
+        assert list(result) == [1, 2, 12]
+
+    def test_apply_raise_if_invalid_query(self):
         inst = self.make_one()
         query = {'WRONG': ''}
         with raises(KeyError):
@@ -210,11 +246,14 @@ class TestReference:
     def test_eq(self):
         from adhocracy_core.interfaces import ISheet
         from adhocracy_core.interfaces import Reference
+        from hypatia.query import Eq
         inst = self.make_one()
         target = testing.DummyResource()
         reference = Reference(None, ISheet, '', target)
-        result = inst.eq(reference)
-        assert result._value == {'reference': reference}
+        query = {'reference': reference}
+        result = inst.eq(query)
+        assert isinstance(result, Eq)
+        assert result._value == query
 
     def test_apply_all(self):
         from adhocracy_core.interfaces import ISheet

--- a/src/adhocracy_core/adhocracy_core/catalog/test_index.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_index.py
@@ -27,7 +27,6 @@ class TestField:
         assert [x for x in inst.sort([0, 3, 1])] == [0, 1, 3]
 
 
-
 class TestReference:
 
     @fixture
@@ -198,7 +197,6 @@ class TestReference:
         import BTrees
         from adhocracy_core.interfaces import ISheet
         from adhocracy_core.interfaces import Reference
-        from adhocracy_core.graph import ObjectMap
         mock_objectmap.sourceids.return_value = set()
         inst = self.make_one()
         inst._mock_objectmap = mock_objectmap

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -555,6 +555,23 @@ def remove_tag_resources(root):  # pragma: no cover
                         'FIRST': item[first_version]})
 
 
+@log_migration
+def set_comment_count(root):  # pragma: no cover
+    """Set comment_count for all ICommentables."""
+    from adhocracy_core.resources.subscriber import _update_comments_count
+    registry = get_current_registry(root)
+    catalogs = find_service(root, 'catalogs')
+    query = search_query._replace(interfaces=ICommentVersion,
+                                  only_visible=True,
+                                  resolve=True)
+    comment_versions = catalogs.search(query).elements
+    count = len(comment_versions)
+    for index, comment in enumerate(comment_versions):
+        logger.info('Set comment_count for resource {0} of {1}'
+                    .format(index + 1, count))
+        _update_comments_count(comment, 1, registry)
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -579,3 +596,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(update_asset_download_children)
     config.add_evolution_step(recreate_all_image_size_downloads)
     config.add_evolution_step(remove_tag_resources)
+    config.add_evolution_step(set_comment_count)

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -558,7 +558,7 @@ def remove_tag_resources(root):  # pragma: no cover
 @log_migration
 def set_comment_count(root):  # pragma: no cover
     """Set comment_count for all ICommentables."""
-    from adhocracy_core.resources.subscriber import _update_comments_count
+    from adhocracy_core.resources.subscriber import update_comments_count
     registry = get_current_registry(root)
     catalogs = find_service(root, 'catalogs')
     query = search_query._replace(interfaces=ICommentVersion,
@@ -569,7 +569,7 @@ def set_comment_count(root):  # pragma: no cover
     for index, comment in enumerate(comment_versions):
         logger.info('Set comment_count for resource {0} of {1}'
                     .format(index + 1, count))
-        _update_comments_count(comment, 1, registry)
+        update_comments_count(comment, 1, registry)
 
 
 def includeme(config):  # pragma: no cover

--- a/src/adhocracy_core/adhocracy_core/evolution/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/test_init.py
@@ -101,7 +101,8 @@ class TestMigrateNewSheet:
             elements=[context])
         self.call_fut(context, IResource, ISheetA)
         assert ISheetA.providedBy(context)
-        search_query = query._replace(interfaces=(IResource))
+        search_query = query._replace(interfaces=(IResource),
+                                      resolve=True)
         assert mock_catalogs.search.call_args[0][0] == search_query
 
     def test_remove_old_isheet(self, context, mock_catalogs, search_result):
@@ -177,7 +178,8 @@ class TestChangeIResource:
         self.call_fut(context, IResource, IResourceA)
         assert [x for x in old.__provides__] == [IResourceA, ISheetA]
         assert mock_catalogs.search.call_args[0][0] == \
-               query._replace(interfaces=IResource)
+               query._replace(interfaces=IResource,
+                              resolve=True)
         assert mock_catalogs.reindex_index.call_args[0] == (old, 'interfaces')
 
 
@@ -274,7 +276,8 @@ class TestMigrateToAttributeStorageSheet:
             self, context, mock_catalogs, search_result, registry, query):
         mock_catalogs.search.return_value = search_result._replace(elements=[])
         self.call_fut(context, ISheet)
-        search_query = query._replace(interfaces=ISheet)
+        search_query = query._replace(interfaces=ISheet,
+                                      resolve=True)
         assert mock_catalogs.search.call_args[0][0] == search_query
 
     def test_ignore_if_resources_with_sheet_but_no_annotation_data(

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -561,12 +561,6 @@ class Comparator(Enum):
     """Comparators for search query parameters."""
 
 
-class ReferenceComparator(Comparator):
-    """Comparators for :class:`adhocracy_core.catalog.index.ReferenceIndex`."""
-
-    eq = 'eq'
-
-
 class FieldComparator(Comparator):
     """Comparators for :class:`hypatia.field.FieldIndex` search index."""
 
@@ -605,6 +599,16 @@ class KeywordSequenceComparator(Comparator):
     notany = 'notany'
 
 
+class ReferenceComparator(Comparator):
+    """Comparators for :class:`adhocracy_core.catalog.index.Reference` index.
+
+    These comparators need to be combined with a
+    :class:`adhocracy_core.interfaces.Reference`. value
+    """
+
+    traverse = 'traverse'
+
+
 class SearchQuery(namedtuple('Query', ['interfaces',
                                        'indexes',
                                        'references',
@@ -636,12 +640,15 @@ class SearchQuery(namedtuple('Query', ['interfaces',
         Available indexes are defined in
         :class:`adhocracy_core.catalog.adhocracy`
         Available :class:`SearchComparator`s depend on the index type.
-    references (Reference):
+    references (Reference or (ReferenceComparator.traverse, Reference)):
         References with (source, isheet, isheet_field, target).
         If `source` is None search for resources referencing target
         (back references).
         If `target` is None search for resources referenced by source
         (reference).
+        If the tuple (ReferenceComparator.traverse, Reference) is given,
+        the resource graph is traversed following all references with the same
+        type as the given Reference)
     root (IResource):
        root resource to start searching  in descendants
     depth (int):

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -130,13 +130,15 @@ class IResourceSheet(IPropertySheet):  # pragma: no cover
             omit=(),
             send_event=True,
             request=None,
+            send_reference_event=True,
             omit_readonly=True) -> bool:
         """Store ``appstruct`` dictionary data.
 
-        :param send_event: throw edit event.
+        :param send_event: raise resource sheet edited event.
         :param request: the current pyramid request for additional permission
                         checks, may be None.
         :param omit_readonly: do not store readonly ``appstruct`` data.
+        :param send_reference_event: raise backreference added/removed events.
         """
 
     def get(params: dict={}, add_back_references=True) -> dict:

--- a/src/adhocracy_core/adhocracy_core/resources/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/subscriber.py
@@ -297,7 +297,7 @@ def decrease_comments_count(event):
     update_comments_count(comment_version, -1, event.registry)
 
 
-def update_comments_count_after_visiblity_change(event):
+def update_comments_count_after_visibility_change(event):
     """Update comments_count in lineage after visibility change."""
     visibility = get_visibility_change(event)
     if visibility == VisibilityChange.concealed:
@@ -383,7 +383,7 @@ def includeme(config):
     config.add_subscriber(decrease_comments_count,
                           ISheetBackReferenceRemoved,
                           event_isheet=ICommentable)
-    config.add_subscriber(update_comments_count_after_visiblity_change,
+    config.add_subscriber(update_comments_count_after_visibility_change,
                           IResourceSheetModified,
                           object_iface=IComment,
                           event_isheet=IMetadata)

--- a/src/adhocracy_core/adhocracy_core/resources/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/subscriber.py
@@ -20,7 +20,12 @@ from adhocracy_core.interfaces import ISheet
 from adhocracy_core.interfaces import IResourceCreatedAndAdded
 from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
 from adhocracy_core.interfaces import ISheetReferenceNewVersion
+from adhocracy_core.interfaces import ISheetBackReferenceAdded
+from adhocracy_core.interfaces import ISheetBackReferenceRemoved
 from adhocracy_core.interfaces import IResourceSheetModified
+from adhocracy_core.interfaces import VisibilityChange
+from adhocracy_core.interfaces import search_query
+from adhocracy_core.interfaces import ReferenceComparator
 from adhocracy_core.resources.principal import IGroup
 from adhocracy_core.resources.principal import IUser
 from adhocracy_core.resources.principal import IPasswordReset
@@ -28,6 +33,8 @@ from adhocracy_core.resources.asset import add_metadata
 from adhocracy_core.resources.asset import IAsset
 from adhocracy_core.resources.image import add_image_size_downloads
 from adhocracy_core.resources.image import IImage
+from adhocracy_core.resources.comment import IComment
+from adhocracy_core.resources.comment import ICommentVersion
 from adhocracy_core.sheets.principal import IPermissions
 from adhocracy_core.sheets.tags import ITags
 from adhocracy_core.exceptions import AutoUpdateNoForkAllowedError
@@ -38,10 +45,14 @@ from adhocracy_core.utils import get_sheet_field
 from adhocracy_core.utils import get_iresource
 from adhocracy_core.utils import get_modification_date
 from adhocracy_core.utils import get_user
+from adhocracy_core.utils import get_visibility_change
 from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.sheets.metadata import IMetadata
 from adhocracy_core.sheets.asset import IAssetData
-
+from adhocracy_core.sheets.comment import ICommentable
+from adhocracy_core.sheets.versions import IVersions
+from adhocracy_core.sheets.subresources import ISubResources
+from adhocracy_core import sheets
 
 logger = getLogger(__name__)
 
@@ -275,6 +286,77 @@ def update_image_downloads(event):
     add_image_size_downloads(event.object, event.registry)
 
 
+def increase_comments_count(event):
+    """Increase comments_count for commentables in :term:`lineage`."""
+    comment_version = event.reference.source
+    update_comments_count(comment_version, 1, event.registry)
+
+
+def decrease_comments_count(event):
+    """Decrease comments_count for commentables in :term:`lineage`."""
+    comment_version = event.reference.source
+    update_comments_count(comment_version, -1, event.registry)
+
+
+def update_comments_count_after_visiblity_change(event):
+    """Update comments_count in lineage after visiblity change."""
+    visibility = get_visibility_change(event)
+    if visibility == VisibilityChange.concealed:
+        delta = -1
+    elif visibility == VisibilityChange.revealed:
+        delta = 1
+    else:
+        delta = 0
+    if delta != 0:
+        versions = get_sheet_field(event.object, IVersions, 'elements',
+                                   registry=event.registry)
+        for version in versions:
+            update_comments_count(version, delta, event.registry)
+
+
+def update_comments_count(resource: ICommentVersion,
+                          delta: int,
+                          registry: Registry):
+    """Update all commentable resources related to `resource`.
+
+    Traverse all commentable resources that have a IComment or ISubresource
+    reference to `resource` and update the comment_count value with `delta`.
+
+    Example reference structure that is traversed:
+
+    Main -ISubResources-> Sub <-IComment- Comment <- IComment- SubComment
+    """
+    catalogs = find_service(resource, 'catalogs')
+    traverse = ReferenceComparator.traverse.value
+    query = search_query._replace(
+        only_visible=True,
+        references=((traverse,
+                     (resource, sheets.comment.IComment, '', None)),
+                    ),
+        resolve=True,
+    )
+    commentables = catalogs.search(query).elements
+    main_resources = []
+    maybe_subresources = [x for x in commentables
+                          if not ICommentVersion.providedBy(x)]
+    for maybe_subresource in maybe_subresources:
+        query = search_query._replace(
+            only_visible=True,
+            references=((traverse,
+                         (None, ISubResources, '', maybe_subresource)),
+                        ),
+            interfaces=ICommentable,
+            resolve=True,
+        )
+        main_resources = catalogs.search(query).elements
+    for commentable in commentables + main_resources:
+        commentable_sheet = registry.content.get_sheet(commentable,
+                                                       ICommentable)
+        old_count = commentable_sheet.get()['comments_count']
+        commentable_sheet.set({'comments_count': old_count + delta},
+                              omit_readonly=False)
+
+
 def includeme(config):
     """Register subscribers."""
     config.add_subscriber(autoupdate_versionable_has_new_version,
@@ -309,3 +391,13 @@ def includeme(config):
                           IResourceSheetModified,
                           object_iface=IImage,
                           event_isheet=IAssetData)
+    config.add_subscriber(increase_comments_count,
+                          ISheetBackReferenceAdded,
+                          event_isheet=ICommentable)
+    config.add_subscriber(decrease_comments_count,
+                          ISheetBackReferenceRemoved,
+                          event_isheet=ICommentable)
+    config.add_subscriber(update_comments_count_after_visiblity_change,
+                          IResourceSheetModified,
+                          object_iface=IComment,
+                          event_isheet=IMetadata)

--- a/src/adhocracy_core/adhocracy_core/resources/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_subscriber.py
@@ -516,13 +516,141 @@ class TestUpdateImageDownload:
         from . import subscriber
         mock = mocker.patch.object(subscriber, 'add_image_size_downloads')
         self.call_fut(event)
-        mock.assert_called_with(event.object, event.registry)
+        assert mock.called_with(event.object, event.registry)
 
 
-@fixture()
-def integration(config):
-    config.include('adhocracy_core.events')
-    config.include('adhocracy_core.resources.subscriber')
+def test_increase_count(mocker, event):
+    from . import subscriber
+    event.reference = Mock()
+    mock = mocker.patch.object(subscriber, 'update_comments_count')
+    subscriber.increase_comments_count(event)
+    mock.assert_called_with(event.reference.source, 1, event.registry)
+
+
+def test_decrease_count(mocker, event):
+    from . import subscriber
+    event.reference = Mock()
+    mock = mocker.patch.object(subscriber, 'update_comments_count')
+    subscriber.decrease_comments_count(event)
+    mock.assert_called_with(event.reference.source, -1, event.registry)
+
+
+@fixture
+def mock_commentable_sheet(event, registry, mock_sheet):
+    event.registry = registry
+    registry.content.get_sheet.return_value = mock_sheet
+    mock_sheet.get.return_value = {'comments_count': 1}
+    return mock_sheet
+
+
+class TestUpdateCommentsCount:
+
+    def call_fut(self, *args):
+        from .subscriber import update_comments_count
+        return update_comments_count(*args)
+
+    def _make_resource(self, parent, iresource, registry):
+        return registry.content.create(iresource.__identifier__,
+                                       parent=parent,
+                                       appstructs={},
+                                       send_event=False,
+                                       )
+
+    def _get_comments_count(self, resource):
+        from adhocracy_core.utils import get_sheet_field
+        from adhocracy_core.sheets.comment import ICommentable
+        comments_count = get_sheet_field(resource,
+                                         ICommentable,
+                                         'comments_count')
+        return comments_count
+
+    def test_call(self, registry, pool_with_catalogs, service):
+        from adhocracy_core.resources.comment import ICommentVersion
+        from adhocracy_core.resources.paragraph import IParagraphVersion
+        from adhocracy_core.resources.document import IDocumentVersion
+        from adhocracy_core.resources.rate import IRateVersion
+        from adhocracy_core import sheets
+        from adhocracy_core.utils import get_sheet
+        pool = pool_with_catalogs
+        pool['comments'] = service  # the IComment sheet needs a post pool
+        comment1 = self._make_resource(pool, ICommentVersion, registry)
+        comment2 = self._make_resource(pool, ICommentVersion, registry)
+        comment3 = self._make_resource(pool, ICommentVersion, registry)
+        non_commentable = self._make_resource(pool, IRateVersion, registry)
+        sub_commentable = self._make_resource(pool, IParagraphVersion, registry)
+        main_commentable = self._make_resource(pool, IDocumentVersion, registry)
+
+        sheet = get_sheet(main_commentable, sheets.document.IDocument)
+        sheet.set({'elements': [sub_commentable]}, send_reference_event=False)
+        sheet = get_sheet(non_commentable, sheets.rate.IRate)
+        sheet.set({'object': [sub_commentable]}, send_reference_event=False)
+
+        sheet = get_sheet(comment3, sheets.comment.IComment)
+        sheet.set({'refers_to': sub_commentable}, send_reference_event=False)
+        sheet = get_sheet(comment2, sheets.comment.IComment)
+        sheet.set({'refers_to': comment3}, send_reference_event=False)
+        sheet = get_sheet(comment1, sheets.comment.IComment)
+        sheet.set({'refers_to': comment2}, send_reference_event=False)
+
+        self.call_fut(comment1, 1, registry)
+        self.call_fut(comment2, 1, registry)
+        self.call_fut(comment3, 1, registry)
+
+        assert self._get_comments_count(comment1) == 0
+        assert self._get_comments_count(comment2) == 1
+        assert self._get_comments_count(comment3) == 2
+        assert self._get_comments_count(sub_commentable) == 3
+        assert self._get_comments_count(main_commentable) == 3
+
+
+class TestUpdateCommentsCountAfterVisibilityChange:
+
+    @fixture
+    def mock_versions_sheet(self, mock_sheet, registry):
+        registry.content.get_sheet.return_value = mock_sheet
+        return mock_sheet
+
+    @fixture
+    def mock_update(self, mocker):
+        from . import subscriber
+        return mocker.patch.object(subscriber, 'update_comments_count')
+
+    def call_fut(self, *args):
+        from .subscriber import update_comments_count_after_visiblity_change
+        return update_comments_count_after_visiblity_change(*args)
+
+    def test_ignore_if_visible(self, mocker, registry, event, mock_update):
+        from adhocracy_core.interfaces import VisibilityChange
+        from . import subscriber
+        event.registry = registry
+        mock_visibility = mocker.patch.object(subscriber, 'get_visibility_change')
+        mock_visibility.return_value = VisibilityChange.visible
+        self.call_fut(event)
+        assert not mock_update.called
+
+    def test_decrease_count_if_consealed(self, mocker, registry, event,
+                                         mock_update, mock_versions_sheet):
+        from adhocracy_core.interfaces import VisibilityChange
+        from . import subscriber
+        event.registry = registry
+        comment_v0 = testing.DummyResource()
+        mock_versions_sheet.get.return_value = {'elements': [comment_v0]}
+        mock_visibility = mocker.patch.object(subscriber, 'get_visibility_change')
+        mock_visibility.return_value = VisibilityChange.concealed
+        self.call_fut(event)
+        assert mock_update.called_with(comment_v0, -1, event.registry)
+
+    def test_increase_count_if_revealed(self, mocker, registry, event,
+                                        mock_update, mock_versions_sheet):
+        from adhocracy_core.interfaces import VisibilityChange
+        from . import subscriber
+        event.registry = registry
+        comment_v0 = testing.DummyResource()
+        mock_versions_sheet.get.return_value = {'elements': [comment_v0]}
+        mock_visibility = mocker.patch.object(subscriber, 'get_visibility_change')
+        mock_visibility.return_value = VisibilityChange.revealed
+        self.call_fut(event)
+        assert mock_update.called_with(comment_v0, 1, event.registry)
 
 
 @mark.usefixtures('integration')
@@ -537,5 +665,8 @@ def test_register_subscriber(registry):
     assert subscriber.send_activation_mail_or_activate_user.__name__ in handlers
     assert subscriber.update_asset_download.__name__ in handlers
     assert subscriber.update_image_downloads.__name__ in handlers
+    assert subscriber.decrease_comments_count.__name__ in handlers
+    assert subscriber.increase_comments_count.__name__ in handlers
+    assert subscriber.update_comments_count_after_visiblity_change.__name__ in handlers
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_subscriber.py
@@ -616,8 +616,8 @@ class TestUpdateCommentsCountAfterVisibilityChange:
         return mocker.patch.object(subscriber, 'update_comments_count')
 
     def call_fut(self, *args):
-        from .subscriber import update_comments_count_after_visiblity_change
-        return update_comments_count_after_visiblity_change(*args)
+        from .subscriber import update_comments_count_after_visibility_change
+        return update_comments_count_after_visibility_change(*args)
 
     def test_ignore_if_visible(self, mocker, registry, event, mock_update):
         from adhocracy_core.interfaces import VisibilityChange
@@ -667,6 +667,6 @@ def test_register_subscriber(registry):
     assert subscriber.update_image_downloads.__name__ in handlers
     assert subscriber.decrease_comments_count.__name__ in handlers
     assert subscriber.increase_comments_count.__name__ in handlers
-    assert subscriber.update_comments_count_after_visiblity_change.__name__ in handlers
+    assert subscriber.update_comments_count_after_visibility_change.__name__ in handlers
 
 

--- a/src/adhocracy_core/adhocracy_core/sheets/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/__init__.py
@@ -159,6 +159,7 @@ class BaseResourceSheet:
             omit=(),
             send_event=True,
             request: Request=None,
+            send_reference_event=True,
             omit_readonly: bool=True) -> bool:
         """Store appstruct."""
         appstruct_old = self.get(add_back_references=False)
@@ -166,7 +167,8 @@ class BaseResourceSheet:
         if omit_readonly:
             appstruct = self._omit_readonly_keys(appstruct)
         self._store_data(appstruct)
-        self._store_references(appstruct, self.registry)
+        self._store_references(appstruct, self.registry,
+                               send_event=send_reference_event)
         if send_event:
             event = ResourceSheetModified(self.context,
                                           self.meta.isheet,
@@ -190,14 +192,15 @@ class BaseResourceSheet:
         """Store data appstruct."""
         raise NotImplementedError
 
-    def _store_references(self, appstruct, registry):
+    def _store_references(self, appstruct, registry, send_event=True):
         """Might be overridden in subclasses."""
         if not self._graph:
             return  # ease testing
         self._graph.set_references_for_isheet(self.context,
                                               self.meta.isheet,
                                               appstruct,
-                                              registry)
+                                              registry,
+                                              send_event=send_event)
 
     def get_cstruct(self, request: Request, params: dict=None):
         """Return cstruct data.

--- a/src/adhocracy_core/adhocracy_core/sheets/comment.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/comment.py
@@ -1,13 +1,16 @@
 """Comment sheet."""
+from BTrees.Length import Length
 import colander
 
 from adhocracy_core.interfaces import ISheet
 from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
 from adhocracy_core.interfaces import SheetToSheet
+from adhocracy_core.schema import Integer
 from adhocracy_core.schema import PostPool
 from adhocracy_core.schema import Reference
 from adhocracy_core.schema import Text
 from adhocracy_core.schema import UniqueReferences
+from adhocracy_core.sheets import AnnotationRessourceSheet
 from adhocracy_core.sheets import add_sheet_to_registry
 from adhocracy_core.sheets import sheet_meta
 
@@ -50,15 +53,51 @@ class CommentableSchema(colander.MappingSchema):
     `post_pool`: Pool to post new :class:`adhocracy_sample.resource.IComment`.
     """
 
+    comments_count = Integer(readonly=True)
+
     comments = UniqueReferences(readonly=True,
                                 backref=True,
                                 reftype=CommentRefersToReference)
     post_pool = PostPool(iresource_or_service_name='comments')
 
 
+class CommentableSheet(AnnotationRessourceSheet):
+    """Resource Sheet that stores data in dictionary annotation."""
+
+    _count_field_name = 'comments_count'
+
+    def _get_data_appstruct(self) -> dict:
+        """Get data appstruct.
+
+        `comments_count` value is converted from :class:`Btrees.Length` to int.
+        """
+        appstruct = super()._get_data_appstruct()
+        if self._count_field_name in appstruct:
+            counter = appstruct[self._count_field_name]
+            appstruct[self._count_field_name] = counter.value
+        return appstruct
+
+    def _store_data(self, appstruct: dict):
+        """Store data appstruct.
+
+        `comments_count` value is converted from int to :class:`Btrees.Length`,
+        to support ZODB conflict resultion.
+        """
+        if self._count_field_name in appstruct:
+            data = getattr(self.context, self._annotation_key, {})
+            if self._count_field_name not in data:
+                counter = Length(0)
+            else:
+                counter = data[self._count_field_name]
+            count = appstruct[self._count_field_name]
+            counter.set(count)
+            appstruct[self._count_field_name] = counter
+        super()._store_data(appstruct)
+
 commentable_meta = sheet_meta._replace(
     isheet=ICommentable,
     schema_class=CommentableSchema,
+    sheet_class=CommentableSheet,
     editable=False,
     creatable=False,
 )

--- a/src/adhocracy_core/adhocracy_core/sheets/comment.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/comment.py
@@ -4,12 +4,12 @@ import colander
 from adhocracy_core.interfaces import ISheet
 from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
 from adhocracy_core.interfaces import SheetToSheet
-from adhocracy_core.sheets import add_sheet_to_registry
-from adhocracy_core.schema import UniqueReferences
-from adhocracy_core.schema import Reference
-from adhocracy_core.sheets import sheet_meta
-from adhocracy_core.schema import Text
 from adhocracy_core.schema import PostPool
+from adhocracy_core.schema import Reference
+from adhocracy_core.schema import Text
+from adhocracy_core.schema import UniqueReferences
+from adhocracy_core.sheets import add_sheet_to_registry
+from adhocracy_core.sheets import sheet_meta
 
 
 class IComment(ISheet, ISheetReferenceAutoUpdateMarker):

--- a/src/adhocracy_core/adhocracy_core/sheets/document.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/document.py
@@ -6,11 +6,12 @@ from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
 from adhocracy_core.interfaces import SheetToSheet
 from adhocracy_core.sheets import sheet_meta
 from adhocracy_core.sheets import add_sheet_to_registry
+from adhocracy_core.sheets.subresources import ISubResources
 from adhocracy_core.schema import UniqueReferences
 from adhocracy_core.schema import Text
 
 
-class IDocument(ISheet, ISheetReferenceAutoUpdateMarker):
+class IDocument(ISubResources):
     """Marker interface for the document sheet."""
 
 

--- a/src/adhocracy_core/adhocracy_core/sheets/principal.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/principal.py
@@ -183,8 +183,8 @@ class PermissionsSchema(colander.MappingSchema):
 class PermissionsAttributeResourceSheet(AttributeResourceSheet):
     """Store the groups field references also as object attribute."""
 
-    def _store_references(self, appstruct, registry):
-        super()._store_references(appstruct, registry)
+    def _store_references(self, appstruct, registry, **kwargs):
+        super()._store_references(appstruct, registry, **kwargs)
         if 'groups' in appstruct:  # pragma: no branch
             groups = appstruct['groups']
             group_ids = [resource_path(g) for g in groups]

--- a/src/adhocracy_core/adhocracy_core/sheets/rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/rate.py
@@ -1,6 +1,7 @@
 """Rate sheet."""
-from pyramid.traversal import resource_path
-from substanced.util import find_catalog
+from pyramid.traversal import find_interface
+from pyramid.registry import Registry
+from substanced.util import find_service
 from zope.interface import implementer
 import colander
 
@@ -8,6 +9,7 @@ from adhocracy_core.interfaces import ISheet
 from adhocracy_core.interfaces import IPredicateSheet
 from adhocracy_core.interfaces import IRateValidator
 from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
+from adhocracy_core.interfaces import search_query
 from adhocracy_core.interfaces import SheetToSheet
 from adhocracy_core.interfaces import Reference
 from adhocracy_core.sheets import add_sheet_to_registry
@@ -18,6 +20,7 @@ from adhocracy_core.schema import UniqueReferences
 from adhocracy_core.schema import PostPool
 from adhocracy_core.sheets import sheet_meta
 from adhocracy_core.utils import get_user
+from adhocracy_core.utils import get_sheet_field
 
 
 class IRate(IPredicateSheet, ISheetReferenceAutoUpdateMarker):
@@ -100,59 +103,77 @@ class RateSchema(colander.MappingSchema):
     object = ReferenceSchema(reftype=RateObjectReference)
     rate = Integer()
 
-    def validator(self, node, value):
-        """
-        Validate the rate.
-
-        1. Validate that the subject is the user who is currently logged-in.
-
-        2. Ensure that no other rate for the same subject/object combination
-           exists, except predecessors of this version.
-
-        3. Ask the validator registered for *object* whether *rate* is valid.
-           In this way, `IRateable` subclasses can modify the range of allowed
-           ratings by registering their own `IRateValidator` adapter.
-        """
-        # TODO make this validator deferred
+    @colander.deferred
+    def validator(self, kw: dict) -> callable:
+        """Validate the rate."""
         # TODO add post_pool validator
-        request = node.bindings['request']
-        self._validate_subject_is_current_user(node, value, request)
-        self._ensure_rate_is_unique(node, value, request)
-        self._query_registered_object_validator(node, value, request)
+        context = kw['context']
+        request = kw.get('request', None)
+        if request is None:
+            return
+        registry = request.registry
+        return colander.All(create_validate_rate_value(registry),
+                            create_validate_subject(request),
+                            create_validate_is_unique(context, registry),
+                            )
 
-    def _validate_subject_is_current_user(self, node, value, request):
+
+def create_validate_subject(request) -> callable:
+    """Create validator to ensure value['subject'] is current user."""
+    def validator(node, value):
         user = get_user(request)
         if user is None or user != value['subject']:
-            err = colander.Invalid(node)
+            err = colander.Invalid(node,
+                                   msg='')  # msg='' workaround colander bug
             err['subject'] = 'Must be the currently logged-in user'
             raise err
+    return validator
 
-    def _ensure_rate_is_unique(self, node, value, request):
-        # Other rates with the same subject and object may occur below the
-        # current context (earlier versions of the same rate item).
-        # If they occur elsewhere, an error is thrown.
-        adhocracy_catalog = find_catalog(request.context, 'adhocracy')
-        index = adhocracy_catalog['reference']
-        reference_subject = Reference(None, IRate, 'subject', value['subject'])
-        query = index.eq(reference_subject)
-        reference_object = Reference(None, IRate, 'object', value['object'])
-        query &= index.eq(reference_object)
-        system_catalog = find_catalog(request.context, 'system')
-        path_index = system_catalog['path']
-        query &= path_index.noteq(resource_path(request.context), depth=None)
-        elements = query.execute(resolver=None)
-        if elements:
-            err = colander.Invalid(node)
-            err['object'] = 'Another rate by the same user already exists'
-            raise err
 
-    def _query_registered_object_validator(self, node, value, request):
-        registry = request.registry
+def create_validate_is_unique(context, registry: Registry) -> callable:
+    """Create validatator to ensure rate version is unique.
+
+    Older rate versions with the same subject and object may occur.
+    If they belong to a different rate item an error is thrown.
+    """
+    from adhocracy_core.resources.rate import IRate as IRateItem
+    from adhocracy_core.sheets.versions import IVersions
+
+    def validator(node, value):
+        catalogs = find_service(context, 'catalogs')
+        query = search_query._replace(
+            references=(Reference(None, IRate, 'subject', value['subject']),
+                        Reference(None, IRate, 'object', value['object'])),
+            resolve=True,
+        )
+        same_rates = catalogs.search(query).elements
+        if not same_rates:
+            return
+        item = find_interface(context, IRateItem)
+        old_versions = get_sheet_field(item, IVersions, 'elements',
+                                       registry=registry)
+        for rate in same_rates:
+            if rate not in old_versions:
+                err = colander.Invalid(node, msg='')
+                err['object'] = 'Another rate by the same user already exists'
+                raise err
+    return validator
+
+
+def create_validate_rate_value(registry: Registry) -> callable:
+    """Create validator to validate value['rate'].
+
+    Ask the validator registered for *object* whether *rate* is valid.
+    In this way, `IRateable` subclasses can modify the range of allowed
+    ratings by registering their own `IRateValidator` adapter.
+    """
+    def validator(node, value):
         rate_validator = registry.getAdapter(value['object'], IRateValidator)
         if not rate_validator.validate(value['rate']):
-            err = colander.Invalid(node)
+            err = colander.Invalid(node, msg='')
             err['rate'] = rate_validator.helpful_error_message()
             raise err
+    return validator
 
 
 rate_meta = sheet_meta._replace(isheet=IRate,

--- a/src/adhocracy_core/adhocracy_core/sheets/subresources.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/subresources.py
@@ -1,0 +1,12 @@
+"""Sheet interfaces to reference subresources."""
+from adhocracy_core.interfaces import ISheet
+from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
+
+
+class ISubResources(ISheet, ISheetReferenceAutoUpdateMarker):
+    """Meta Marker interface for the sheets that reference subresources.
+
+    For example references to document parts or form fields.
+    These are :term:``essence`` references, if the referenced Resource
+    has a new Version the referecing resource is also updated.
+    """

--- a/src/adhocracy_core/adhocracy_core/sheets/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_init.py
@@ -140,7 +140,8 @@ class TestBaseResourceSheet:
         inst.set({'references': [target]})
 
         mock_graph.set_references_for_isheet.assert_called_with(
-            context, ISheet, {'references': [target]}, registry)
+            context, ISheet, {'references': [target]}, registry,
+            send_event=True)
 
     def test_get_valid_back_references(self, inst, context, sheet_catalogs,
                                        mock_node_unique_references):
@@ -184,10 +185,19 @@ class TestBaseResourceSheet:
         node = mock_node_single_reference
         inst.schema.children.append(node)
         target = testing.DummyResource()
-        mock_graph.get_references_for_isheet.return_value = {}
         inst.set({'reference': target})
         graph_set_args = mock_graph.set_references_for_isheet.call_args[0]
         assert graph_set_args == (context, ISheet, {'reference': target}, registry)
+
+    def test_set_reference_without_send_events(
+            self, inst, context, mock_graph, mock_node_single_reference,
+            registry):
+        node = mock_node_single_reference
+        inst.schema.children.append(node)
+        target = testing.DummyResource()
+        inst.set({'reference': target})
+        graph_set_kwargs = mock_graph.set_references_for_isheet.call_args[1]
+        assert graph_set_kwargs == {'send_event': True}
 
     def test_get_reference(self, inst, context, sheet_catalogs,
                            mock_node_single_reference):

--- a/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
@@ -9,8 +9,6 @@ import colander
 from adhocracy_core.sheets.rate import IRateable
 
 
-
-
 @fixture
 def integration(config):
     config.include('adhocracy_core.content')
@@ -53,15 +51,18 @@ class TestRateSheet:
         from adhocracy_core.sheets.rate import rate_meta
         return rate_meta
 
-    def test_create(self, meta, context):
+    def test_meta(self, meta, context):
         from adhocracy_core.sheets.rate import IRate
         from adhocracy_core.sheets.rate import RateSchema
         from adhocracy_core.sheets import AttributeResourceSheet
-        inst = meta.sheet_class(meta, context)
         assert issubclass(meta.sheet_class, AttributeResourceSheet)
-        assert inst.meta.isheet == IRate
-        assert inst.meta.schema_class == RateSchema
-        assert inst.meta.create_mandatory
+        assert meta.isheet == IRate
+        assert meta.schema_class == RateSchema
+        assert meta.create_mandatory
+
+    def test_crete(self, meta, context):
+        inst = meta.sheet_class(meta, context)
+        assert inst
 
     def test_get_empty(self, meta, context):
         inst = meta.sheet_class(meta, context)
@@ -70,185 +71,171 @@ class TestRateSheet:
                               'rate': 0,
                               }
 
+    def test_validators(self, mocker, meta, context, request_):
+        from . import rate
+        inst = meta.sheet_class(meta, context)
+        validate_value = mocker.patch.object(rate, 'create_validate_rate_value')
+        validate_subject = mocker.patch.object(rate, 'create_validate_subject')
+        validate_unique = mocker.patch.object(rate,
+                                              'create_validate_is_unique')
+        bindings = {'context': context, 'request': request_}
 
-class DummyQuery:
+        validators = inst.schema.validator(inst.schema, bindings)
 
-    def __init__(self, result=[]):
-        self.result = result
+        validate_value.assert_called_with(request_.registry)
+        validate_subject.assert_called_with(request_)
+        validate_unique.assert_called_with(context, request_.registry)
 
-    def __iand__(self, other):
-        return self
-
-    def execute(self, **kwargs):
-        return self.result
-
-
-class DummyIndex:
-
-    def __init__(self, result=[]):
-        self.result = result
-
-    def eq(self, *args, **kwargs):
-        return DummyQuery(self.result)
-
-    def noteq(self, *args, **kwargs):
-        return DummyQuery(self.result)
+    @mark.usefixtures('integration')
+    def test_includeme_register(self, meta):
+        from adhocracy_core.utils import get_sheet
+        context = testing.DummyResource(__provides__=meta.isheet)
+        assert get_sheet(context, meta.isheet)
 
 
-@mark.usefixtures('integration')
-class TestRateSchema:
+class TestCreateValidateRateValue:
 
     @fixture
-    def schema_with_mock_ensure_rate(self, request_, context):
-        from adhocracy_core.sheets.rate import RateSchema
-        schema = RateSchema().bind(request=request_, context=context)
-        schema._ensure_rate_is_unique = Mock()
-        return schema
+    def registry(self, registry_with_content):
+        return registry_with_content
 
-    @fixture
-    def subject(self, monkeypatch):
-        from adhocracy_core.sheets import rate
-        from adhocracy_core.sheets.rate import ICanRate
-        subject = testing.DummyResource(__provides__=ICanRate)
-        mock_get_user = Mock(return_value=subject)
-        monkeypatch.setattr(rate, 'get_user', mock_get_user)
-        return subject
+    def call_fut(self, *args):
+        from .rate import create_validate_rate_value
+        return create_validate_rate_value(*args)
 
-    def test_deserialize_valid(self, context, schema_with_mock_ensure_rate,
-                               subject):
-        context['subject'] = subject
-        object = _make_rateable()
-        context['object'] = object
-        data = {'subject': '/subject', 'object': '/object', 'rate': '1'}
-        assert schema_with_mock_ensure_rate.deserialize(data) == {
-            'subject': subject, 'object': object, 'rate': 1}
+    def test_ignore_if_validation_passes(self, node, registry):
+        from pyramid.registry import Registry
+        from .rate import IRateValidator
+        mock_validator = Mock()
+        mock_validator.validate.return_value = True
+        registry.getAdapter = Mock(spec=Registry.getAdapter,
+                                   return_value=mock_validator)
+        object_ = testing.DummyResource()
+        validator = self.call_fut(registry)
 
-    def test_deserialize_valid_minus_one(self, context,
-                                         schema_with_mock_ensure_rate,
-                                         subject):
-        context['subject'] = subject
-        object = _make_rateable()
-        context['object'] = object
-        data = {'subject': '/subject', 'object': '/object', 'rate': '-1'}
-        assert schema_with_mock_ensure_rate.deserialize(data) == {
-            'subject': subject, 'object': object, 'rate': -1}
+        validator(node, {'object': object_,
+                         'rate': 1})
 
-    def test_deserialize_invalid_rate(self, context,
-                                      schema_with_mock_ensure_rate, subject):
-        context['subject'] = subject
-        object = _make_rateable()
-        context['object'] = object
-        data = {'subject': '/subject', 'object': '/object', 'rate': '77'}
+        mock_validator.validate.assert_called_with(1)
+        assert registry.getAdapter.call_args[0] == (object_, IRateValidator)
+
+    def test_raise_if_validation_not_passes(self, node, registry):
+        from pyramid.registry import Registry
+        mock_validator = Mock()
+        mock_validator.validate.return_value = False
+        registry.getAdapter = Mock(spec=Registry.getAdapter,
+                                   return_value=mock_validator)
+        object_ = testing.DummyResource()
+        validator = self.call_fut(registry)
         with raises(colander.Invalid):
-            schema_with_mock_ensure_rate.deserialize(data)
+            node['rate'] = Mock()  # needed create the Error
+            validator(node,
+                      {'object': object_,
+                       'rate': 'WRONG'})
 
-    def test_deserialize_invalid_subject(self, context,
-                                         schema_with_mock_ensure_rate):
+
+class TestCreateValidateSubject:
+
+    def call_fut(self, *args):
+        from .rate import create_validate_subject
+        return create_validate_subject(*args)
+
+    @fixture
+    def mock_get_user(self, mocker):
+        from . import rate
+        mock_get_user = mocker.patch.object(rate, 'get_user')
+        return mock_get_user
+
+    def test_ignore_if_subject_is_loggedin_user(self, node, request_, mock_get_user):
+        user = testing.DummyResource()
+        mock_get_user.return_value = user
+        validator = self.call_fut(request_)
+        assert validator(node, {'subject': user}) is None
+
+    def test_ignore_if_subject_is_not_loggedin_user(self, node, request_,
+                                                    mock_get_user):
+        user = testing.DummyResource()
+        mock_get_user.return_value = None
+        validator = self.call_fut(request_)
+        with raises(colander.Invalid):
+            node['subject'] = Mock()
+            validator(node,  {'subject': user})
+
+
+class TestCreateValidateIsUnique:
+
+    def call_fut(self, *args):
+        from .rate import create_validate_is_unique
+        return create_validate_is_unique(*args)
+
+    @fixture
+    def registry(self, registry_with_content):
+        return registry_with_content
+
+    @fixture
+    def mock_versions_sheet(self, registry, mock_sheet):
+        mock_sheet.get.return_value = {'elements': []}
+        registry.content.get_sheet = Mock(return_value=mock_sheet)
+        return mock_sheet
+
+    @fixture
+    def mock_catalogs(self, mock_catalogs, monkeypatch):
+        from . import rate
+        monkeypatch.setattr(rate, 'find_service', lambda x, y: mock_catalogs)
+        return mock_catalogs
+
+    def test_ignore_if_no_other_rates(self, node, context, registry, query,
+                                      mock_catalogs):
+        from adhocracy_core.interfaces import Reference
+        from .rate import IRate
         subject = testing.DummyResource()
-        context['subject'] = subject
-        object = _make_rateable()
-        context['object'] = object
-        data = {'subject': '/subject', 'object': '/object', 'rate': '0'}
+        object_ = testing.DummyResource()
+        value = {'subject': subject,
+                 'object': object_,
+                 'rate': '1'}
+        validator = self.call_fut(context, registry)
+        assert validator(node, value) is None
+        assert mock_catalogs.search.call_args[0][0] == query._replace(
+                references=(Reference(None, IRate, 'subject', subject),
+                            Reference(None, IRate, 'object', object_)),
+                resolve=True)
+
+    def test_ignore_if_some_but_older_versions(
+            self, node, context, registry, search_result, mock_catalogs,
+            mock_versions_sheet):
+        value = {'subject': testing.DummyResource(),
+                 'object': testing.DummyResource(),
+                 'rate': '1'}
+        old_version = testing.DummyResource()
+        mock_catalogs.search.return_value = search_result._replace(
+                elements=[old_version])
+        mock_versions_sheet.get.return_value = \
+            {'elements': [old_version]}
+        validator = self.call_fut(context, registry)
+        assert validator(node, value) is None
+
+    def test_raise_if_other_rates(
+            self, node, context, registry, search_result, mock_catalogs,
+            mock_versions_sheet):
+        value = {'subject': testing.DummyResource(),
+                 'object': testing.DummyResource(),
+                 'rate': '1'}
+        old_version = testing.DummyResource()
+        other_version = testing.DummyResource()
+        mock_catalogs.search.return_value = search_result._replace(
+                elements=[old_version, other_version])
+        mock_versions_sheet.get.return_value = \
+            {'elements': [old_version]}
+        validator = self.call_fut(context, registry)
         with raises(colander.Invalid):
-            schema_with_mock_ensure_rate.deserialize(data)
-
-    def test_deserialize_invalid_subject_missing(self, context,
-                                                 schema_with_mock_ensure_rate):
-        object = _make_rateable()
-        context['object'] = object
-        data = {'subject': '', 'object': '/object', 'rate': '0'}
-        with raises(colander.Invalid):
-            schema_with_mock_ensure_rate.deserialize(data)
-
-    def test_deserialize_subject_isnt_current_user(
-            self, context, monkeypatch, schema_with_mock_ensure_rate):
-        from adhocracy_core.sheets import rate
-        from adhocracy_core.sheets.rate import ICanRate
-        subject = testing.DummyResource(__provides__=ICanRate)
-        user = testing.DummyResource(__provides__=ICanRate)
-        mock_get_user = Mock(return_value=user)
-        monkeypatch.setattr(rate, 'get_user', mock_get_user)
-        context['subject'] = subject
-        object = _make_rateable()
-        context['object'] = object
-        data = {'subject': '/subject', 'object': '/object', 'rate': '0'}
-        with raises(colander.Invalid):
-            schema_with_mock_ensure_rate.deserialize(data)
-
-    def test_deserialize_invalid_object(self, context,
-                                        schema_with_mock_ensure_rate,
-                                        subject):
-        context['subject'] = subject
-        object = testing.DummyResource()
-        context['object'] = object
-        data = {'subject': '/subject', 'object': '/object', 'rate': '0'}
-        with raises(colander.Invalid):
-            schema_with_mock_ensure_rate.deserialize(data)
-
-    def test_deserialize_invalid_object_missing(self, context,
-                                        schema_with_mock_ensure_rate, subject):
-        context['subject'] = subject
-        data = {'subject': '/subject', 'object': '', 'rate': '0'}
-        with raises(colander.Invalid):
-            schema_with_mock_ensure_rate.deserialize(data)
-
-    def test_deserialize_valid_likeable(self, context,
-                                        schema_with_mock_ensure_rate,
-                                        subject):
-        from adhocracy_core.sheets.rate import ILikeable
-        context['subject'] = subject
-        object = _make_rateable(ILikeable)
-        context['object'] = object
-        data = {'subject': '/subject', 'object': '/object', 'rate': '1'}
-        assert schema_with_mock_ensure_rate.deserialize(data) == {
-            'subject': subject, 'object': object, 'rate': 1}
-
-    def test_deserialize_invalid_rate_with_likeable(
-            self, context, schema_with_mock_ensure_rate, subject):
-        from adhocracy_core.sheets.rate import ILikeable
-        context['subject'] = subject
-        object = _make_rateable(ILikeable)
-        context['object'] = object
-        data = {'subject': '/subject', 'object': '/object', 'rate': '-1'}
-        with raises(colander.Invalid):
-            schema_with_mock_ensure_rate.deserialize(data)
-
-    def test_ensure_rate_is_unique_ok(self, monkeypatch, request_,
-                                      context, subject):
-        from adhocracy_core.sheets.rate import RateSchema
-        from adhocracy_core.sheets import rate
-        mock_find_catalog = Mock(return_value={'reference': DummyIndex(),
-                                               'path': DummyIndex()})
-        monkeypatch.setattr(rate, 'find_catalog', mock_find_catalog)
-        schema = RateSchema().bind(request=request_, context=context)
-        object = _make_rateable()
-        node = Mock()
-        value = {'subject': subject, 'object': object, 'rate': '1'}
-        result = schema._ensure_rate_is_unique(node, value, request_)
-        assert result is None
-
-    def test_ensure_rate_is_unique_error(self, monkeypatch, request_,
-                                         context, subject):
-        from adhocracy_core.sheets.rate import RateSchema
-        from adhocracy_core.sheets import rate
-        from adhocracy_core.utils import named_object
-        mock_find_catalog = Mock(
-            return_value={'reference': DummyIndex(['dummy']),
-                          'path': DummyIndex()})
-        monkeypatch.setattr(rate, 'find_catalog', mock_find_catalog)
-        schema = RateSchema().bind(request=request_, context=context)
-        object = _make_rateable()
-        node = Mock()
-        node.children = [named_object('object')]
-        value = {'subject': subject, 'object': object, 'rate': '1'}
-        with raises(colander.Invalid):
-            schema._ensure_rate_is_unique(node, value, request_)
+            node['object'] = Mock()
+            validator(node, value)
 
 
 @mark.usefixtures('integration')
 class TestRateValidators:
 
-    def test_rateable_rate_validator(self, registry):
+    def test_validate_rateable_rate_validator(self, registry):
         from adhocracy_core.interfaces import IRateValidator
         rateable = _make_rateable()
         validator = registry.getAdapter(rateable, IRateValidator)
@@ -258,7 +245,7 @@ class TestRateValidators:
         assert validator.validate(2) is False
         assert validator.validate(-2) is False
 
-    def test_likeable_rate_validator(self, registry):
+    def test_validate_likeable_rate_validator(self, registry):
         from adhocracy_core.interfaces import IRateValidator
         from adhocracy_core.sheets.rate import ILikeable
         rateable = _make_rateable(ILikeable)
@@ -268,14 +255,10 @@ class TestRateValidators:
         assert validator.validate(-1) is False
         assert validator.validate(2) is False
 
-
-@mark.usefixtures('integration')
-def test_includeme_register_rate_sheet(config, context):
-    from adhocracy_core.sheets.rate import IRate
-    from adhocracy_core.utils import get_sheet
-    context = testing.DummyResource(__provides__=IRate)
-    inst = get_sheet(context, IRate)
-    assert inst.meta.isheet is IRate
-
-
-
+    def test_helpfull_error_message(self, registry):
+        from adhocracy_core.interfaces import IRateValidator
+        from adhocracy_core.sheets.rate import ILikeable
+        rateable = _make_rateable(ILikeable)
+        validator = registry.getAdapter(rateable, IRateValidator)
+        assert validator.helpful_error_message() == \
+               "rate must be one of (1, 0)"

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -1043,7 +1043,9 @@ multiple times::
     >>> resp_data['errors'][0]['name']
     'data.adhocracy_core.sheets.rate.IRate.object'
     >>> resp_data['errors'][0]['description']
-    'Another rate by the same user already exists'
+    '; Another rate by the same user already exists'
+
+ ...TODO: remove ';' suffix of error description, :mod:`colander` bug
 
 The *subject* of a rate must always be the user that is currently logged in --
 it's not possible to vote for other users::
@@ -1056,7 +1058,7 @@ it's not possible to vote for other users::
     >>> resp_data['errors'][0]['name']
     'data.adhocracy_core.sheets.rate.IRate.subject'
     >>> resp_data['errors'][0]['description']
-    'Must be the currently logged-in user'
+    '; Must be the currently logged-in user'
 
 
 Batch requests

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/subscriber.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/subscriber.py
@@ -1,5 +1,6 @@
 """Initialize Mercator ACM."""
 from pyramid.events import ApplicationCreated
+
 from adhocracy_core.authorization import set_acms_for_app_root
 from adhocracy_core.resources.root import root_acm
 from adhocracy_mercator.resources.root import mercator_acm

--- a/src/adhocracy_mercator/adhocracy_mercator/resources/test_subscriber.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/resources/test_subscriber.py
@@ -15,4 +15,3 @@ def test_set_root_acms(monkeypatch):
     set_root_acms(event)
     mock_set_acms.assert_called_with(event.app, (mercator_acm, root_acm))
 
-

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator.py
@@ -12,6 +12,7 @@ from adhocracy_core.sheets import workflow
 from adhocracy_core.sheets.image import IImageMetadata
 from adhocracy_core.sheets.image import ImageMetadataSchema
 from adhocracy_core.sheets.image import image_metadata_meta
+from adhocracy_core.sheets.subresources import ISubResources
 from adhocracy_core.schema import AdhocracySchemaNode
 from adhocracy_core.schema import Boolean
 from adhocracy_core.schema import CurrencyAmount
@@ -24,7 +25,7 @@ from adhocracy_core.schema import URL
 from adhocracy_core.schema import Resource
 
 
-class IMercatorSubResources(ISheet, ISheetReferenceAutoUpdateMarker):
+class IMercatorSubResources(ISubResources):
     """Marker interface for commentable subresources of MercatorProposal."""
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
@@ -2,7 +2,6 @@
 import colander
 
 from adhocracy_core.interfaces import ISheet
-from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
 from adhocracy_core.interfaces import SheetToSheet
 from adhocracy_core.schema import AdhocracySchemaNode
 from adhocracy_core.schema import Boolean
@@ -18,6 +17,7 @@ from adhocracy_core.schema import URL
 from adhocracy_core.schema import AdhocracySequenceNode
 from adhocracy_core.sheets import add_sheet_to_registry
 from adhocracy_core.sheets import sheet_meta
+from adhocracy_core.sheets.subresources import ISubResources
 
 
 class IUserInfo(ISheet):
@@ -490,7 +490,7 @@ winnerinfo_meta = sheet_meta._replace(
 )
 
 
-class IMercatorSubResources(ISheet, ISheetReferenceAutoUpdateMarker):
+class IMercatorSubResources(ISubResources):
     """Marker interface for commentable subresources of MercatorProposal."""
 
 

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -10,6 +10,7 @@ import * as AdhTopLevelState from "../../../TopLevelState/TopLevelState";
 
 import * as AdhMercator2015Proposal from "../../2015/Proposal/Proposal";
 
+import * as SICommentable from "../../../../Resources_/adhocracy_core/sheets/comment/ICommentable";
 import * as SIChallenge from "../../../../Resources_/adhocracy_mercator/sheets/mercator2/IChallenge";
 import * as SICommunity from "../../../../Resources_/adhocracy_mercator/sheets/mercator2/ICommunity";
 import * as SIConnectionCohesion from "../../../../Resources_/adhocracy_mercator/sheets/mercator2/IConnectionCohesion";
@@ -229,7 +230,7 @@ var fill = (data : IFormData, resource) => {
                     }
                     return result;
                 }, []),
-                other: data.topic.otherText
+                topic_other: data.topic.otherText
             });
             resource.data[SITitle.nick] = new SITitle.Sheet({
                 title: data.title
@@ -498,18 +499,18 @@ var get = (
                 // fixed in the backend.
                 commentCounts: {
                     proposal: 0,
-                    pitch: 0,
-                    partners: 0,
-                    duration: 0,
-                    challenge: 0,
-                    goal: 0,
-                    plan: 0,
-                    target: 0,
-                    team: 0,
-                    extrainfo: 0,
-                    connectioncohesion: 0,
-                    difference: 0,
-                    practicalrelevance: 0
+                    pitch: subs.pitch.data[SICommentable.nick].comments_count,
+                    partners: subs.partners.data[SICommentable.nick].comments_count,
+                    duration: subs.duration.data[SICommentable.nick].comments_count,
+                    challenge: subs.challenge.data[SICommentable.nick].comments_count,
+                    goal: subs.goal.data[SICommentable.nick].comments_count,
+                    plan: subs.plan.data[SICommentable.nick].comments_count,
+                    target: subs.target.data[SICommentable.nick].comments_count,
+                    team: subs.team.data[SICommentable.nick].comments_count,
+                    extrainfo: subs.extrainfo.data[SICommentable.nick].comments_count,
+                    connectioncohesion: subs.connectioncohesion.data[SICommentable.nick].comments_count,
+                    difference: subs.difference.data[SICommentable.nick].comments_count,
+                    practicalrelevance: subs.practicalrelevance.data[SICommentable.nick].comments_count
                 }
             };
         });

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -493,12 +493,8 @@ var get = (
                     difference: subs.difference.data[SIDifference.nick].difference,
                     practical: subs.practicalrelevance.data[SIPracticalRelevance.nick].practicalrelevance
                 },
-
-                // FIXME: It is not currently possible to get the
-                // recursive comment count of a subresource. Will be
-                // fixed in the backend.
                 commentCounts: {
-                    proposal: 0,
+                    proposal: proposal.data[SICommentable.nick].comments_count,
                     pitch: subs.pitch.data[SICommentable.nick].comments_count,
                     partners: subs.partners.data[SICommentable.nick].comments_count,
                     duration: subs.duration.data[SICommentable.nick].comments_count,


### PR DESCRIPTION
API Extensions:

- add field ICommentable:comment_count: 
 
  number of all comments referenced by ISubresource (IDocument/IMercator2Subresources) and       IComment references. Example traverse:
document -elements-> paragraph  <-referes_to- comment1 <-refers_to- comment2

  visiblity is checked but not view permissions

Internal Changes:

- refactor rate validation

- 'traverse' search comparator to so traveres all references of a given type starting by the given resource.

- 'send_reference_event' option for the sheet set method (defaults True) 
  (This is more like a workaround.  For testing I need to create References without raising IBacksheetAdded events. The exiting similar option 'send_event'  did not provided this, but fixing 
  this would be quite complicated)

Migration:

- short running migration script to set initial  'comment_count' field values


TODO: 

- [x]  Make the fronted use the new comment_count field for the Mercator2Proposal
