### PR TITLE
by default don't list elements of IServicePool (performance workaround)

### DIFF
--- a/src/adhocracy_core/adhocracy_core/sheets/pool.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/pool.py
@@ -6,6 +6,7 @@ import colander
 
 from adhocracy_core.interfaces import ISheet
 from adhocracy_core.interfaces import SheetToSheet
+from adhocracy_core.interfaces import IServicePool
 from adhocracy_core.sheets import AnnotationRessourceSheet
 from adhocracy_core.sheets import sheet_meta
 from adhocracy_core.sheets import add_sheet_to_registry
@@ -95,6 +96,9 @@ class PoolSheet(AnnotationRessourceSheet):
             add 'aggregateby` field. defaults to False.
         """
         params = params or {}
+        is_service_pool = IServicePool.providedBy(self.context)
+        has_no_custom_filters = params == {'depth': 1,
+                                           'root': self.context}
         filter_view_permission = asbool(self.registry.settings.get(
             'adhocracy.filter_by_view_permission', True))
         if filter_view_permission:
@@ -105,6 +109,10 @@ class PoolSheet(AnnotationRessourceSheet):
             params['only_visible'] = True
         params_query = remove_keys_from_dict(params, self._additional_params)
         appstruct = self.get(params=params_query)
+        if is_service_pool and has_no_custom_filters:
+            # workaround to reduce needless but expensive listing of elements
+            params['serialization_form'] = 'omit'
+            params['show_count'] = True
         if params.get('serialization_form', False) == 'omit':
             appstruct['elements'] = []
         if params.get('show_frequency', False):

--- a/src/adhocracy_core/adhocracy_core/sheets/test_pool.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_pool.py
@@ -104,6 +104,28 @@ class TestFilteringPoolSheet:
         cstruct = inst.get_cstruct(request_, params={'name': 'child'})
         assert 'name' in inst.get.call_args[1]['params']
 
+    def test_get_cstruct_of_service_pool_with_default_params(
+            self, inst, request_, service):
+        inst.get = Mock()
+        child = testing.DummyResource()
+        inst.get.return_value = {'elements': [child],
+                                 'count': 1}
+        inst.context = service
+        cstruct = inst.get_cstruct(request_, params={'root': inst.context,
+                                                     'depth': 1})
+        assert cstruct == {'elements': [],
+                           'count': '1'}
+
+    def test_get_cstruct_of_service_pool_with_params(self, inst, request_,
+                                                     service):
+        inst.get = Mock()
+        child = testing.DummyResource()
+        inst.get.return_value = {'elements': [child],
+                                 'count': 1}
+        inst.context = service
+        cstruct = inst.get_cstruct(request_, params={'name': 'child'})
+        assert cstruct == {'elements': ['http://example.com/']}
+
     def test_get_cstruct_filter_by_view_permission(self, inst, request_):
         inst.get = Mock()
         inst.get.return_value = {'elements': []}

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -1303,8 +1303,9 @@ any), but not for any further failed requests. The backend stops processing
 encoded requests once the first of them has failed, since further processing
 would probably only lead to further errors.
 
-Filtering Pools
----------------
+
+Filtering Pools / Search
+------------------------
 
 It's possible to filter and aggregate the information collected in pools by
 adding suitable GET parameters. For example, we can only retrieve children
@@ -1644,3 +1645,25 @@ will be 1 or higher. ::
     ...             'depth': 'all', 'aggregateby': 'tag'}).json
     >>> pprint(resp_data['data']['adhocracy_core.sheets.pool.IPool']['aggregateby'])
     {'tag': {'FIRST': 3, 'LAST': 3}}
+
+Service Pools
+-------------
+
+A :term:`service` pool is used to add many child resources, for example
+the :term:`post_pool` for comments or rates.
+By default it does not list the child elements but only the result_count:
+
+    >>> resp_data = testapp.get('/Documents/document_0000000/comments/').json
+    >>> pprint(resp_data['data']['adhocracy_core.sheets.pool.IPool'])
+    {'count': '3', 'elements': []}
+
+To list child elements you have to do search query and limit the number of
+listet result elements::
+
+    >>> resp_data = testapp.get('/Documents/document_0000000/comments',
+    ...     params={'limit': 10,
+    ...             'offset': 0,
+    ...             'elements': 'paths'}).json
+    >>> pprint(resp_data['data']['adhocracy_core.sheets.pool.IPool'])
+    {'elements': ['http://localhost...]}
+


### PR DESCRIPTION

API Change

- IServie pool like (../comments, ..../rates, ../users/ don't list elements by default.
 Instead the elements count is shown. If you need all resources do a search query, 
 and limit search results, for example with .` ../comments/?serialization_form=content&limit=10`

Part of https://github.com/liqd/adhocracy3/issues/1932, 
Assumes: https://github.com/liqd/adhocracy3/pull/1958 is merged. 