### PR TITLE
mercator 2016 proposal edit

### DIFF
--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Create.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Create.html
@@ -19,7 +19,7 @@
         <div class="form-error" data-ng-repeat="error in errors track by $index">
             <p>{{ error | adhFormatError | translate }}</p>
         </div>
-        <section class="mercator-proposal-form-section mercator-proposal-form-section-info">
+        <section class="mercator-proposal-form-section mercator-proposal-form-section-info" data-ng-if="create">
             {{ "TR__MERCATOR_PROPOSAL_2016_SUBMISSION_DEADLINE" | translate }}
         </section>
 
@@ -1313,7 +1313,7 @@
                             placeholder="{{ 'TR__MAX_CHARS_500' | translate }}"></textarea>
                     </label>
 
-                    <div data-ng-if="create === 'true'">
+                    <div data-ng-if="create">
                         <span class="label-text">{{ "TR__MERCATOR_PROPOSAL_HEARD_FROM_LABEL" | translate }} *</span>
 
                         <div data-ng-class="{ 'ng-invalid': showHeardFromError() }">

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
@@ -25,8 +25,8 @@
                 <i class="icon-speechbubble-document"></i> {{ data.commentCounts.proposal }}
             </a>
         </h1>
-        <div data-ng-if="selectedTopics">
-            {{ "TR__MERCATOR_TOPIC" | translate }}: <em><span class="topic" data-ng-repeat="topic in selectedTopics">{{ topic | translate }}{{$last ? '' : ', '}}</span>
+        <div data-ng-if="data.selectedTopics">
+            {{ "TR__MERCATOR_TOPIC" | translate }}: <em><span class="topic" data-ng-repeat="topic in data.selectedTopics">{{ topic | translate }}{{$last ? '' : ', '}}</span>
             <span data-ng-if="data.topic.other">, {{data.topic_other}}</span>
             </em>
         </div>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Module.ts
@@ -66,6 +66,7 @@ export var register = (angular) => {
             adhEmbedProvider.registerDirective("mercator-2016-proposal-listitem");
         }])
         .directive("adhMercator2016ProposalCreate", ["adhConfig", Proposal.createDirective])
+        .directive("adhMercator2016ProposalEdit", ["adhConfig", Proposal.editDirective])
         .directive("adhMercator2016ProposalListing", ["adhConfig", Proposal.listing])
         .directive("adhMercator2016ProposalListitem", ["$q", "adhConfig", "adhHttp", "adhTopLevelState", "adhGetBadges", Proposal.listItem])
         .controller("mercatorProposalFormController2016", [

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Module.ts
@@ -67,7 +67,15 @@ export var register = (angular) => {
         }])
         .directive("adhMercator2016ProposalCreate", [
             "$location", "adhConfig", "adhHttp", "adhPreliminaryNames", "adhResourceUrlFilter", Proposal.createDirective])
-        .directive("adhMercator2016ProposalEdit", ["$q", "adhConfig", "adhHttp", "adhTopLevelState", Proposal.editDirective])
+        .directive("adhMercator2016ProposalEdit", [
+            "$q",
+            "$location",
+            "adhConfig",
+            "adhHttp",
+            "adhTopLevelState",
+            "adhPreliminaryNames",
+            "adhResourceUrlFilter",
+            Proposal.editDirective])
         .directive("adhMercator2016ProposalListing", ["adhConfig", Proposal.listing])
         .directive("adhMercator2016ProposalListitem", ["$q", "adhConfig", "adhHttp", "adhTopLevelState", "adhGetBadges", Proposal.listItem])
         .controller("mercatorProposalFormController2016", [

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Module.ts
@@ -65,18 +65,15 @@ export var register = (angular) => {
             adhEmbedProvider.registerDirective("mercator-2016-proposal-detail");
             adhEmbedProvider.registerDirective("mercator-2016-proposal-listitem");
         }])
-        .directive("adhMercator2016ProposalCreate", ["adhConfig", Proposal.createDirective])
+        .directive("adhMercator2016ProposalCreate", [
+            "$location", "adhConfig", "adhHttp", "adhPreliminaryNames", "adhResourceUrlFilter", Proposal.createDirective])
         .directive("adhMercator2016ProposalEdit", ["$q", "adhConfig", "adhHttp", "adhTopLevelState", Proposal.editDirective])
         .directive("adhMercator2016ProposalListing", ["adhConfig", Proposal.listing])
         .directive("adhMercator2016ProposalListitem", ["$q", "adhConfig", "adhHttp", "adhTopLevelState", "adhGetBadges", Proposal.listItem])
         .controller("mercatorProposalFormController2016", [
             "$scope",
             "$element",
-            "$window",
-            "$location",
             "adhShowError",
-            "adhHttp",
-            "adhPreliminaryNames",
             "adhTopLevelState",
             "adhSubmitIfValid",
             "adhResourceUrlFilter",

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Module.ts
@@ -66,7 +66,7 @@ export var register = (angular) => {
             adhEmbedProvider.registerDirective("mercator-2016-proposal-listitem");
         }])
         .directive("adhMercator2016ProposalCreate", ["adhConfig", Proposal.createDirective])
-        .directive("adhMercator2016ProposalEdit", ["adhConfig", Proposal.editDirective])
+        .directive("adhMercator2016ProposalEdit", ["$q", "adhConfig", "adhHttp", "adhTopLevelState", Proposal.editDirective])
         .directive("adhMercator2016ProposalListing", ["adhConfig", Proposal.listing])
         .directive("adhMercator2016ProposalListitem", ["$q", "adhConfig", "adhHttp", "adhTopLevelState", "adhGetBadges", Proposal.listItem])
         .controller("mercatorProposalFormController2016", [

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -198,6 +198,7 @@ export interface IDetailData extends IData {
     supporterCount : number;
     creationDate : string;
     creator : string;
+    selectedTopics : string[];
 }
 
 export interface IFormData extends IData {
@@ -477,6 +478,7 @@ var get = (
                     result[key] = _.indexOf(proposal.data[SITopic.nick].topic, key) !== -1;
                     return result;
                 }, {}),
+                selectedTopics: proposal.data[SITopic.nick].topic,
                 topic_other: proposal.data[SITopic.nick].topic_other,
                 title: proposal.data[SITitle.nick].title,
                 location: {
@@ -637,13 +639,6 @@ export var editDirective = (
 
             get($q, adhHttp, adhTopLevelState)(scope.path).then((data) => {
                 scope.data = data;
-                scope.selectedTopics = [];
-
-                _.forEach(scope.data.topic, (isSelected, key) => {
-                    if (isSelected) {
-                        scope.selectedTopics.push(topicTrString(key));
-                    }
-                });
             });
 
             scope.submit = () => edit(adhHttp, adhPreliminaryNames)(scope).then(() => {
@@ -852,14 +847,6 @@ export var detailDirective = (
 
             get($q, adhHttp, adhTopLevelState)(scope.path).then((data) => {
                 scope.data = data;
-
-                scope.selectedTopics = [];
-
-                _.forEach(scope.data.topic, function(isSelected, key) {
-                    if ((isSelected === true) && (key !== "other")) {
-                        scope.selectedTopics.push(topicTrString(key));
-                    }
-                });
             });
         }
     };

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -458,7 +458,10 @@ var get = (
                     secured: (proposal.data[SIExtraFunding.nick] || {}).secured
                 },
                 experience: proposal.data[SICommunity.nick].expected_feedback,
-                heardFrom: proposal.data[SICommunity.nick].heard_from,
+                heardFrom: _.reduce(proposal.data[SICommunity.nick].heard_froms, (result, item : string) => {
+                    result[item] = true;
+                    return result;
+                }, {}),
                 introduction: {
                     pitch: subs.pitch.data[SIPitch.nick].pitch,
                     picture: proposal.data[SIImageReference.nick].picture

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -531,6 +531,9 @@ export var createDirective = (adhConfig : AdhConfig.IService) => {
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
         scope: {
             poolPath: "@"
+        },
+        link: (scope) => {
+            scope.create = true;
         }
     };
 };
@@ -719,9 +722,6 @@ export var mercatorProposalFormController2016 = (
     };
 
     $scope.showError = adhShowError;
-
-    // FIXME !
-    $scope.create = "true";
 
     $scope.submitIfValid = () => {
         adhSubmitIfValid($scope, $element, $scope.mercatorProposalForm, () => {

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -343,7 +343,10 @@ var fill = (data : IFormData, resource) => {
     }
 };
 
-var create = (adhHttp : AdhHttp.Service<any>) => (scope, adhPreliminaryNames) => {
+var create = (
+    adhHttp : AdhHttp.Service<any>,
+    adhPreliminaryNames : AdhPreliminaryNames.Service
+) => (scope) => {
     var data : IFormData = scope.data;
     return adhHttp.withTransaction((transaction) => {
         var proposal = new RIMercatorProposal({preliminaryNames: adhPreliminaryNames});
@@ -709,7 +712,7 @@ export var mercatorProposalFormController2016 = (
 
     $scope.submitIfValid = () => {
         adhSubmitIfValid($scope, $element, $scope.mercatorProposalForm, () => {
-            var post = () => create(adhHttp)($scope, adhPreliminaryNames).then((proposalPath) => {
+            var post = () => create(adhHttp, adhPreliminaryNames)($scope).then((proposalPath) => {
                 $location.url(adhResourceUrl(proposalPath));
             });
 

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -534,16 +534,67 @@ export var createDirective = (adhConfig : AdhConfig.IService) => {
         },
         link: (scope) => {
             scope.create = true;
+
+            scope.data = {
+                user_info: {},
+                organization_info: {},
+                introduction: {},
+                partners: {
+                    partner1: {},
+                    partner2: {},
+                    partner3: {}
+                },
+                topic: {},
+                location: {},
+                impact: {},
+                criteria: {},
+                finance: {},
+                heardFrom: {}
+            };
         }
     };
 };
 
-export var editDirective = (adhConfig : AdhConfig.IService) => {
+export var editDirective = (
+    $q : angular.IQService,
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service
+) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
         scope: {
             path: "@"
+        },
+        link: (scope) => {
+            scope.data = {
+                user_info: {},
+                organization_info: {},
+                introduction: {},
+                partners: {
+                    partner1: {},
+                    partner2: {},
+                    partner3: {}
+                },
+                topic: {},
+                location: {},
+                impact: {},
+                criteria: {},
+                finance: {},
+                heardFrom: {}
+            };
+
+            get($q, adhHttp, adhTopLevelState)(scope.path).then((data) => {
+                scope.data = data;
+                scope.selectedTopics = [];
+
+                _.forEach(scope.data.topic, (isSelected, key) => {
+                    if (isSelected) {
+                        scope.selectedTopics.push(topicTrString(key));
+                    }
+                });
+            });
         }
     };
 };
@@ -631,23 +682,6 @@ export var mercatorProposalFormController2016 = (
 
     $scope.selection_criteria_link = "/en/idea-space/selection-criteria/";
     $scope.financial_plan_link = "/en/idea-space/financial-plan/";
-
-    $scope.data = {
-        user_info: {},
-        organization_info: {},
-        introduction: {},
-        partners: {
-            partner1: {},
-            partner2: {},
-            partner3: {}
-        },
-        topic: {},
-        location: {},
-        impact: {},
-        criteria: {},
-        finance: {},
-        heardFrom: {}
-    };
 
     var topicTotal = 0;
 

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -525,7 +525,13 @@ var get = (
 };
 
 
-export var createDirective = (adhConfig : AdhConfig.IService) => {
+export var createDirective = (
+    $location : angular.ILocationService,
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service<any>,
+    adhPreliminaryNames : AdhPreliminaryNames.Service,
+    adhResourceUrl
+) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
@@ -551,6 +557,10 @@ export var createDirective = (adhConfig : AdhConfig.IService) => {
                 finance: {},
                 heardFrom: {}
             };
+
+            scope.submit = () => create(adhHttp, adhPreliminaryNames)(scope).then((proposalPath) => {
+                $location.url(adhResourceUrl(proposalPath));
+            });
         }
     };
 };
@@ -595,6 +605,10 @@ export var editDirective = (
                     }
                 });
             });
+
+            scope.submit = () => {
+                console.log(scope);
+            };
         }
     };
 };
@@ -664,11 +678,7 @@ export var listItem = (
 export var mercatorProposalFormController2016 = (
     $scope,
     $element,
-    $window,
-    $location,
     adhShowError,
-    adhHttp : AdhHttp.Service<any>,
-    adhPreliminaryNames : AdhPreliminaryNames.Service,
     adhTopLevelState : AdhTopLevelState.Service,
     adhSubmitIfValid,
     adhResourceUrl,
@@ -759,10 +769,6 @@ export var mercatorProposalFormController2016 = (
 
     $scope.submitIfValid = () => {
         adhSubmitIfValid($scope, $element, $scope.mercatorProposalForm, () => {
-            var post = () => create(adhHttp, adhPreliminaryNames)($scope).then((proposalPath) => {
-                $location.url(adhResourceUrl(proposalPath));
-            });
-
             if ($scope.$flow && $scope.$flow.support && $scope.$flow.files.length > 0) {
                 return adhUploadImage(
                     adhTopLevelState.get("processUrl"),
@@ -771,10 +777,10 @@ export var mercatorProposalFormController2016 = (
                     SIMercatorIntroImageMetadata.nick
                 ).then((imageUrl : string) => {
                     $scope.data.introduction.picture = imageUrl;
-                    return post();
+                    return $scope.submit();
                 });
             } else {
-                return post();
+                return $scope.submit();
             }
         });
     };

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -535,6 +535,16 @@ export var createDirective = (adhConfig : AdhConfig.IService) => {
     };
 };
 
+export var editDirective = (adhConfig : AdhConfig.IService) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
+        scope: {
+            path: "@"
+        }
+    };
+};
+
 export var listing = (adhConfig : AdhConfig.IService) => {
     return {
         restrict: "E",

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -728,7 +728,15 @@ export var mercatorProposalFormController2016 = (
     $scope.selection_criteria_link = "/en/idea-space/selection-criteria/";
     $scope.financial_plan_link = "/en/idea-space/financial-plan/";
 
-    var topicTotal = 0;
+    var topicTotal = () => {
+        return _.reduce($scope.data.topic, (result, include, topic : string) => {
+            if (include && (topic !== "otherText")) {
+                return result + 1;
+            } else {
+                return result;
+            }
+        }, 0);
+    };
 
     $scope.topics = topics;
 
@@ -749,8 +757,7 @@ export var mercatorProposalFormController2016 = (
 
     $scope.topicChange = (isChecked) => {
         if ($scope.data.topic) {
-            topicTotal = isChecked ? (topicTotal + 1) : (topicTotal - 1);
-            var validity = topicTotal > 0 && topicTotal < 3;
+            var validity = topicTotal() > 0 && topicTotal() < 3;
             $scope.mercatorProposalForm.mercatorProposalBriefForm["introduction-topics"].$setValidity("enoughTopics", validity);
             $scope.mercatorProposalForm.mercatorProposalBriefForm["introduction-topics"].$setDirty();
         } else {
@@ -775,7 +782,7 @@ export var mercatorProposalFormController2016 = (
     };
 
     $scope.showTopicsError = () : boolean => {
-        return ((topicTotal < 1) || (topicTotal > 2)) &&
+        return ((topicTotal() < 1) || (topicTotal() > 2)) &&
             $scope.mercatorProposalForm.mercatorProposalBriefForm["introduction-topics"].$dirty;
     };
 

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/ProposalDetailColumn.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/ProposalDetailColumn.html
@@ -16,7 +16,7 @@
     <adh-recompile-on-change data-ng-switch-when="body" data-value="{{proposalUrl}}">
         <adh-resource-actions
             data-resource-path="{{proposalUrl}}"
-            data-edit="false"
+            data-edit="true"
             data-report="true"
             data-share="true"
             data-delete="false"

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/ProposalEditColumn.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/ProposalEditColumn.html
@@ -1,0 +1,15 @@
+<div data-ng-switch="transclusionId">
+    <div data-ng-switch-when="menu">
+        <i class="icon-document moving-column-icon"></i>
+    </div>
+
+    <div data-ng-switch-when="body">
+        <adh-resource-actions
+            data-resource-path="{{proposalUrl}}"
+            data-cancel="true"></adh-resource-actions>
+        <adh-mercator-2016-proposal-edit
+            data-ng-if="proposalUrl"
+            data-path="{{proposalUrl}}">
+        </adh-mercator-2016-proposal-edit>
+    </div>
+</div>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.html
@@ -4,7 +4,7 @@
         <adh-mercator-2016-proposal-listing-column data-ng-if="view !== 'create_proposal'"></adh-mercator-2016-proposal-listing-column>
     </adh-moving-column>
     <adh-moving-column>
-        <!-- <adh&#45;mercator&#45;2016&#45;proposal&#45;edit&#45;column data&#45;ng&#45;if="view === 'edit'"></adh&#45;mercator&#45;2016&#45;proposal&#45;edit&#45;column> -->
+        <adh-mercator-2016-proposal-edit-column data-ng-if="view === 'edit'"></adh-mercator-2016-proposal-edit-column>
         <adh-mercator-2016-proposal-detail-column data-ng-if="view !== 'edit'"></adh-mercator-2016-proposal-detail-column>
     </adh-moving-column>
     <adh-moving-column>


### PR DESCRIPTION
*This replaces #1951*

This adds editing to mercator 2016 proposals.

It is based on #1951, but I rebased it and did some changes. Most importantly, I created a separate `editDirective` instead of extending `createDirective` (but they still share the template). I hope I got all important parts, but especially c93ec2d6d8c05016ffcb8f149e12c2cdf017e5f6 was a bit overwhelming.