### PR TITLE
Fixup #1938

### DIFF
--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/ProposalCreateColumn.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/ProposalCreateColumn.html
@@ -2,11 +2,13 @@
     <div data-ng-switch-when="menu">
         <i class="icon-document moving-column-icon"></i>
     </div>
-    <adh-resource-actions
+
+    <div data-ng-switch-when="body">
+        <adh-resource-actions
             data-resource-path="{{processUrl}}"
             data-cancel="true"></adh-resource-actions>
-    <adh-mercator-2016-proposal-create
-        data-ng-switch-when="body"
-        data-pool-path="{{processUrl}}">
-    </adh-mercator-2016-proposal-create>
+        <adh-mercator-2016-proposal-create
+            data-pool-path="{{processUrl}}">
+        </adh-mercator-2016-proposal-create>
+    </div>
 </div>


### PR DESCRIPTION
#1938 added a cancel button to the mercator 2016 proposal create column. Unfortunately, the button was included in all slots, not only in the body. This fixes the issue.