### PR TITLE
extract frontend stats

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -261,7 +261,7 @@ def main():
         print('digraph adhocracy_frontend {')
         print('  graph [splines=ortho];')
 
-        for rank in range(args.min_rank, args.max_rank):
+        for rank in range(args.min_rank, args.max_rank + 1):
             print('  subgraph rank%i {' % rank)
             print('    rank = same;')
             for path, module in modules.items():

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -55,13 +55,16 @@ def get_modules():
 
 def add_counts(modules):
     """Add import_count/export_count to an existing dict of modules."""
-    for path, module in modules.items():
-        module['import_count'] = len(module['imports'])
-        module['export_count'] = 0
+    for module in modules.values():
+        module['exports'] = set()
 
     for path, module in modules.items():
         for imp in module['imports']:
-            modules[imp]['export_count'] += 1
+            modules[imp]['exports'].add(path)
+
+    for path, module in modules.items():
+        module['import_count'] = len(module['imports'])
+        module['export_count'] = len(module['exports'])
 
 
 def add_rank(modules):

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -7,8 +7,17 @@ import subprocess
 import os
 import re
 import argparse
+import json
 
 CATEGORIES = ['peripheral', 'control', 'shared', 'core']
+
+
+class SetEncoder(json.JSONEncoder):
+    # https://stackoverflow.com/questions/8230315
+    def default(self, obj):
+       if isinstance(obj, set):
+          return list(obj)
+       return json.JSONEncoder.default(self, obj)
 
 
 def normpath(path):
@@ -257,6 +266,8 @@ def parse_args():
         'some general stats')
     parser.add_argument('-v', '--verbose', action='store_true')
 
+    parser.add_argument('--dump', action='store_true')
+
     return parser.parse_args()
 
 
@@ -277,6 +288,8 @@ def main():
         print_matrix(m, names)
     elif args.stats:
         print_stats(modules, verbose=args.verbose)
+    elif args.dump:
+        print(json.dumps(modules, indent=2, separators=(',', ': '), sort_keys=True, ensure_ascii=False, cls=SetEncoder))
     else:
         print_dot(modules, args)
 

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -67,6 +67,32 @@ def add_counts(modules):
         module['export_count'] = len(module['exports'])
 
 
+def add_recursive_counts(modules):
+    def set_recursive_imports(module):
+        k = 'recursive_imports'
+        if k not in module:
+            module[k] = set(module['imports'])
+            for key in module['imports']:
+                imp = modules[key]
+                set_recursive_imports(imp)
+                module[k] = module[k].union(imp[k])
+
+    def set_recursive_exports(module):
+        k = 'recursive_exports'
+        if k not in module:
+            module[k] = set(module['exports'])
+            for key in module['exports']:
+                exp = modules[key]
+                set_recursive_exports(exp)
+                module[k] = module[k].union(exp[k])
+
+    for module in modules.values():
+        set_recursive_imports(module)
+        module['recursive_import_count'] = len(module['recursive_imports'])
+        set_recursive_exports(module)
+        module['recursive_export_count'] = len(module['recursive_exports'])
+
+
 def add_rank(modules):
     """Add rank to an existing dict of modules."""
     done = []
@@ -122,6 +148,7 @@ def main():
     args = parse_args()
     modules = get_modules()
     add_counts(modules)
+    add_recursive_counts(modules)
     max_rank = add_rank(modules)
 
     if args.max_rank is None:

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -51,8 +51,7 @@ def get_modules():
 
             modules[normpath(path)] = {
                 'name': name,
-                'imports': imports,
-                'color': color(name),
+                'imports': imports
             }
 
     return modules
@@ -155,7 +154,7 @@ def add_category(modules):
 
 def render_module(module):
     """Render a module to string."""
-    opts = ['color=%s' % module['color']]
+    opts = ['color=%s' % color(module['name'])]
 
     if module['import_count'] == 0:
         opts.append('shape=box')
@@ -237,7 +236,7 @@ def print_dot(modules, args):
             print('  %s->%s [color=%s];' % (
                 modules[imp]['name'],
                 module['name'],
-                modules[imp]['color']))
+                color(modules[imp]['name'])))
 
     print('}')
 

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -228,11 +228,13 @@ def print_stats(modules, verbose=True):
     print('max rank: %i' % max((m['rank'] for m in modules.values())))
 
 
-def print_dot(modules, args):
+def print_dot(modules):
+    ranks = [m['rank'] for m in modules.values()]
+
     print('digraph adhocracy_frontend {')
     print('  graph [splines=ortho];')
 
-    for rank in range(args.min_rank, args.max_rank + 1):
+    for rank in range(min(ranks), max(ranks) + 1):
         print('  subgraph rank%i {' % rank)
         print('    rank = same;')
         for path, module in modules.items():
@@ -291,7 +293,7 @@ def main():
     elif args.dump:
         print(json.dumps(modules, indent=2, separators=(',', ': '), sort_keys=True, ensure_ascii=False, cls=SetEncoder))
     else:
-        print_dot(modules, args)
+        print_dot(modules)
 
 
 if __name__ == '__main__':

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -1,4 +1,7 @@
-"""Extract graph of angular module dependencies in DOT format."""
+"""Extract informaton about angular module dependencies.
+
+For some of the concepts, see http://almossawi.com/firefox/
+"""
 
 import subprocess
 import os
@@ -68,6 +71,10 @@ def add_counts(modules):
 
 
 def add_recursive_counts(modules):
+    """Add fan_in/fan_out to an existing dict of modules.
+
+    These are like import_count/export_count, but recursive.
+    """
     def set_recursive_imports(module):
         k = 'recursive_imports'
         if k not in module:
@@ -94,7 +101,10 @@ def add_recursive_counts(modules):
 
 
 def add_rank(modules):
-    """Add rank to an existing dict of modules."""
+    """Add rank to an existing dict of modules.
+
+    The rank of a module is always greater that that of its dependencies.
+    """
     done = []
 
     while len(done) < len(modules):
@@ -113,6 +123,7 @@ def add_rank(modules):
 
 
 def add_category(modules):
+    """Mark a module as 'peripheral', 'control', 'shared', or 'core'."""
     n = len(modules)
     average_in = sum(m['fan_in'] for m in modules.values()) / float(n)
     average_out = sum(m['fan_out'] for m in modules.values()) / float(n)

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -88,9 +88,9 @@ def add_recursive_counts(modules):
 
     for module in modules.values():
         set_recursive_imports(module)
-        module['recursive_import_count'] = len(module['recursive_imports'])
+        module['fan_in'] = len(module['recursive_imports'])
         set_recursive_exports(module)
-        module['recursive_export_count'] = len(module['recursive_exports'])
+        module['fan_out'] = len(module['recursive_exports'])
 
 
 def add_rank(modules):
@@ -135,7 +135,7 @@ def include(module, args):
 
 def adjacency_matrix(modules, direct=False):
     keys = list(modules.keys())
-    keys.sort(key=lambda k: (-modules[k]['recursive_export_count'], k))
+    keys.sort(key=lambda k: (-modules[k]['fan_out'], k))
     names = [modules[key]['name'] for key in keys]
 
     m = []

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -112,6 +112,22 @@ def add_rank(modules):
     return max([m['rank'] for m in modules.values()])
 
 
+def add_category(modules):
+    n = len(modules)
+    average_in = sum(m['fan_in'] for m in modules.values()) / float(n)
+    average_out = sum(m['fan_out'] for m in modules.values()) / float(n)
+
+    categories = ['peripheral', 'control', 'shared', 'core']
+
+    for module in modules.values():
+        i = 0
+        if module['fan_in'] > average_in:
+            i += 1
+        if module['fan_out'] > average_out:
+            i += 2
+        module['category'] = categories[i]
+
+
 def render_module(module):
     """Render a module to string."""
     opts = ['color=%s' % module['color']]
@@ -187,6 +203,7 @@ def main():
     add_counts(modules)
     add_recursive_counts(modules)
     max_rank = add_rank(modules)
+    add_category(modules)
 
     if args.matrix:
         m, names = adjacency_matrix(modules, direct=args.direct)

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -255,6 +255,8 @@ def print_dot(modules):
 def parse_args():
     """Parse command line argumants."""
     parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--input', default=None)
+
     parser.add_argument('--min-rank', type=int, default=0)
     parser.add_argument('--max-rank', type=int, default=None)
     parser.add_argument('-x', '--exclude', nargs='*', default=[])
@@ -276,14 +278,19 @@ def parse_args():
 def main():
     """Print module graph in DOT format to stdout."""
     args = parse_args()
-    modules = get_modules()
-    max_rank = add_rank(modules)
-    if args.max_rank is None:
-        args.max_rank = max_rank
-    _filter(modules, args)
-    add_counts(modules)
-    add_recursive_counts(modules)
-    add_category(modules)
+    if args.input is None:
+        modules = get_modules()
+
+        max_rank = add_rank(modules)
+        if args.max_rank is None:
+            args.max_rank = max_rank
+        _filter(modules, args)
+        add_counts(modules)
+        add_recursive_counts(modules)
+        add_category(modules)
+    else:
+        with open(args.input) as fh:
+            modules = json.load(fh)
 
     if args.matrix:
         m, names = adjacency_matrix(modules, direct=args.direct)

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -193,18 +193,17 @@ def adjacency_matrix(modules, direct=False):
     return m, names
 
 
-def draw_matrix(matrix, names):
-    s = 'P1\n'
+def print_matrix(matrix, names):
+    print('P1')
     for name in names:
-        s += '# %s\n' % name
+        print('# %s' % name)
     n = len(matrix)
-    s += '%i %i\n' % (n, n)
+    print('%i %i' % (n, n))
     for row in matrix:
-        s += ' '.join([str(int(i)) for i in row]) + '\n'
-    return s
+        print(' '.join([str(int(i)) for i in row]))
 
 
-def stats(modules, verbose=True):
+def print_stats(modules, verbose=True):
     n = len(modules)
     print('total modules: %i' % n)
     for category in CATEGORIES:
@@ -254,9 +253,9 @@ def main():
 
     if args.matrix:
         m, names = adjacency_matrix(modules, direct=args.direct)
-        print(draw_matrix(m, names))
+        print_matrix(m, names)
     elif args.stats:
-        stats(modules, verbose=args.verbose)
+        print_stats(modules, verbose=args.verbose)
     else:
         print('digraph adhocracy_frontend {')
         print('  graph [splines=ortho];')

--- a/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/scripts/deps2dot.py
@@ -220,6 +220,28 @@ def print_stats(modules, verbose=True):
     print('max rank: %i' % max((m['rank'] for m in modules.values())))
 
 
+def print_dot(modules, args):
+    print('digraph adhocracy_frontend {')
+    print('  graph [splines=ortho];')
+
+    for rank in range(args.min_rank, args.max_rank + 1):
+        print('  subgraph rank%i {' % rank)
+        print('    rank = same;')
+        for path, module in modules.items():
+            if module['rank'] == rank:
+                print(render_module(module))
+        print('  }')
+
+    for module in modules.values():
+        for imp in module['imports']:
+            print('  %s->%s [color=%s];' % (
+                modules[imp]['name'],
+                module['name'],
+                modules[imp]['color']))
+
+    print('}')
+
+
 def parse_args():
     """Parse command line argumants."""
     parser = argparse.ArgumentParser()
@@ -257,25 +279,7 @@ def main():
     elif args.stats:
         print_stats(modules, verbose=args.verbose)
     else:
-        print('digraph adhocracy_frontend {')
-        print('  graph [splines=ortho];')
-
-        for rank in range(args.min_rank, args.max_rank + 1):
-            print('  subgraph rank%i {' % rank)
-            print('    rank = same;')
-            for path, module in modules.items():
-                if module['rank'] == rank:
-                    print(render_module(module))
-            print('  }')
-
-        for module in modules.values():
-            for imp in module['imports']:
-                print('  %s->%s [color=%s];' % (
-                    modules[imp]['name'],
-                    module['name'],
-                    modules[imp]['color']))
-
-        print('}')
+        print_dot(modules, args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
After reading an article about the [Evolution of the Firefox Codebase](http://almossawi.com/firefox/) I spent some of my free time analysing the adhocracy3 frontend. Some time ago I had already created a script called `deps2dot` that extracts the graph of angular module dependencies from our code. This pull requests extends that script to provide more output options.

-  `--matrix`: Output dependency matrix as PBM. If you want to only include direct dependencies, use the `--direct` switch.

    ![1](https://cloud.githubusercontent.com/assets/202576/12373027/18e6acee-bc6c-11e5-99b7-bff1b8ea731d.png) ![2](https://cloud.githubusercontent.com/assets/202576/12373026/16090c56-bc6c-11e5-97ec-eca637b37829.png)

   Note that the order of modules has a huge impact on the outcome of this. I have experimented a bit, but I am not yet sure which order should be used.

-  `--stats`: Output some general stats
   -   Total number of modules.
   -   A categorization of modules into "core", "shared", "peripheral", and "control"
   -   Propagation cost
   -   Maximum rank

-  `--dump`: Dump data as JSON. Can later be loaded using the `-i` option.

In addition to extending the script, I collected data from different states of our git history and produced these graphs (note that the 2nd and 3rd graphs only cover the last 3 month because our import structure has changed at that time and deps2dot does not work on older code):

Get the [raw data](https://github.com/liqd/adhocracy3/files/92942/stats.txt) as csv.

## size

![size_2014-11_2016-01](https://cloud.githubusercontent.com/assets/202576/12373030/1fef011c-bc6c-11e5-868c-24bddc2be81a.png)

Both LOC and total number of modules have grown significantly in the last year. However, the number of modules is growing faster, which means smaller modules on average.

## modules

A module is categorized by the number of modules it depends on (fan-in) and the number of module that depend on it (fan-out).

fan-in | fan-out | category
--------|----------|---------------
high | high | core
high | low | control
low | hight | shared
low | low | peripheral

High/low means above/below average.

![modules_2015-09_2016-01](https://cloud.githubusercontent.com/assets/202576/12373028/1bbf83fa-bc6c-11e5-8469-f853a6b13f6c.png)

We have next to no core modules (which is good!) and the biggest increase is in control modules. This is expected because we recently mainly added high level stuff like new workbenches. But this also shows that our abstractions actually work because we do not need to add core/shared modules all the time.

## general metrics

![metrics_2015-09_2016-01](https://cloud.githubusercontent.com/assets/202576/12373029/1e5bfd64-bc6c-11e5-8edc-8172c66b8c67.png)

Code size, propagation cost and maxiumum rank have grown about the same in the past 3 month. Note however that this is a very small dataset (e.g. maximum rank changes from 11 to 12).