### PR TITLE
fix mercator2016 edit

### DIFF
--- a/src/mercator/mercator/static/i18n/mercator_en.json
+++ b/src/mercator/mercator/static/i18n/mercator_en.json
@@ -182,7 +182,7 @@
     "TR__MERCATOR_PROPOSAL_VALUE_ANNOTATION": "What value does your idea add to Europe? What makes it different from others? Could you imagine transferring this idea to other countries, sectors or organisations? (max. 800 characters)",
     "TR__MERCATOR_PROPOSAL_VALUE_LABEL": "Why does Europe need your idea?",
     "TR__MERCATOR_PROPOSAL_WHO_BEHIND": "Who is behind it?",
-    "TR__MERCATOR_TOPIC": "Topic/s",
+    "TR__MERCATOR_TOPIC": "Topics",
     "TR__MERCATOR_TOPIC_COMMUNITY": "Communities",
     "TR__MERCATOR_TOPIC_CULTURE": "Arts and (inter-)cultural activities",
     "TR__MERCATOR_TOPIC_DEMOCRACY": "Democracy and participation",

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Create.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Create.html
@@ -1034,19 +1034,13 @@
             <div class="annotated-section">
                 <div class="annotated-section-body">
                     <label>
-                        <span class="label-text">{{ "TR__MERCATOR_PROPOSAL_IMPACT_EXTRAINFO_LABEL" | translate }} *</span>
+                        <span class="label-text">{{ "TR__MERCATOR_PROPOSAL_IMPACT_EXTRAINFO_LABEL" | translate }}</span>
                         <textarea
                             data-msd-elastic=""
                             data-ng-model="data.impact.extraInfo"
                             name="impact-extrainfo"
                             maxlength="500"
-                            placeholder="{{ 'TR__MAX_CHARS_500' | translate }}"
-                            required="required"></textarea>
-
-                        <span
-                            class="input-error"
-                            data-ng-if="showError(mercatorProposalForm, mercatorProposalImpactForm['impact-extrainfo'], 'required')">
-                            {{ "TR__ERROR_REQUIRED_TEXT" | translate }}</span>
+                            placeholder="{{ 'TR__MAX_CHARS_500' | translate }}"></textarea>
                     </label>
                 </div><!-- /.annotated-section-body -->
             </div><!-- /.annotated-section -->

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Create.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Create.html
@@ -179,10 +179,11 @@
                                 <span class="label-text">{{ "TR__MERCATOR_PROPOSAL_ORGANIZATION_DATE_OF_REGISTRATION_2016" | translate }} *</span>
                                 <input
                                     type="text"
-                                    data-ng-model="data.organizationInfo.registrationDate"
+                                    data-ng-model="data.organizationInfo.registrationDateField"
                                     name="organization-info-registration-date"
                                     data-ng-pattern="/^[0-9]{4}$/"
                                     placeholder="yyyy"
+                                    data-ng-change="dateChange()"
                                     data-required="required"
                                     />
                                 <span
@@ -250,14 +251,13 @@
                             </label>
                             <label>
                                 <span class="label-text">{{ "TR__MERCATOR_PROPOSAL_ORGANIZATION_DATE_PLANNED_NONPROFIT_2016" | translate }} *</span>
-                                <input type="hidden" ng-model="data.organizationInfo.registrationDate">
                                 <input
                                     type="text"
                                     data-ng-model="data.organizationInfo.registrationDateField"
                                     name="organization-info-registration-date"
                                     data-ng-pattern="/([0-9]{4})-(1[0-2]|0[1-9])$/"
                                     placeholder="yyyy-mm"
-                                    data-ng-change="dateChange(data.organizationInfo.registrationDateField)"
+                                    data-ng-change="dateChange()"
                                     required="required" />
                                 <span
                                     class="input-error"

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -642,6 +642,9 @@ export var editDirective = (
 
             get($q, adhHttp, adhTopLevelState)(scope.path).then((data) => {
                 scope.data = data;
+
+                scope.data.partners.hasPartners = scope.data.partners.hasPartners ? "true" : "false";
+
                 if (scope.data.organizationInfo.status === "planned_nonprofit") {
                     scope.data.organizationInfo.registrationDateField = data.organizationInfo.registrationDate.substr(0, 7);
                 } else if (scope.data.organizationInfo.status === "registered_nonprofit") {

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -642,6 +642,11 @@ export var editDirective = (
 
             get($q, adhHttp, adhTopLevelState)(scope.path).then((data) => {
                 scope.data = data;
+                if (scope.data.organizationInfo.status === "planned_nonprofit") {
+                    scope.data.organizationInfo.registrationDateField = data.organizationInfo.registrationDate.substr(0, 7);
+                } else if (scope.data.organizationInfo.status === "registered_nonprofit") {
+                    scope.data.organizationInfo.registrationDateField = data.organizationInfo.registrationDate.substr(0, 4);
+                }
             });
 
             scope.submit = () => edit(adhHttp, adhPreliminaryNames)(scope).then(() => {
@@ -807,7 +812,11 @@ export var mercatorProposalFormController2016 = (
 
     $scope.dateChange = (date) => {
         // FIXME: this is quite hacky dates need proper validation EG not so much in the past or future too
-        $scope.data.organizationInfo.registrationDate = date + "-01";
+        if ($scope.data.organizationInfo.status === "planned_nonprofit") {
+            $scope.data.organizationInfo.registrationDate = $scope.data.organizationInfo.registrationDateField + "-01";
+        } else {
+            $scope.data.organizationInfo.registrationDate = $scope.data.organizationInfo.registrationDateField + "-01-01";
+        }
     };
 
     $scope.showError = adhShowError;


### PR DESCRIPTION
There were some issues with editing mercator 2016 proposals, namely:

-   `registrationDate` was not properly loaded
-   `hasPartners` was not properly loaded
-   `extraInfo` was marked as required (backend needs adaption, see #1986)