### PR TITLE
update frontend dependencies

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -135,7 +135,7 @@ html_check =
 
 [nodejs]
 recipe = gp.recipe.node
-version = 0.10.28
+version = 4.2.4
 scripts = node npm
 
 [npm_config]

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -12,10 +12,9 @@ parts +=
     AdhocracySpec.ts
     meta_api
     resources
-    javascript.amd
+    javascript
     gruntfile
     grunt
-    javascript.umd
     rubygems
     stylesheets
     hologram
@@ -276,19 +275,12 @@ command =
 update-command = ${:command}
 jsdir = ${adhocracy:frontend.static_dir}/js
 
-[javascript.umd]
+[javascript]
 recipe = plone.recipe.command
 stop-on-error = True
 command =
     ${buildout:bin-directory}/node ${buildout:bin-directory}/tsc -m umd -d --sourcemap ${adhocracy:frontend.static_dir}/js/Adhocracy*.ts
-update-command = ${javascript.umd:command}
-
-[javascript.amd]
-recipe = plone.recipe.command
-stop-on-error = True
-command =
-    ${buildout:bin-directory}/node ${buildout:bin-directory}/tsc -m amd -d --sourcemap ${adhocracy:frontend.static_dir}/js/Adhocracy*.ts
-update-command = ${javascript.amd:command}
+update-command = ${javascript:command}
 
 [gruntfile]
 recipe = collective.recipe.template

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -145,22 +145,22 @@ input = inline:
         "devDependencies": {
             "typescript": "1.6.2",
             "tslint": "2.5.0",
-            "bower": "1.5.3",
+            "bower": "1.7.2",
             "jasmine-node": "2.0.0-beta4",
             "protractor": "2.2.0",
             "sync-exec": "0.6.2",
             "q": "1.4.1",
             "lodash": "3.10.1",
             "node-fs": "0.1.7",
-            "underscore.string": "3.2.2",
+            "underscore.string": "3.2.3",
             "grunt": "0.4.5",
             "grunt-cli": "0.1.13",
-            "grunt-angular-templates": "0.5.7",
-            "requirejs": "2.1.20",
+            "grunt-angular-templates": "1.0.1",
+            "requirejs": "2.1.22",
             "grunt-contrib-requirejs": "0.4.4",
-            "htmlhint": "0.9.7",
-            "grunt-htmlhint": "0.4.1",
-            "mailparser": "0.5.2",
+            "htmlhint": "0.9.12",
+            "grunt-htmlhint": "0.9.12-fix",
+            "mailparser": "0.5.3",
             "ini": "1.3.4"
         }
     }
@@ -189,26 +189,26 @@ update-command = ${:command}
 [bower]
 recipe = bowerrecipe
 packages =
-    jquery#2.1.4
-    angular#1.4.6
-    angular-animate#1.4.6
-    angular-aria#1.4.6
-    angular-messages#1.4.6
+    jquery#2.2.0
+    angular#1.4.8
+    angular-animate#1.4.8
+    angular-aria#1.4.8
+    angular-messages#1.4.8
     angular-cache#4.3.2
-    angular-elastic#2.5.0
-    angular-scroll#0.7.2
+    angular-elastic#2.5.1
+    angular-scroll#1.0.0
     angular-translate#2.8.1
     angular-translate-loader-static-files#2.8.1
-    markdown-it#4.4.0
-    leaflet#0.7.5
+    markdown-it#5.1.0
+    leaflet#0.7.7
     lodash#3.10.1
-    requirejs#2.1.20
+    requirejs#2.1.22
     requirejs-text#2.0.14
     DefinitelyTyped#54f064352a3615443f7bff4198078db15e28247b
-    jasmine#2.3.4
+    jasmine#2.4.1
     blanket#1.1.7
     q#1.4.1
-    moment#2.10.6
+    moment#2.11.1
     relatively-sticky#2.0.0
     ng-flow#2.6.1
     nidico/socialshareprivacy#protocol-relative-urls
@@ -385,11 +385,11 @@ update-command = ${grunt:command}
 [rubygems]
 recipe = rubygemsrecipe
 gems =
-    sass==3.4.18
+    sass==3.4.21
     compass==1.0.3
     hologram==1.4.0
     scss-lint==0.38.0
-    susy==2.2.5
+    susy==2.2.11
 
 [frontend.current.link]
 recipe = plone.recipe.command

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -57,7 +57,10 @@ input = inline:
         "no-empty": true,
         "no-eval": true,
         "no-string-literal": false,
-        "no-trailing-comma": true,
+        "trailing-comma": {
+            "multiline": "never",
+            "singleline": "never"
+        },
         "no-trailing-whitespace": true,
         "no-unused-expression": true,
         "no-unused-variable": true,
@@ -143,7 +146,7 @@ input = inline:
         "version": "0.0.1",
         "devDependencies": {
             "typescript": "1.7.5",
-            "tslint": "2.5.0",
+            "tslint": "3.2.2",
             "bower": "1.7.2",
             "jasmine-node": "2.0.0-beta4",
             "protractor": "2.2.0",

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -143,7 +143,7 @@ input = inline:
         "name": "adhocracy-frontend",
         "version": "0.0.1",
         "devDependencies": {
-            "typescript": "1.6.2",
+            "typescript": "1.7.5",
             "tslint": "2.5.0",
             "bower": "1.7.2",
             "jasmine-node": "2.0.0-beta4",


### PR DESCRIPTION
We haven't updated the frontend dependencies in a while, so this is quite a lot:

## Notable changes

-  [sass](http://sass-lang.com/documentation/file.SASS_CHANGELOG.html) had some breaking changes in 3.4.20, but nothing that should concern us, as far as I could see.
-  [tslint](https://github.com/palantir/tslint/blob/master/CHANGELOG.md) had a major release with some breaking changes.
-  [node.js](https://nodejs.org) was updated to the LTS version.
-  [TypeScript](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#typescript-17) was updated to 1.7, containing the UMD fix required for #1661. They also moved to github.

## What was not updated?

-   version 3.0.0 of [protractor](https://github.com/angular/protractor/blob/master/CHANGELOG.md) has been released, but a trivial update did not work for me.
-  version 4.4.3 of [angular-cache](https://github.com/jmdobry/angular-cache/blob/master/CHANGELOG.md) has been released, but it did not work for me.
-  version 4.0.0 of [lodash](https://github.com/lodash/lodash/wiki/Changelog#v400) has been relased. It containes many breaking changes. They provide the tool [lodash-migrate](https://www.npmjs.com/package/lodash-migrate) to help with migration.

## Heads up

-   version 2.2. will be the final release of [jquery's](http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/) 2.x branch. So we will have to switch to 3.x soon.
-   [leaflet](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md) is preparing a major 1.0 release