### PR TITLE
Do not drop empty 'other_sources' field

### DIFF
--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/mercator2.py
@@ -409,7 +409,7 @@ class IExtraFunding(ISheet):
 
 
 class ExtraFundingSchema(colander.MappingSchema):
-    other_sources = Text()
+    other_sources = Text(missing='')
     secured = Boolean(default=False)
 
 

--- a/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
+++ b/src/adhocracy_mercator/adhocracy_mercator/sheets/test_mercator2.py
@@ -1027,6 +1027,12 @@ class TestExtraFundingSchema:
             {'other_sources': 'XYZ grant',
              'secured': False}
 
+    def test_deserialize_empty_other_sources(self, inst, cstruct_required):
+        assert inst.deserialize({'other_sources': '',
+                                 'secured': 'False'}) == \
+            {'other_sources': '',
+             'secured': False}
+
 
 class TestExtraFundingSheet:
 


### PR DESCRIPTION
Fixes #1985 

The problem may be more global since the deserialize function is behaving the same for `null` or `""` (empty string) there is no way to distinguish between case one: we want to ignore the value (drop) and case two we want to set it to an empty value.

Here we solve the problem by suppressing the drop behavior for the field but what is solution in general @joka ?