### PR TITLE
add missing leaflet dependency in spd

### DIFF
--- a/src/spd/spd/static/js/Adhocracy.ts
+++ b/src/spd/spd/static/js/Adhocracy.ts
@@ -3,6 +3,7 @@
 /// <reference path="../lib/DefinitelyTyped/lodash/lodash.d.ts"/>
 /// <reference path="../lib/DefinitelyTyped/modernizr/modernizr.d.ts"/>
 /// <reference path="../lib/DefinitelyTyped/moment/moment.d.ts"/>
+/// <reference path="../lib/DefinitelyTyped/leaflet/leaflet.d.ts"/>
 /// <reference path="./_all.d.ts"/>
 
 import * as angular from "angular";
@@ -20,6 +21,7 @@ import * as angularFlow from "angularFlow";  if (angularFlow) { ; };
 import * as markdownit from "markdownit";
 import * as modernizr from "modernizr";
 import * as moment from "moment";
+import * as leaflet from "leaflet";
 import * as webshim from "polyfiller";
 
 import * as AdhAbuseModule from "./Packages/Abuse/Module";
@@ -153,6 +155,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
     app.value("angular", angular);
     app.value("modernizr", modernizr);
     app.value("moment", moment);
+    app.value("leaflet", leaflet);
 
     // register our modules
     app.value("adhConfig", config);


### PR DESCRIPTION
leaflet is not actually used, but adhDocument can optionally have a map, so it depends on leaflet.