### PR TITLE
Remove unused splinter flags in tox

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/scaffolds/adhocracy/tox.ini
+++ b/src/adhocracy_frontend/adhocracy_frontend/scaffolds/adhocracy/tox.ini
@@ -7,11 +7,6 @@ addopts =
     --doctest-glob='*.rst'
     --tb=native
     --capture=no
-    --splinter-implicit-wait=1
-    --splinter-speed=0
-    --splinter-socket-timeout=120
-    --splinter-webdriver=phantomjs
-    --splinter-make-screenshot-on-failure=false
 python_files = test_*.py
 markers =
     functional: mark tests that start the complete pyramid app and the websocket server

--- a/src/adhocracy_frontend/tox.ini
+++ b/src/adhocracy_frontend/tox.ini
@@ -7,11 +7,6 @@ addopts =
     --doctest-glob='*.rst'
     --tb=native
     --capture=no
-    --splinter-implicit-wait=1
-    --splinter-speed=0
-    --splinter-socket-timeout=120
-    --splinter-webdriver=phantomjs
-    --splinter-make-screenshot-on-failure=false
 python_files = test_*.py
 markers =
     functional: mark tests that start the complete pyramid app and the websocket server

--- a/src/aula/tox.ini
+++ b/src/aula/tox.ini
@@ -7,11 +7,6 @@ addopts =
     --doctest-glob='*.rst'
     --tb=native
     --capture=no
-    --splinter-implicit-wait=1
-    --splinter-speed=0
-    --splinter-socket-timeout=120
-    --splinter-webdriver=phantomjs
-    --splinter-make-screenshot-on-failure=false
 python_files = test_*.py
 markers =
     functional: mark tests that start the complete pyramid app and the websocket server

--- a/src/euth/tox.ini
+++ b/src/euth/tox.ini
@@ -7,11 +7,6 @@ addopts =
     --doctest-glob='*.rst'
     --tb=native
     --capture=no
-    --splinter-implicit-wait=1
-    --splinter-speed=0
-    --splinter-socket-timeout=120
-    --splinter-webdriver=phantomjs
-    --splinter-make-screenshot-on-failure=false
 python_files = test_*.py
 markers =
     functional: mark tests that start the complete pyramid app and the websocket server

--- a/src/meinberlin/tox.ini
+++ b/src/meinberlin/tox.ini
@@ -7,11 +7,6 @@ addopts =
     --doctest-glob='*.rst'
     --tb=native
     --capture=no
-    --splinter-implicit-wait=1
-    --splinter-speed=0
-    --splinter-socket-timeout=120
-    --splinter-webdriver=phantomjs
-    --splinter-make-screenshot-on-failure=false
 python_files = test_*.py
 markers =
     functional: mark tests that start the complete pyramid app and the websocket server

--- a/src/pcompass/tox.ini
+++ b/src/pcompass/tox.ini
@@ -7,11 +7,6 @@ addopts =
     --doctest-glob='*.rst'
     --tb=native
     --capture=no
-    --splinter-implicit-wait=1
-    --splinter-speed=0
-    --splinter-socket-timeout=120
-    --splinter-webdriver=phantomjs
-    --splinter-make-screenshot-on-failure=false
 python_files = test_*.py
 markers =
     functional: mark tests that start the complete pyramid app and the websocket server

--- a/src/s1/tox.ini
+++ b/src/s1/tox.ini
@@ -7,11 +7,6 @@ addopts =
     --doctest-glob='*.rst'
     --tb=native
     --capture=no
-    --splinter-implicit-wait=1
-    --splinter-speed=0
-    --splinter-socket-timeout=120
-    --splinter-webdriver=phantomjs
-    --splinter-make-screenshot-on-failure=false
 python_files = test_*.py
 markers =
     functional: mark tests that start the complete pyramid app and the websocket server

--- a/src/spd/tox.ini
+++ b/src/spd/tox.ini
@@ -7,11 +7,6 @@ addopts =
     --doctest-glob='*.rst'
     --tb=native
     --capture=no
-    --splinter-implicit-wait=1
-    --splinter-speed=0
-    --splinter-socket-timeout=120
-    --splinter-webdriver=phantomjs
-    --splinter-make-screenshot-on-failure=false
 python_files = test_*.py
 markers =
     functional: mark tests that start the complete pyramid app and the websocket server


### PR DESCRIPTION
This prevented to executed one of the frontend test directly with
py.test.