### PR TITLE
Remove unused rates back-references for IRateable

### DIFF
--- a/src/adhocracy_core/adhocracy_core/sheets/rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/rate.py
@@ -16,7 +16,6 @@ from adhocracy_core.sheets import add_sheet_to_registry
 from adhocracy_core.sheets import AttributeResourceSheet
 from adhocracy_core.schema import Integer
 from adhocracy_core.schema import Reference as ReferenceSchema
-from adhocracy_core.schema import UniqueReferences
 from adhocracy_core.schema import PostPool
 from adhocracy_core.sheets import sheet_meta
 from adhocracy_core.utils import get_user
@@ -196,9 +195,6 @@ class RateableSchema(colander.MappingSchema):
     `post_pool`: Pool to post new :class:`adhocracy_sample.resource.IRate`.
     """
 
-    rates = UniqueReferences(readonly=True,
-                             backref=True,
-                             reftype=RateObjectReference)
     post_pool = PostPool(iresource_or_service_name='rates')
 
 

--- a/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
@@ -39,9 +39,7 @@ class TestRateableSheet:
 
     def test_get_empty(self, inst):
         post_pool = inst.context['rates']
-        assert inst.get() == {'post_pool': post_pool,
-                              'rates': [],
-                              }
+        assert inst.get() == {'post_pool': post_pool}
 
 
 class TestRateSheet:


### PR DESCRIPTION
Workaround to improve performance. This pull request is part of issue #1932

API CHANGE:

rm field: IRateable:rates
