### PR TITLE
(very) basic process overview

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Listing.html
@@ -1,0 +1,3 @@
+<adh-listing data-content-type="{{contentType}}" data-params="params" data-path="/" data-no-create-form="true">
+    <adh-process-list-item data-path="{{element}}"></adh-process-list-item>
+</adh-listing>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Module.ts
@@ -12,5 +12,7 @@ export var register = (angular) => {
         ])
         .provider("adhProcess", AdhProcess.Provider)
         .directive("adhWorkflowSwitch", ["adhConfig", "adhHttp", "adhPermissions", "$window", AdhProcess.workflowSwitchDirective])
-        .directive("adhProcessView", ["adhTopLevelState", "adhProcess", "$compile", AdhProcess.processViewDirective]);
+        .directive("adhProcessView", ["adhTopLevelState", "adhProcess", "$compile", AdhProcess.processViewDirective])
+        .directive("adhProcessListItem", AdhProcess.listItemDirective)
+        .directive("adhProcessListing", ["adhConfig", AdhProcess.listingDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
@@ -8,6 +8,7 @@ import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 
 import * as SIName from "../../Resources_/adhocracy_core/sheets/name/IName";
 import * as SIWorkflow from "../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
+import RIProcess from "../../Resources_/adhocracy_core/resources/process/IProcess";
 
 var pkgLocation = "/Process";
 
@@ -126,6 +127,30 @@ export var processViewDirective = (
                     });
                 }
             });
+        }
+    };
+};
+
+export var listItemDirective = () => {
+    return {
+        restrict: "E",
+        scope: {
+            path: "@"
+        },
+        template: "<a data-ng-href=\"{{ path | adhResourceUrl }}\">{{path}}</a>"
+    };
+};
+
+export var listingDirective = (adhConfig : AdhConfig.IService) => {
+    return {
+        restrict: "E",
+        scope: {},
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Listing.html",
+        link: (scope) => {
+            scope.contentType = RIProcess.content_type;
+            scope.params = {
+                depth: "all"
+            };
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/Module.ts
@@ -6,6 +6,8 @@ import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhUtil from "../Util/Util";
 
+import RIRootPool from "../../Resources_/adhocracy_core/resources/root/IRootPool";
+
 import * as AdhResourceArea from "./ResourceArea";
 
 
@@ -22,6 +24,11 @@ export var register = (angular) => {
         .config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
             adhTopLevelStateProvider
                 .when("r", ["adhResourceArea", (adhResourceArea : AdhResourceArea.Service) => adhResourceArea]);
+        }])
+        .config(["adhResourceAreaProvider", (adhResourceAreaProvider : AdhResourceArea.Provider) => {
+            adhResourceAreaProvider.default(RIRootPool, "", "", "", {
+                space: "overview"
+            });
         }])
         .provider("adhResourceArea", AdhResourceArea.Provider)
         .directive("adhResourceArea", ["adhResourceArea", "$compile", AdhResourceArea.directive])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.html
@@ -1,4 +1,10 @@
 <adh-page-wrapper>
+    <adh-space data-key="overview">
+        <div class="l-center">
+            <adh-process-listing></adh-process-listing>
+        </div>
+    </adh-space>
+
     <adh-space data-key="content">
         <adh-process-view></adh-process-view>
     </adh-space>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -306,6 +306,10 @@ export class Service implements AdhTopLevelState.IAreaInput {
         var self : Service = this;
         var segs : string[] = path.replace(/\/+$/, "").split("/");
 
+        if (path === "/") {
+            segs = ["", ""];
+        }
+
         if (segs.length < 2 || segs[0] !== "") {
             throw "bad path: " + path;
         }
@@ -323,7 +327,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
             view = segs.pop().replace(/^@/, "");
         }
 
-        var resourceUrl : string = this.adhConfig.rest_url + segs.join("/") + "/";
+        var resourceUrl : string = this.adhConfig.rest_url + (segs.join("/") + "/").replace(/\/+$/, "/");
 
         return self.$q.all([
             self.adhHttp.get(resourceUrl),


### PR DESCRIPTION
This adds an extremely basic process overview. The following issues still exist:

-  [ ] proper list items
-  [ ] tile layout for listings
-  [ ] do not automatically create `/adhocracy/` process
-  [ ] Many processes rely on an embed context to work properly. This is mostly used for replacing the header. When using a process overview, all processes are in the same context.