### PR TITLE
remove IVersion sheet followed_by field

### DIFF
--- a/src/adhocracy_core/adhocracy_core/resources/test_itemversion.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_itemversion.py
@@ -105,6 +105,7 @@ class TestItemVersion:
     def test_autoupdate_with_referencing_versionable(self, config, registry,
                                                      item, other_item):
         # for more tests see adhocracy_core.resources.subscriber
+        from pyramid.traversal import resource_path
         from adhocracy_core.sheets.document import IDocument
         from adhocracy_core.resources.itemversion import itemversion_meta
         from adhocracy_core.resources import add_resource_type_to_registry
@@ -122,6 +123,6 @@ class TestItemVersion:
         referenced_v1 = self.make_one(registry, item, follows=[referenced_v0])
         referenced_v1.v1 = 1
 
-        referencing_v0_versions = get_sheet(referenceing_v0, IVersionable).get()
-        assert len(referencing_v0_versions['followed_by']) == 1
+        referenceing_v0_path = resource_path(referenceing_v0)
+        assert registry.changelog[referenceing_v0_path].followed_by
 

--- a/src/adhocracy_core/adhocracy_core/sheets/test_versions.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_versions.py
@@ -182,13 +182,6 @@ class TestVersionableSheet:
         inst = meta.sheet_class(meta, context)
         data = inst.get()
         assert list(data['follows']) == []
-        assert list(data['followed_by']) == []
-
-    def test_set_with_followed_by(self, meta, context):
-        inst = meta.sheet_class(meta, context)
-        inst.set({'followed_by': iter([])})
-        appstruct = getattr(context, inst._annotation_key)
-        assert not 'followed_by' in appstruct
 
 
 def test_includeme_register_versionable_sheet(config):

--- a/src/adhocracy_core/adhocracy_core/sheets/versions.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/versions.py
@@ -80,15 +80,11 @@ def deferred_validate_follows(node: colander.SchemaNode, kw: dict) -> callable:
 class VersionableSchema(colander.MappingSchema):
     """Versionable sheet data structure.
 
-    Set/get predecessor (`follows`) and get successor (`followed_by`) versions
-    of this resource.
+    Set/get predecessor (`follows`) versions of this resource.
     """
 
     follows = UniqueReferences(reftype=VersionableFollowsReference,
                                validator=deferred_validate_follows)
-    followed_by = UniqueReferences(readonly=True,
-                                   backref=True,
-                                   reftype=VersionableFollowsReference)
 
 
 versionable_meta = sheet_meta._replace(

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -578,7 +578,7 @@ Fetch the first Document version, it is empty ::
     {'elements': []}
 
     >>> pprint(resp.json['data']['adhocracy_core.sheets.versions.IVersionable'])
-    {'followed_by': [], 'follows': []}
+    {'follows': []}
 
 but owned by the Document item creator::
     >>> pprint(resp.json['data']['adhocracy_core.sheets.metadata.IMetadata']['creator'])
@@ -608,14 +608,6 @@ to work ::
     >>> vers_fields = resp.json['sheets']['adhocracy_core.sheets.versions.IVersionable']['fields']
     >>> pprint(sorted(vers_fields, key=itemgetter('name')))
     [{'containertype': 'list',
-      'creatable': False,
-      'create_mandatory': False,
-      'editable': False,
-      'name': 'followed_by',
-      'readable': True,
-      'targetsheet': 'adhocracy_core.sheets.versions.IVersionable',
-      'valuetype': 'adhocracy_core.schema.AbsolutePath'},
-     {'containertype': 'list',
       'creatable': True,
       'create_mandatory': False,
       'editable': True,
@@ -625,10 +617,7 @@ to work ::
       'valuetype': 'adhocracy_core.schema.AbsolutePath'}]
 
 The 'follows' element must be set by the client when it creates a new
-version that is the successor of one or several earlier versions. The
-'followed_by' element is automatically populated by the server by
-"reversing" any 'follows' links pointing to the version in question.
-Therefore 'followed_by' is read-only, while 'follows' is writable.
+version that is the successor of one or several earlier versions.
 
 Create a Section item inside the Document item ::
 
@@ -736,7 +725,7 @@ But if we set the `root_version` to the last  Document version (pvrs3)::
     ...         }
     >>> resp = testapp.post_json(s2dag_path, svrs, headers=god_header)
 
-a new version is automatically created only for pvrs3, not for pvrs2::
+a new version pvrs4 is automatically created following only pvrs3, not pvrs2::
 
     >>> resp = testapp.get(pdag_path)
     >>> pprint(resp.json['data']['adhocracy_core.sheets.versions.IVersions'])
@@ -746,15 +735,14 @@ a new version is automatically created only for pvrs3, not for pvrs2::
                   '.../Documents/document_0000000/VERSION_0000003/',
                   '.../Documents/document_0000000/VERSION_0000004/']}
 
-    >>> resp = testapp.get(rest_url + '/Documents/document_0000000/VERSION_0000003')
-    >>> pvrs4_path = resp.json['path']
-    >>> resp = testapp.get(rest_url + '/Documents/document_0000000/VERSION_0000003')
-    >>> len(resp.json['data']['adhocracy_core.sheets.versions.IVersionable']['followed_by'])
-    1
-
     >>> resp = testapp.get(rest_url + '/Documents/document_0000000/VERSION_0000004')
-    >>> len(resp.json['data']['adhocracy_core.sheets.versions.IVersionable']['followed_by'])
-    0
+    >>> pvrs4_path = resp.json['path']
+    >>> resp.json['data']['adhocracy_core.sheets.versions.IVersionable']['follows']
+    [.../Documents/document_0000000/VERSION_0000003/']
+
+    >>> resp = testapp.get(rest_url + '/Documents/document_0000000/VERSION_0000003')
+    >>> resp.json['data']['adhocracy_core.sheets.versions.IVersionable']['follows']
+    [.../Documents/document_0000000/VERSION_0000002/']
 
 
 


### PR DESCRIPTION
part of https://github.com/liqd/adhocracy3/issues/1932

API CHANGE:

- rm 'followed_by" backreference field of IVersions sheet

This  has a small performance impact and this field is actually not used. 
If you want to traverse all versions you can use the 'first'  tag of the item and follow the 'follows' field, use the `elements`field or  do a search query.