### PR TITLE
Fixup delete paragraphs

### DIFF
--- a/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
+++ b/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
@@ -191,7 +191,8 @@ export var createDirective = (
             scope.data = {
                 title: "",
                 paragraphs: [{
-                    body: ""
+                    body: "",
+                    deleted: false
                 }]
             };
             scope.showError = adhShowError;


### PR DESCRIPTION
This is a small fixup to #2019: adhBlog builds upon adhDocument, but does not use the paragraph feature. The the changes in #2019 are not relevant for this except for a changed type.