### PR TITLE
refactor colors

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
@@ -74,7 +74,6 @@ is selected, no state is applied.
 .comment-children-create-form,
 .comment-children-edit-form {
     @extend .listing-create-form;
-    background: $color-background-base-introvert;
 }
 
 /*doc
@@ -274,7 +273,6 @@ parent: comment
 .comment-create-form-text,
 .comment-edit-form-text {
     @include rem(min-height, 5.8rem);
-    background: $color-text-inverted;
 }
 
 .comment-edit-form-text {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -105,7 +105,7 @@ textarea {
     @include rem(padding, 0.25rem 1rem);
     display: block;
     width: 100%;
-    border: 1px solid $color-structure-border;
+    border: 1px solid $color-structure-introvert;
     color: $color-text-normal;
     background-color: $color-background-base;
 
@@ -293,8 +293,8 @@ This error concerns the whole form.
 .form-error {
     @include rem(margin, 1rem 0);
     @include rem(padding, 0 1rem);
-    border-top: 1px solid $color-structure-border;
-    border-bottom: 1px solid $color-structure-border;
+    border-top: 1px solid $color-structure-introvert;
+    border-bottom: 1px solid $color-structure-introvert;
     background: $color-structure-introvert;
 }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -118,11 +118,6 @@ textarea {
         @include rem(font-size, $font-size-large);
     }
 
-    &:focus {
-        border-color: $color-text-highlight-normal;
-        outline: 1px solid $color-text-highlight-normal;
-    }
-
     &.ng-dirty.ng-invalid {
         @extend .error-state;
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_listing.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_listing.scss
@@ -47,7 +47,6 @@ a form for creating new elements. This form is then always visible.
 .listing-create-form {
     @include rem(margin-bottom, 1rem);
     @include rem(padding, 1rem 20px 12px);
-    background-color: $color-structure-introvert;
 
     .comment-create-form-text {
         @include rem(margin-bottom, 20px);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_listing.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_listing.scss
@@ -53,7 +53,7 @@ a form for creating new elements. This form is then always visible.
 .load-more {
     display: block;
     line-height: 2;
-    background: $color-structure-extrovert;
+    background: $color-structure-introvert;
     color: $color-text-inverted;
     text-align: center;
     text-decoration: none;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_listing.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_listing.scss
@@ -29,21 +29,6 @@ a form for creating new elements. This form is then always visible.
     margin: 0;
 }
 
-// starting animations
-.listing-element {
-    &.ng-enter {
-        @include transition(all 0.3s);
-        @include opacity(0.5);
-        background: $color-function-animation-enter;
-
-        // destination animations
-        &.ng-enter-active {
-            @include opacity(1);
-            background: $color-background-base;
-        }
-    }
-}
-
 .listing-create-form {
     @include rem(margin-bottom, 1rem);
     @include rem(padding, 1rem 20px 12px);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -370,7 +370,7 @@ A list of alert messages to notify users in the moving column
     @include clearfix;
     @include rem(padding, 1rem);
     background: $color-structure-normal;
-    border-top: 1px solid $color-structure-border;
+    border-top: 1px solid $color-structure-introvert;
     // .leaflet-top has 1000
     z-index: 1000;
     max-height: 80%;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -295,7 +295,7 @@ States:
         background-color: $color-structure-introvert;
 
         &:hover, &:focus {
-            color: $color-brand-three-normal;
+            color: $color-text-highlight-normal;
         }
 
         &:active {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
@@ -47,14 +47,14 @@ $arrow-width: 1rem;
     margin-left: $arrow-width;
     text-transform: uppercase;
     line-height: $line-height;
-    background-color: $color-brand-one-normal;
-    color: $color-text-inverted;
+    background-color: $color-button-cta-base;
+    color: $color-button-cta-text;
     cursor: pointer;
     text-align: center;
     text-decoration: none;
 
     &:before {
-        @include rem(border-right, $arrow-width solid $color-brand-one-normal);
+        @include rem(border-right, $arrow-width solid $color-button-cta-base);
         border-top: $line-height/2 * 1em solid $color-structure-transparent;
         border-bottom: $line-height/2 * 1em solid $color-structure-transparent;
         content: "";
@@ -66,11 +66,11 @@ $arrow-width: 1rem;
     }
 
     &:hover, &:focus {
-        color: $color-text-inverted;
-        background-color: $color-brand-one-extrovert;
+        color: $color-button-cta-text;
+        background-color: $color-button-cta-hover-background;
 
         &:before {
-            border-right-color: $color-brand-one-extrovert;
+            border-right-color: $color-button-cta-hover-background;
         }
     }
 
@@ -90,7 +90,7 @@ $arrow-width: 1rem;
         // That's why it is skipped here.
         &:hover {
             // scss-lint:disable NestingDepth
-            background: $color-brand-three-normal;
+            background: $color-button-cta-base;
 
             .supporting .text-unsupport {
                 display: block;
@@ -101,7 +101,7 @@ $arrow-width: 1rem;
             }
 
             &:before {
-                border-right-color: $color-brand-three-normal;
+                border-right-color: $color-button-cta-base;
             }
         }
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
@@ -26,7 +26,7 @@ The button has the is-rate-button-active state.
     &.is-disabled {
         .like-button, .like-button:hover, .like-button:focus {
             background: $color-structure-normal;
-            color: $color-structure-extrovert;
+            color: $color-structure-introvert;
 
             &:before {
                 border-right-color: $color-structure-normal;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_tabs.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_tabs.scss
@@ -33,7 +33,7 @@
 
         .tab-button {
             @include rem(padding, 0.5rem 1rem);
-            background: $color-structure-border;
+            background: $color-structure-introvert;
             color: $color-text-inverted;
             display: block;
             margin-right: 1px;
@@ -50,7 +50,7 @@
         &.is-active {
             .tab-button {
                 background: $color-background-base-introvert;
-                border: 1px solid $color-structure-border;
+                border: 1px solid $color-structure-introvert;
                 border-width: 1px 1px 0;
                 color: $color-text-normal;
                 font-weight: bold;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_type.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_type.scss
@@ -231,7 +231,7 @@ table {
     td, th {
         @include rem(padding, 0.5rem);
         @include text-align(start);
-        border-top: 1px solid $color-structure-border;
+        border-top: 1px solid $color-structure-introvert;
         vertical-align: top;
     }
 
@@ -414,7 +414,7 @@ pre {
     @include rem(padding, 0.7rem);
     display: block;
     background-color: $color-structure-introvert;
-    border: 1px solid $color-structure-border;
+    border: 1px solid $color-structure-introvert;
     overflow: auto;
 
     code {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_indicator.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_user_indicator.scss
@@ -31,16 +31,11 @@ It is usually used in the header bar.
     .user-indicator-login,
     .user-indicator-register {
         @include rem(font-size, $font-size-plus);
-        color: $color-text-highlight-introvert;
         font-variant: small-caps;
         text-transform: lowercase;
 
         &:hover, &:focus {
             text-decoration: underline;
-        }
-
-        &:active {
-            color: $color-text-normal;
         }
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/debug/_placeholder.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/debug/_placeholder.scss
@@ -16,7 +16,7 @@ documentation. It can be used to style elements that are not yet done.
     @include rem(min-width, 3rem);
     @include rem(min-height, 3rem);
     background-color: $color-structure-normal;
-    border: 2px dashed $color-structure-border;
+    border: 2px dashed $color-structure-introvert;
     color: $color-text-introvert;
     text-align: center;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -1,12 +1,12 @@
 /* documentation is in variables_doc */
 
 // Text colors
-$color-text-normal: #575756;
-$color-text-introvert: #808080;
-$color-text-extrovert: #1c1c1b;
-$color-text-highlight-normal: #26a9e0;
-$color-text-highlight-introvert: #808080;
-$color-text-highlight-extrovert: #333;
+$color-text-normal: #444;
+$color-text-introvert: lighten($color-text-normal, 15%);
+$color-text-extrovert: darken($color-text-normal, 10%);
+$color-text-highlight-normal: #026dca;
+$color-text-highlight-introvert: darken($color-text-highlight-normal, 10%);
+$color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);
 $color-text-inverted: white;
 
 // Function colors

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -22,7 +22,6 @@ $color-background-mask: black;
 // Structure colors
 $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
-$color-structure-border: #9d9c9c;
 $color-structure-transparent: transparent;
 
 //Brand colors

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -22,7 +22,6 @@ $color-background-mask: black;
 // Structure colors
 $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
-$color-structure-extrovert: #999;
 $color-structure-border: #9d9c9c;
 $color-structure-transparent: transparent;
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -13,7 +13,6 @@ $color-text-inverted: white;
 $color-function-valid: #2eac66;
 $color-function-invalid: #e6332a;
 $color-function-neutral: #f6d02b;
-$color-function-animation-enter: greenyellow;
 
 // Background colors
 $color-background-base: white;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -33,9 +33,6 @@ $color-brand-one-extrovert: lighten($color-brand-one-normal, 10%);
 $color-brand-two-normal: #00aae5;
 $color-brand-two-introvert: darken($color-brand-two-normal, 10%);
 $color-brand-two-extrovert: lighten($color-brand-two-normal, 10%);
-$color-brand-three-normal: #ce128b;
-$color-brand-three-introvert: darken($color-brand-three-normal, 10%);
-$color-brand-three-extrovert: lighten($color-brand-three-normal, 10%);
 
 $font-family-normal: "Lato", sans-serif;
 $font-weight-introvert: 400;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -37,9 +37,6 @@ $color-brand-two-extrovert: lighten($color-brand-two-normal, 10%);
 $color-brand-three-normal: #ce128b;
 $color-brand-three-introvert: darken($color-brand-three-normal, 10%);
 $color-brand-three-extrovert: lighten($color-brand-three-normal, 10%);
-$color-brand-four-normal: #73bf44;
-$color-brand-four-introvert: darken($color-brand-four-normal, 10%);
-$color-brand-four-extrovert: lighten($color-brand-four-normal, 10%);
 
 $font-family-normal: "Lato", sans-serif;
 $font-weight-introvert: 400;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -112,11 +112,6 @@ category: Variables
         <td>For neutral (neither valid nor invalid) content</td>
     </tr>
     <tr>
-        <td><div class="example-color color-function-animation-enter"></div></td>
-        <td><code>color-function-animation-enter</code></td>
-        <td>For flashing elements that appear.</td>
-    </tr>
-    <tr>
         <td colspan="3"><strong>Structural colors</strong></td>
     </tr>
     <tr>
@@ -226,7 +221,6 @@ category: Variables
 .color-function-valid {background-color: $color-function-valid;}
 .color-function-invalid {background-color: $color-function-invalid;}
 .color-function-neutral {background-color: $color-function-neutral;}
-.color-function-animation-enter {background-color: $color-function-animation-enter;}
 
 .color-background-base {background-color: $color-background-base;}
 .color-background-base-introvert {background-color: $color-background-base-introvert;}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -20,6 +20,11 @@ category: Variables
         <td>For secondary text</td>
     </tr>
     <tr>
+        <td><div class="example-color color-text-extrovert"></div></td>
+        <td><code>color-text-extrovert</code></td>
+        <td></td>
+    </tr>
+    <tr>
         <td><div class="example-color color-text-inverted"></div></td>
         <td><code>color-text-inverted</code></td>
         <td>Used as either foreground or background with
@@ -122,6 +127,11 @@ category: Variables
         <td>For neutral (neither valid nor invalid) content</td>
     </tr>
     <tr>
+        <td><div class="example-color color-function-animation-enter"></div></td>
+        <td><code>color-function-animation-enter</code></td>
+        <td>For flashing elements that appear.</td>
+    </tr>
+    <tr>
         <td colspan="3"><strong>Structural colors</strong></td>
     </tr>
     <tr>
@@ -140,6 +150,16 @@ category: Variables
         <td>border color for active or filled elements</td>
     </tr>
     <tr>
+        <td><div class="example-color color-structure-border"></div></td>
+        <td><code>color-structure-border</code></td>
+        <td>border color</td>
+    </tr>
+    <tr>
+        <td><div class="example-color color-structure-transparent"></div></td>
+        <td><code>color-structure-transparent</code></td>
+        <td></td>
+    </tr>
+    <tr>
         <td colspan="3"><strong>Background colors</strong></td>
     </tr>
     <tr>
@@ -151,6 +171,11 @@ category: Variables
         <td><div class="example-color color-background-base-introvert"></div></td>
         <td><code>color-background-base-introvert</code></td>
         <td></td>
+    </tr>
+    <tr>
+        <td><div class="example-color color-background-mask"></div></td>
+        <td><code>color-background-mask</code></td>
+        <td>Mask behind an overlay</td>
     </tr>
     <tr>
         <td colspan="3"><strong>Button colors</strong></td>
@@ -219,14 +244,17 @@ category: Variables
 .color-function-valid {background-color: $color-function-valid;}
 .color-function-invalid {background-color: $color-function-invalid;}
 .color-function-neutral {background-color: $color-function-neutral;}
+.color-function-animation-enter {background-color: $color-function-animation-enter;}
 
 .color-background-base {background-color: $color-background-base;}
 .color-background-base-introvert {background-color: $color-background-base-introvert;}
+.color-background-mask {background-color: $color-background-mask;}
 
 .color-structure-normal {background-color: $color-structure-normal;}
 .color-structure-introvert {background-color: $color-structure-introvert;}
 .color-structure-extrovert {background-color: $color-structure-extrovert;}
 .color-structure-border {background-color: $color-structure-border;}
+.color-structure-transparent {background-color: $color-structure-transparent;}
 
 .color-button-text {background-color: $color-button-text;}
 .color-button-text-hover {background-color: $color-button-text-hover;}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -94,21 +94,6 @@ category: Variables
         <td>Brand color 3 extroverted style</td>
     </tr>
     <tr>
-        <td><div class="example-color color-brand-four-normal"></div></td>
-        <td><code>color-brand-four-normal</code></td>
-        <td>Brand color 4</td>
-    </tr>
-    <tr>
-        <td><div class="example-color color-brand-four-introvert"></div></td>
-        <td><code>color-brand-four-introvert</code></td>
-        <td>Brand color 4 introverted style</td>
-    </tr>
-    <tr>
-        <td><div class="example-color color-brand-four-extrovert"></div></td>
-        <td><code>color-brand-four-extrovert</code></td>
-        <td>Brand color 4 extroverted style</td>
-    </tr>
-    <tr>
         <td colspan="3"><strong>Functional colors</strong></td>
     </tr>
     <tr>
@@ -229,9 +214,6 @@ category: Variables
 .color-brand-three-normal {background-color: $color-brand-three-normal;}
 .color-brand-three-introvert {background-color: $color-brand-three-introvert;}
 .color-brand-three-extrovert {background-color: $color-brand-three-extrovert;}
-.color-brand-four-normal {background-color: $color-brand-four-normal;}
-.color-brand-four-introvert {background-color: $color-brand-four-introvert;}
-.color-brand-four-extrovert {background-color: $color-brand-four-extrovert;}
 
 .color-text-normal {background-color: $color-text-normal;}
 .color-text-introvert {background-color: $color-text-introvert;}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -79,21 +79,6 @@ category: Variables
         <td>Brand color 2 extroverted style</td>
     </tr>
     <tr>
-        <td><div class="example-color color-brand-three-normal"></div></td>
-        <td><code>color-brand-three-normal</code></td>
-        <td>Brand color 3</td>
-    </tr>
-    <tr>
-        <td><div class="example-color color-brand-three-introvert"></div></td>
-        <td><code>color-brand-three-introvert</code></td>
-        <td>Brand color 3 introverted style</td>
-    </tr>
-    <tr>
-        <td><div class="example-color color-brand-three-extrovert"></div></td>
-        <td><code>color-brand-three-extrovert</code></td>
-        <td>Brand color 3 extroverted style</td>
-    </tr>
-    <tr>
         <td colspan="3"><strong>Functional colors</strong></td>
     </tr>
     <tr>
@@ -206,9 +191,6 @@ category: Variables
 .color-brand-two-normal {background-color: $color-brand-two-normal;}
 .color-brand-two-introvert {background-color: $color-brand-two-introvert;}
 .color-brand-two-extrovert {background-color: $color-brand-two-extrovert;}
-.color-brand-three-normal {background-color: $color-brand-three-normal;}
-.color-brand-three-introvert {background-color: $color-brand-three-introvert;}
-.color-brand-three-extrovert {background-color: $color-brand-three-extrovert;}
 
 .color-text-normal {background-color: $color-text-normal;}
 .color-text-introvert {background-color: $color-text-introvert;}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -177,7 +177,7 @@ category: Variables
     @include inline-block;
     height: 3rem;
     width: 3rem;
-    border: 1px solid $color-structure-border;
+    border: 1px solid $color-structure-introvert;
 }
 
 .color-brand-one-normal {background-color: $color-brand-one-normal;}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -110,11 +110,6 @@ category: Variables
         <td>Secondary background color</td>
     </tr>
     <tr>
-        <td><div class="example-color color-structure-border"></div></td>
-        <td><code>color-structure-border</code></td>
-        <td>border color</td>
-    </tr>
-    <tr>
         <td><div class="example-color color-structure-transparent"></div></td>
         <td><code>color-structure-transparent</code></td>
         <td></td>
@@ -205,7 +200,6 @@ category: Variables
 
 .color-structure-normal {background-color: $color-structure-normal;}
 .color-structure-introvert {background-color: $color-structure-introvert;}
-.color-structure-border {background-color: $color-structure-border;}
 .color-structure-transparent {background-color: $color-structure-transparent;}
 
 .color-button-text {background-color: $color-button-text;}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -110,11 +110,6 @@ category: Variables
         <td>Secondary background color</td>
     </tr>
     <tr>
-        <td><div class="example-color color-structure-extrovert"></div></td>
-        <td><code>color-structure-extrovert</code></td>
-        <td>border color for active or filled elements</td>
-    </tr>
-    <tr>
         <td><div class="example-color color-structure-border"></div></td>
         <td><code>color-structure-border</code></td>
         <td>border color</td>
@@ -210,7 +205,6 @@ category: Variables
 
 .color-structure-normal {background-color: $color-structure-normal;}
 .color-structure-introvert {background-color: $color-structure-introvert;}
-.color-structure-extrovert {background-color: $color-structure-extrovert;}
 .color-structure-border {background-color: $color-structure-border;}
 .color-structure-transparent {background-color: $color-structure-transparent;}
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -214,6 +214,8 @@ category: Variables
 @include check-contrast($color-text-normal, $color-structure-introvert);
 @include check-contrast($color-text-extrovert, $color-background-base);
 @include check-contrast($color-text-extrovert, $color-structure-introvert);
-@include check-contrast($color-text-highlight-normal, $color-text-inverted);
+@include check-contrast($color-text-introvert, $color-background-base);
+@include check-contrast($color-text-introvert, $color-structure-introvert, 3);
+@include check-contrast($color-text-inverted, $color-text-highlight-normal);
 @include check-contrast($color-text-highlight-normal, $color-background-base);
-@include check-contrast($color-text-highlight-normal, $color-structure-introvert);
+@include check-contrast($color-text-highlight-normal, $color-background-base-introvert);

--- a/src/euth/euth/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/euth/euth/static/stylesheets/scss/general/_variables_theme.scss
@@ -13,9 +13,6 @@ $color-brand-one-extrovert: lighten($color-brand-one-normal, 10%);
 $color-brand-two-normal: #1468b3;
 $color-brand-two-introvert: #204379;
 $color-brand-two-extrovert: $color-brand-two-introvert;
-$color-brand-three-normal: $color-brand-one-normal;
-$color-brand-three-extrovert: lighten($color-brand-three-normal, 10%);
-$color-brand-three-extrovert: lighten($color-brand-three-normal, 10%);
 
 $font-family-normal: "Open Sans", sans-serif;
 $font-size-large: 18px;

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_comment_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_comment_theme.scss
@@ -6,16 +6,6 @@
 
 .comment-create-form,
 .comment-children-edit-form {
-    background: $color-background-base-introvert;
-    margin: 0;
-    padding: 0;
-
-    .comment-create-form-text,
-    .comment-edit-form-text {
-        @include rem(min-height, 70px);
-        margin: 0;
-    }
-
     .form-footer-button {
         @include rem(font-size, $font-size-small);
         @include rem(line-height, 24px);
@@ -56,16 +46,6 @@
 .comment-children-create-form,
 .comment-children-edit-form {
     @include rem(margin-bottom, 20px);
-
-    .comment-create-form, & {
-        background: transparent;
-
-        .comment-create-form-text,
-        .comment-edit-form-text {
-            background: $color-background-base-introvert;
-            border-left: 1px solid $color-text-highlight-normal;
-        }
-    }
 }
 
 .comment-main {

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_forms_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_forms_theme.scss
@@ -15,7 +15,6 @@ textarea {
     @include rem(margin-bottom, 15px);
     @include rem(padding, 5px $font-size-small);
     background: $color-background-base-introvert;
-    border: 0;
 }
 
 .label-text, .form-row, .login-check-input {

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_forms_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_forms_theme.scss
@@ -16,11 +16,6 @@ textarea {
     @include rem(padding, 5px $font-size-small);
     background: $color-background-base-introvert;
     border: 0;
-
-    &:focus {
-        border-color: $color-brand-one-normal;
-        outline: 1px solid $color-brand-one-normal;
-    }
 }
 
 .label-text, .form-row, .login-check-input {

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
@@ -1,30 +1,30 @@
 //brand colors
-$color-brand-one-normal: #31458a;
-$color-brand-one-introvert: #122556;
-$color-brand-one-extrovert: #8faff5;
-$color-brand-two-normal: #ff195a;
-$color-brand-two-introvert: #c81e50;
-$color-brand-two-extrovert: #f27179;
+$color-brand-one-normal: #253276;
+$color-brand-one-introvert: #162c60;
+$color-brand-one-extrovert: #31448a;
+$color-brand-two-normal: #cd0055;
+$color-brand-two-introvert: #ae0048;
+$color-brand-two-extrovert: #ed0062;
 
 // text colors
 $color-text-normal: #4c4c4c;
 $color-text-introvert: #666;
 $color-text-extrovert: #1c1c1b;
-$color-text-highlight-normal: #ec145a;
+$color-text-highlight-normal: $color-brand-two-normal;
 $color-text-highlight-introvert: $color-brand-two-introvert;
 $color-text-highlight-extrovert: #333;
 $color-text-inverted: white;
 
 // function colors
-$color-function-valid: #73bf44;
+$color-function-valid: #139156;
 $color-function-invalid: #f00;
 
 // background colors
 $color-background-base: white;
-$color-background-base-introvert: #f2f2f2;
+$color-background-base-introvert: #f6f6f6;
 
 // structure colors
-$color-structure-normal: #e6e6e6;
+$color-structure-normal: #e4e4e4;
 $color-structure-introvert: #ccc;
 
 //font sizes

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
@@ -26,7 +26,6 @@ $color-background-base-introvert: #f2f2f2;
 // structure colors
 $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
-$color-structure-extrovert: #808080;
 
 //font sizes
 $font-size-smaller: 10px;

--- a/src/mercator/mercator/static/stylesheets/scss/_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/_theme.scss
@@ -5,7 +5,6 @@
 @import "components/error_pages_theme";
 @import "components/forms_theme";
 @import "components/jury_decision_theme";
-@import "components/listing_theme";
 @import "components/mercator_proposal";
 @import "components/meta_list_theme";
 @import "components/rate_theme";

--- a/src/mercator/mercator/static/stylesheets/scss/components/_forms_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_forms_theme.scss
@@ -25,7 +25,6 @@ select,
 textarea,
 .country-select {
     background: $color-structure-normal;
-    border: 0;
     margin-bottom: $input-margin-bottom;
 
     &.ng-dirty.ng-invalid {

--- a/src/mercator/mercator/static/stylesheets/scss/components/_listing_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_listing_theme.scss
@@ -1,4 +1,0 @@
-.listing-create-form {
-    background-color: $color-structure-normal;
-    overflow: hidden;
-}

--- a/src/mercator/mercator/static/stylesheets/scss/components/_mercator_proposal.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_mercator_proposal.scss
@@ -194,10 +194,6 @@ $mercator-proposal-form-nav-width: 100% / 12 * 2;
     @include action-section-button;
     float: right;
 
-    &:hover, &:focus {
-        color: $color-brand-three-normal;
-    }
-
     i {
         @include rem(font-size, 23px);
     }

--- a/src/mercator/mercator/static/stylesheets/scss/components/_meta_list_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/components/_meta_list_theme.scss
@@ -19,15 +19,10 @@
         color: $color-text-highlight-normal;
     }
 
+    .meta-list-item-total-comments,
     .meta-list-item-supporters {
         i {
-            color: $color-brand-one-normal;
-        }
-    }
-
-    .meta-list-item-total-comments {
-        i {
-            color: $color-brand-three-normal;
+            color: $color-text-highlight-normal;
         }
     }
 }

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -25,7 +25,6 @@ $color-background-base-introvert: #f2f2f2;
 // structure colors
 $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
-$color-structure-extrovert: #999;
 $color-structure-border: #9d9c9c;
 
 //font sizes

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -4,7 +4,6 @@ $color-brand-one-extrovert: #fcd370;
 $color-brand-two-normal: #00aae5;
 $color-brand-two-introvert: #0097d5;
 $color-brand-two-extrovert: #89c5ec;
-$color-brand-three-normal: #ce128b;
 
 // text colors
 $color-text-normal: #333;

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -25,7 +25,6 @@ $color-background-base-introvert: #f2f2f2;
 // structure colors
 $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
-$color-structure-border: #9d9c9c;
 
 //font sizes
 $font-size-smaller: 10px;

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -5,7 +5,6 @@ $color-brand-two-normal: #00aae5;
 $color-brand-two-introvert: #0097d5;
 $color-brand-two-extrovert: #89c5ec;
 $color-brand-three-normal: #ce128b;
-$color-brand-four-normal: #73bf44;
 
 // text colors
 $color-text-normal: #333;
@@ -17,7 +16,7 @@ $color-text-highlight-extrovert: #333;
 $color-text-inverted: white;
 
 // function colors
-$color-function-valid: $color-brand-four-normal;
+$color-function-valid: #73bf44;
 $color-function-invalid: #f00;
 
 // background colors

--- a/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
@@ -18,9 +18,6 @@ $color-brand-two-extrovert: $color-brand-one-extrovert;
 $color-brand-three-normal: #949699;
 $color-brand-three-introvert: #565658;
 $color-brand-three-extrovert: #cecdce;
-$color-brand-four-normal: $color-brand-three-normal;
-$color-brand-four-introvert: $color-brand-three-introvert;
-$color-brand-four-extrovert: $color-brand-three-extrovert;
 
 // Text colors
 $color-text-normal: #4d4d4d;

--- a/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
@@ -15,9 +15,6 @@ $color-brand-one-extrovert: #faa84f;
 $color-brand-two-normal: $color-brand-one-normal;
 $color-brand-two-introvert: $color-brand-one-introvert;
 $color-brand-two-extrovert: $color-brand-one-extrovert;
-$color-brand-three-normal: #949699;
-$color-brand-three-introvert: #565658;
-$color-brand-three-extrovert: #cecdce;
 
 // Text colors
 $color-text-normal: #4d4d4d;

--- a/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
@@ -5,7 +5,6 @@ $color-brand-one-extrovert: #808080;
 $color-brand-two-normal: #29abe2;
 $color-brand-two-introvert: #7fcdee;
 $color-brand-two-extrovert: #1f80aa;
-$color-brand-three-normal: #666;
 
 // Text colors
 $color-text-normal: #333;

--- a/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
@@ -19,7 +19,6 @@ $color-function-invalid: #f00;
 $color-function-winner: #f79321;
 
 // Structure colors
-$color-structure-extrovert: #808080;
 $color-structure-border: $color-background-base-introvert;
 
 $font-family-normal: "Roboto", sans-serif;

--- a/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
@@ -18,9 +18,6 @@ $color-function-valid: #73bf44;
 $color-function-invalid: #f00;
 $color-function-winner: #f79321;
 
-// Structure colors
-$color-structure-border: $color-background-base-introvert;
-
 $font-family-normal: "Roboto", sans-serif;
 $font-family-serif: "Merriweather", serif;
 

--- a/src/spd/spd/static/stylesheets/scss/_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/_theme.scss
@@ -2,6 +2,5 @@
 @import "components/chapter_theme";
 @import "components/comment_theme";
 @import "components/forms_theme";
-@import "components/listing_theme";
 @import "components/standalone_wrapper_theme";
 @import "components/user_profile_theme";

--- a/src/spd/spd/static/stylesheets/scss/components/_forms_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_forms_theme.scss
@@ -20,7 +20,6 @@ input[type="number"],
 select,
 textarea {
     background: $color-background-base-introvert;
-    border: 0;
     margin-bottom: $input-margin-bottom;
 
     &.ng-dirty.ng-invalid {

--- a/src/spd/spd/static/stylesheets/scss/components/_listing_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_listing_theme.scss
@@ -1,4 +1,0 @@
-.listing-create-form {
-    background-color: $color-structure-normal;
-    overflow: hidden;
-}

--- a/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
@@ -13,9 +13,6 @@ $color-brand-one-extrovert: lighten($color-brand-one-normal, 10%);
 $color-brand-two-normal: #e3000f;
 $color-brand-two-introvert: #b61c3e;
 $color-brand-two-extrovert: $color-brand-two-introvert;
-$color-brand-three-normal: $color-brand-one-normal;
-$color-brand-three-extrovert: lighten($color-brand-three-normal, 10%);
-$color-brand-three-extrovert: lighten($color-brand-three-normal, 10%);
 
 $font-family-normal: "Open Sans", sans-serif;
 $font-size-large: 18px;


### PR DESCRIPTION
@stadine and me simplified the color scheme and improved contrast, especially for meinberlin:

-  `color-structure-extrovert` and `color-structure-border` were merged into `color-structure-introvert`
-  `color-brand-three-*` and `color-brand-four-*` were removed
-  input element are now closer to browser default styles, e.g. they have borders everywhere and the default `:focus` styling
-  colors on meinberlin were changed to match the colors used on berlin.de more closly and to have better contrast