### PR TITLE
build all styleguides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ src/aula/aula/build/
 RELEASE-VERSION
 *-requirements.txt
 /src/Mako/
+/styleguides

--- a/bin/all_styleguides
+++ b/bin/all_styleguides
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-projects="adhocracy_frontend mercator meinberlin spd pcompass s1"
+if [ -z ${1+x} ]; then
+    projects="adhocracy_frontend mercator meinberlin spd pcompass s1"
+else
+    projects=$1;
+fi
 
 for project in $projects; do
     builddir=src/$project/$project/build

--- a/bin/all_styleguides
+++ b/bin/all_styleguides
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -z ${1+x} ]; then
     projects="adhocracy_frontend mercator meinberlin spd pcompass s1"

--- a/bin/all_styleguides
+++ b/bin/all_styleguides
@@ -44,6 +44,10 @@ EOF
     bin/compass compile -c etc/compass_${project}.rb
     bin/hologram etc/hologram_${project}.yml
 
+    # clean up
+    find $builddir -type l -exec rm {} +
+    find $builddir -type d -empty -delete
+
     echo
 done
 

--- a/bin/all_styleguides
+++ b/bin/all_styleguides
@@ -46,3 +46,16 @@ EOF
 
     echo
 done
+
+{
+    echo "<html>"
+    echo "<body>"
+    echo "<h1>Styleguides</h1>"
+    echo "<ul>"
+    for project in $projects; do
+        echo "    <li><a href=\"$project/styleguide/\">$project</a></li>"
+    done
+    echo "</ul>"
+    echo "</body>"
+    echo "</html>"
+} > styleguides/index.html

--- a/bin/all_styleguides
+++ b/bin/all_styleguides
@@ -7,6 +7,8 @@ else
 fi
 
 for project in $projects; do
+    echo "-- Building \"$project\""
+
     builddir="styleguides/$project"
 
     mkdir -p $builddir
@@ -41,4 +43,6 @@ EOF
     # run hologram
     bin/compass compile -c etc/compass_${project}.rb
     bin/hologram etc/hologram_${project}.yml
+
+    echo
 done

--- a/bin/all_styleguides
+++ b/bin/all_styleguides
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+projects="adhocracy_frontend mercator meinberlin spd pcompass s1"
+
+for project in $projects; do
+    builddir=src/$project/$project/build
+
+    mkdir -p $builddir
+    find $builddir -type l -exec rm {} +
+
+    # merge static directories
+    for dir in `printf "src/$project/$project/static\nsrc/adhocracy_frontend/adhocracy_frontend/static" | uniq`; do
+        cp -ans `readlink -f $dir`/. $builddir
+    done
+
+    # create compass config
+    cat <<EOF > etc/compass_${project}.rb
+http_path = "/"
+css_dir = "$builddir/stylesheets"
+sass_dir = "$builddir/stylesheets/scss"
+fonts_dir = "$builddir/fonts"
+http_fonts_path = "../fonts"
+images_dir = "$builddir/images"
+javascripts_dir = "$builddir/js"
+sourcemap = true
+add_import_path "$builddir/stylesheets/scss"
+EOF
+
+    # create hologram config
+    cat <<EOF > etc/hologram_${project}.yml
+source: `realpath $builddir`/stylesheets/scss
+destination: `realpath $builddir`/styleguide
+documentation_assets: ../docs/styleguide_assets
+index: type
+EOF
+
+    # run hologram
+    bin/compass compile -c etc/compass_${project}.rb
+    bin/hologram etc/hologram_${project}.yml
+done
+
+for project in $projects; do
+    dir=src/$project/$project/build/styleguides
+
+    mkdir -p $dir
+
+    for project2 in $projects; do
+        ln -s `realpath src/$project2/$project2/build` $dir/$project2
+        echo "<a href=\"$project2/styleguide\">$project2</a>" >> $dir/index.html
+    done
+done

--- a/bin/all_styleguides
+++ b/bin/all_styleguides
@@ -7,7 +7,7 @@ else
 fi
 
 for project in $projects; do
-    builddir=src/$project/$project/build
+    builddir="styleguides/$project"
 
     mkdir -p $builddir
     find $builddir -type l -exec rm {} +
@@ -41,15 +41,4 @@ EOF
     # run hologram
     bin/compass compile -c etc/compass_${project}.rb
     bin/hologram etc/hologram_${project}.yml
-done
-
-for project in $projects; do
-    dir=src/$project/$project/build/styleguides
-
-    mkdir -p $dir
-
-    for project2 in $projects; do
-        ln -s `realpath src/$project2/$project2/build` $dir/$project2
-        echo "<a href=\"$project2/styleguide\">$project2</a>" >> $dir/index.html
-    done
 done


### PR DESCRIPTION
*fixes #1242*

This adds a script for building all style guides at the same time.

The script has been around for a while in #1242, but it had the issue that it created some symlinks that caused infinite loops in buildout. I worked around that by building the styleguides to a separate dir (`styleguides`). This way it can also be easily moved or copied, e.g. to a server.