### PR TITLE
change implementation of conditionallyRedirectVersionToLast

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -255,7 +255,13 @@ export class Service implements AdhTopLevelState.IAreaInput {
 
         return self.adhHttp.get(AdhUtil.parentPath(resourceUrl)).then((item : ResourcesBase.Resource) => {
             if (item.data.hasOwnProperty(SITags.nick)) {
-                return item.data[SITags.nick].LAST !== resourceUrl;
+                var lastUrl = item.data[SITags.nick].LAST;
+                if (lastUrl === resourceUrl) {
+                    return false;
+                } else {
+                    self.$location.path(self.adhResourceUrlFilter(lastUrl));
+                    return true;
+                }
             } else {
                 return false;
             }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -9,7 +9,7 @@ import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhUtil from "../Util/Util";
 
 import RIProcess from "../../Resources_/adhocracy_core/resources/process/IProcess";
-import * as SIVersionable from "../../Resources_/adhocracy_core/sheets/versions/IVersionable";
+import * as SITags from "../../Resources_/adhocracy_core/sheets/tags/ITags";
 
 var pkgLocation = "/ResourceArea";
 
@@ -253,18 +253,9 @@ export class Service implements AdhTopLevelState.IAreaInput {
     private conditionallyRedirectVersionToLast(resourceUrl : string) : angular.IPromise<boolean> {
         var self : Service = this;
 
-        return self.adhHttp.get(resourceUrl).then((resource : ResourcesBase.Resource) => {
-            if (resource.data.hasOwnProperty(SIVersionable.nick)) {
-                if (resource.data[SIVersionable.nick].followed_by.length === 0) {
-                    return false;
-                } else {
-                    var itemUrl = AdhUtil.parentPath(resourceUrl);
-                    return self.adhHttp.getNewestVersionPathNoFork(itemUrl).then((lastUrl) => {
-                        self.$location.path(self.adhResourceUrlFilter(lastUrl));
-                        return true;
-                    });
-
-                }
+        return self.adhHttp.get(AdhUtil.parentPath(resourceUrl)).then((item : ResourcesBase.Resource) => {
+            if (item.data.hasOwnProperty(SITags.nick)) {
+                return item.data[SITags.nick].LAST !== resourceUrl;
             } else {
                 return false;
             }


### PR DESCRIPTION
`conditionallyRedirectVersionToLast` checks whether a resource URL points to a version that is not the last one. For this, it uses `IVersionable.followed_by`. This field was removed in #2028. So I changed the implementation. Now it checks whether the resource URL is different from `ITag.LAST` on the parent resource.