### PR TITLE
opinion result toggle

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -114,6 +114,8 @@
     "TR__NO": "nein",
     "TR__ON": "am",
     "TR__ONLINE": "online",
+    "TR__OPINION_SHOW_RATE": "abstimmen",
+    "TR__OPINION_SHOW_RESULT": "Zwischenergebnis anzeigen",
     "TR__OPTIONAL": "optional",
     "TR__OR": "oder",
     "TR__OR_REGISTER_HERE": "oder [[link:hier]] registrieren",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -114,6 +114,8 @@
     "TR__NO": "no",
     "TR__ON": "on",
     "TR__ONLINE": "online",
+    "TR__OPINION_SHOW_RATE": "vote",
+    "TR__OPINION_SHOW_RESULT": "show interim result",
     "TR__OPTIONAL": "optional",
     "TR__OR": "or",
     "TR__OR_REGISTER_HERE": "or register [[link:here]]",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Opinion.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Opinion.html
@@ -62,4 +62,8 @@
             </span>
         </span>
     </span>
+    <a href="" data-ng-if="showResultToggle()" data-ng-click="toggleShowResult()" class="opinion-result-toggle">
+        <span data-ng-if="!showResult()">{{ "TR__OPINION_SHOW_RESULT" | translate }}</span>
+        <span data-ng-if="showResult()">{{ "TR__OPINION_SHOW_RATE" | translate }}</span>
+    </a>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Opinion.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Opinion.html
@@ -41,23 +41,23 @@
                 class="opinion-bar opinion-bar-yes"
                 data-ng-if="myRate !== -1"
                 title="{{'TR__YOU_VOTED' | translate}} {{'TR__YES' | translate}}"
-                style="width: {{rates(1) | percentage:(rates(1) + rates(-1))}}"></span>
+                style="width: {{rates(1) | percentage:((rates(1) + rates(-1)) || 1)}}"></span>
             <span
                 class="opinion-bar opinion-bar-no"
-                style="width: {{rates(-1) | percentage:(rates(1) + rates(-1))}}"
+                style="width: {{rates(-1) | percentage:((rates(1) + rates(-1)) || 1)}}"
                 data-ng-if="myRate === -1"
                 title="{{'TR__YOU_VOTED' | translate}} {{'TR__NO' | translate}}"></span>
         </span>
         <span class="opinion-result-numerics">
             <span class="opinion-result-yes">
                 <strong>{{'TR__YES' | translate | uppercase}}</strong>
-                {{rates(1) | percentage:(rates(1) + rates(-1))}}
+                {{rates(1) | percentage:((rates(1) + rates(-1)) || 1)}}
                 <span class="opinion-result-absolute">({{rates(1)}} {{'TR__VOTES' | translate}})</span>
             </span>
             <span class="opinion-result-total">{{rates(1) + rates(-1)}} {{'TR__TOTAL_VOTES' | translate}}</span>
             <span class="opinion-result-no">
                 <span class="opinion-result-absolute">({{rates(-1)}} {{'TR__VOTES' | translate}})</span>
-                {{rates(-1) | percentage:(rates(1) + rates(-1))}}
+                {{rates(-1) | percentage:((rates(1) + rates(-1)) || 1)}}
                 <strong>{{'TR__NO' | translate | uppercase }}</strong>
             </span>
         </span>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
@@ -57,6 +57,8 @@ export interface IRateScope extends angular.IScope {
     uncast() : angular.IPromise<void>;
     toggle(value : number) : angular.IPromise<void>;
     showResult() : boolean;
+    showResultToggle() : boolean;
+    toggleShowResult() : void;
 
     // not currently used in the UI
     auditTrail : { subject: string; rate: number }[];
@@ -356,8 +358,22 @@ export var directiveFactory = (template : string, adapter : IRateAdapter<RIRateV
                 }
             };
 
+            var showResult : boolean = false;
+
             scope.showResult = () : boolean => {
-                return scope.hasCast || forceResult;
+                if (scope.showResultToggle()) {
+                    return showResult;
+                } else {
+                    return true;
+                }
+            };
+
+            scope.showResultToggle = () : boolean => {
+                return !scope.hasCast && !forceResult;
+            };
+
+            scope.toggleShowResult = () : void => {
+                showResult = !showResult;
             };
 
             // sync with other local rate buttons

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
@@ -249,6 +249,50 @@ Click show results
     }
 }
 
+/*doc
+---
+title: Opinion
+name: opionion
+parent: rate
+---
+
+The Opinion widget is very similar in functionaility to the Rate widget, but it
+is bigger and exposes more details.
+
+```html_example
+<div class="opinion">
+    <span class="opinion-button-container">
+        <a href="#" class="opinion-yes opinion-button">yes</a>
+    </span>
+    <span class="opinion-button-container">
+        <a href="#" class="opinion-no opinion-button">no</a>
+    </span>
+</div>
+
+<div class="opinion">
+    <span class="opinion-results">
+        <span class="opinion-bar-container">
+            <span
+                class="opinion-bar opinion-bar-yes"
+                style="width: 19%"></span>
+        </span>
+        <span class="opinion-result-numerics">
+            <span class="opinion-result-yes">
+                <strong>YES</strong>
+                19
+                <span class="opinion-result-absolute">(6 votes)</span>
+            </span>
+            <span class="opinion-result-total">32 total votes</span>
+            <span class="opinion-result-no">
+                <span class="opinion-result-absolute">(26 votes)</span>
+                81
+                <strong>NO</strong>
+            </span>
+        </span>
+    </span>
+</div>
+```
+*/
 .opinion {
     @include clearfix;
     width: 100%;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
@@ -267,6 +267,7 @@ is bigger and exposes more details.
     <span class="opinion-button-container">
         <a href="#" class="opinion-no opinion-button">no</a>
     </span>
+    <a href="#" class="opinion-result-toggle">show results</a>
 </div>
 
 <div class="opinion">
@@ -290,11 +291,15 @@ is bigger and exposes more details.
             </span>
         </span>
     </span>
+    <a href="#" class="opinion-result-toggle">vote</a>
 </div>
 ```
 */
 .opinion {
     @include clearfix;
+    @include rem(margin-bottom, 4.5rem);
+    @include rem(padding-bottom, 2.5rem);
+    position: relative;
     width: 100%;
 }
 
@@ -347,7 +352,7 @@ is bigger and exposes more details.
     @include clearfix;
     @include rem(font-size, $font-size-small);
     display: block;
-    position: relative;
+    position: absolute;
     width: 100%;
 
     .opinion-result-yes {
@@ -382,4 +387,10 @@ is bigger and exposes more details.
 
 .is-opinion-none .opinion-bar {
     background-color: $color-text-normal;
+}
+
+.opinion-result-toggle {
+    position: absolute;
+    bottom: 0;
+    right: 0;
 }


### PR DESCRIPTION
This adds a toggle button to the opinion widget as used in meinberlin stadtforum. It allows to toggle between results and rate button in the cases in which previously it was only possible to vote. This has the advantage that users to not try to vote only to see the results. It has the disadvantage that users may be biased by seeing the results before voting.

I also added documentation for the opinion widget. The styling was changed quite a bit, so it should be reviewed with extra care.