### PR TITLE
update read the docs documentation theming

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,11 +32,9 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.coverage',
               'sphinx.ext.viewcode',
               'sphinx.ext.pngmath',
+              'repoze.sphinx.autointerface',
               'sphinx_autodoc_annotation',
               'sphinx.ext.graphviz']
-
-if os.environ.get('READTHEDOCS', None) != 'True':
-    extensions.append('repoze.sphinx.autointerface')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 
 import sys, os
+import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -100,7 +101,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -108,7 +109,7 @@ html_theme = 'nature'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/rtd.txt
+++ b/rtd.txt
@@ -89,6 +89,7 @@ python-magic==0.4.6
 pytz==2014.10
 repoze.lru==0.6
 repoze.sendmail==4.2
+repoze.sphinx.autointerface==0.7.1
 requests==2.5.1
 selenium==2.44.0
 setuptools==18.3.2

--- a/rtd.txt
+++ b/rtd.txt
@@ -97,6 +97,7 @@ sh==1.11
 simplegeneric==0.8.1
 six==1.9.0
 snowballstemmer==1.2.0
+sphinx-rtd-theme==0.1.9
 statsd==3.0.1
 testfixtures==4.1.2
 transaction==1.4.4

--- a/rtd.txt
+++ b/rtd.txt
@@ -4,38 +4,73 @@
 -e ./src/adhocracy_core
 -e ./src/adhocracy_frontend
 -e ./src/adhocracy_mercator
+-e ./src/adhocracy_meinberlin
 -e ./src/adhocracy_sample
+-e ./src/adhocracy_spd
 -e ./src/mercator
 -e git+https://github.com/hsoft/sphinx-autodoc-annotation.git@5a5bb637dbde91ac3dde70546b6da4949851bf1c#egg=sphinx-autodoc-annotation
 # other dependencies
-autobahn==0.9.6
-beautifulsoup4==4.3.2
-BTrees==4.1.1
+BTrees==4.2.0
+Babel==1.3
 Chameleon==2.22
+Jinja2==2.7.3
+MarkupSafe==0.23
+PasteDeploy==1.5.2
+Pillow==2.7.0
+PyYAML==3.11
+Pygments==2.0.2
+Sphinx==1.3.5
+WebOb==1.4
+WebTest==2.0.18
+ZConfig==3.0.4
+ZEO==4.1.0
+ZODB==4.2.0
+alabaster==0.7.7
+argh==0.26.1
+args==0.1.0
+astroid==1.3.4
+autobahn==0.9.6
+beautifulsoup4==4.4.0
+clint==0.4.1
 colander==1.0
 contexttimer==0.3.1
-cornice==0.17
 coverage==3.7.1
 cryptacular==1.4.1
 deform==2.0a2
+docutils==0.12
+flake8==2.4.1
+flake8-debugger==1.4.0
+flake8-docstrings==0.2.1.post1
+flake8-quotes==0.0.1
 gunicorn==19.2.1
 hypatia==0.3
-ipdb==0.8
-ipython==2.4.1
+ipdb==0.8.1
+ipython==4.0.0
 iso8601==0.1.10
-Mako==1.0.1
-MarkupSafe==0.23
+lingua==3.10
+logilab-common==0.63.2
+mccabe==0.3.1
+meld3==1.0.0
 mock==1.0.1
-PasteDeploy==1.5.2
+mr.developer==1.31
+multipledispatch==0.4.8
+path.py==8.1.2
+pathtools==0.1.2
 pbkdf2==1.3
+pep257==0.7.0
+pep8==1.5.7
+pep8-naming==0.3.3
 peppercorn==0.5
-persistent==4.0.8
-Pillow==2.7.0
+persistent==4.1.1
+polib==1.0.7
+polytester==1.2.0
 profilehooks==1.7.1
+ptyprocess==0.5.1
 pudb==2015.2
-py==1.4.26
+py==1.4.30
 pycallgraph==1.0.1
-Pygments==2.0.2
+pyflakes==0.8.1
+pylint==1.4.1
 pyramid==1.5.2
 pyramid-cachebust==0.1.1
 pyramid-chameleon==0.3
@@ -45,40 +80,61 @@ pyramid-mailer==0.14
 pyramid-mako==1.0.2
 pyramid-tm==0.11
 pyramid-zodbconn==0.7
-pytest==2.6.4
+pytest==2.8.7
+pytest-mock==0.10.1
 pytest-pyramid==0.1.1
-pytest-splinter==1.2.10
-pytest-timeout==0.4
+pytest-timeout==0.5
 python-coveralls==2.5.0
 python-magic==0.4.6
 pytz==2014.10
-PyYAML==3.11
 repoze.lru==0.6
 repoze.sendmail==4.2
 requests==2.5.1
 selenium==2.44.0
+setuptools==18.3.2
 sh==1.11
-simplejson==3.6.5
+simplegeneric==0.8.1
 six==1.9.0
-splinter==0.7.0
+snowballstemmer==1.2.0
 statsd==3.0.1
-transaction==1.4.3
+testfixtures==4.1.2
+transaction==1.4.4
+transifex-client==0.11b3
 translationstring==1.3
 urwid==1.3.0
 venusian==1.0
 waitress==0.8.9
-WebOb==1.4
+watchdog==0.8.2
 websocket-client==0.23.0
-WebTest==2.0.18
+z3c.checkversions==0.5
+zc.buildout==2.4.4
 zc.lockfile==1.1.0
-ZConfig==3.0.4
 zdaemon==4.0.1
-ZEO==4.1.0
-ZODB==4.1.0
-zodbpickle==0.5.2
+zodbpickle==0.6.0
 zodburi==2.0
 zope.component==4.2.1
 zope.copy==4.0.3
 zope.deprecation==4.1.2
 zope.event==4.0.3
 zope.interface==4.1.2
+
+#Required by:
+#ipython 4.0.0
+#traitlets 4.1.0
+decorator==4.0.9
+
+#Required by:
+#traitlets 4.1.0
+ipython-genutils==0.1.0
+
+#Required by:
+#ipython 4.0.0
+pexpect==4.0.1
+
+#Required by:
+#ipython 4.0.0
+pickleshare==0.6
+
+#Required by:
+#ipython 4.0.0
+traitlets==4.1.0

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -46,6 +46,7 @@ test_requires = [
     'Sphinx',
     'repoze.sphinx.autointerface',
     'sphinx-autodoc-annotation',
+    'sphinx-rtd-theme',
 ]
 
 debug_requires = [

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -43,6 +43,9 @@ test_requires = [
     'babel',
     'lingua',
     'testfixtures',
+    'Sphinx',
+    'repoze.sphinx.autointerface',
+    'sphinx-autodoc-annotation',
 ]
 
 debug_requires = [

--- a/src/adhocracy_core/sphinx.cfg
+++ b/src/adhocracy_core/sphinx.cfg
@@ -1,6 +1,5 @@
 [buildout]
 parts +=
-     sphinx
      sphinx_build
      sphinx_api
 
@@ -25,11 +24,3 @@ input = inline:
     make html
 output = ${buildout:bin-directory}/sphinx_build_adhocracy
 mode = 755
-
-[sphinx]
-recipe = zc.recipe.egg
-dependent-scripts = true
-eggs = ${buildout:eggs}
-       Sphinx
-       repoze.sphinx.autointerface
-       sphinx-autodoc-annotation

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -1,5 +1,5 @@
 [versions]
-Sphinx = 1.3b2
+Sphinx = 1.3.5
 Jinja2 = 2.7.3
 MarkupSafe = 0.23
 PasteDeploy = 1.5.2


### PR DESCRIPTION
Updates to HTML documentation generated by sphinx:

- use read the docs sphinx theme for our documentation ( http://adhocracy3.readthedocs.org/en/latest/)

- fix #1186 

-  update sphinx to 3.5
