### PR TITLE
Changed sorting of comments

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
@@ -1,5 +1,4 @@
 import * as AdhComment from "./Comment";
-import * as AdhUtil from "../Util/Util";
 import * as AdhHttp from "../Http/Http";
 
 import * as ResourcesBase from "../../ResourcesBase";
@@ -99,7 +98,7 @@ export class CommentAdapter implements AdhComment.ICommentAdapter<RICommentVersi
         };
         params[SIComment.nick + ":refers_to"] = container.path;
         return adhHttp.get(this.poolPath(container), params).then((pool) => {
-            return _.map(pool.data[SIPool.nick].elements, AdhUtil.parentPath);
+            return pool.data[SIPool.nick].elements;
         });
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Adapter.ts
@@ -1,5 +1,6 @@
 import * as AdhComment from "./Comment";
 import * as AdhUtil from "../Util/Util";
+import * as AdhHttp from "../Http/Http";
 
 import * as ResourcesBase from "../../ResourcesBase";
 
@@ -9,6 +10,7 @@ import * as SIVersionable from "../../Resources_/adhocracy_core/sheets/versions/
 import * as SICommentable from "../../Resources_/adhocracy_core/sheets/comment/ICommentable";
 import * as SIComment from "../../Resources_/adhocracy_core/sheets/comment/IComment";
 import * as SIMetadata from "../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
+import * as SIPool from "../../Resources_/adhocracy_core/sheets/pool/IPool";
 
 
 export class CommentAdapter implements AdhComment.ICommentAdapter<RICommentVersion> {
@@ -88,8 +90,17 @@ export class CommentAdapter implements AdhComment.ICommentAdapter<RICommentVersi
         return meta.modification_date > meta.item_creation_date;
     }
 
-    elemRefs(container : ResourcesBase.Resource) {
-        return AdhUtil.eachItemOnce(container.data[SICommentable.nick].comments);
+    elemRefs(adhHttp : AdhHttp.Service<any>, container : ResourcesBase.Resource) {
+        var params = {
+            depth: 2,
+            tag: "LAST",
+            content_type: RICommentVersion.content_type,
+            sort: "item_creation_date"
+        };
+        params[SIComment.nick + ":refers_to"] = container.path;
+        return adhHttp.get(this.poolPath(container), params).then((pool) => {
+            return _.map(pool.data[SIPool.nick].elements, AdhUtil.parentPath);
+        });
     }
 
     poolPath(container : ResourcesBase.Resource) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/AdapterSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/AdapterSpec.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
 
-import * as JasmineHelpers from "../../JasmineHelpers";
-
 import * as AdhCommentAdapter from "./Adapter";
 
 import RICommentVersion from "../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
@@ -108,40 +106,6 @@ export var register = () => {
             describe("modificationDate", () => {
                 it("gets modificationDate from adhocracy_core.sheets.metadata.IMetadata", () => {
                     expect(adapter.modificationDate(resource)).toBe("modificationDate");
-                });
-            });
-
-            describe("elemRefs", () => {
-                var generateResource = () => {
-                    return {
-                        data: {
-                            "adhocracy_core.sheets.comment.ICommentable": {
-                                comments: [
-                                    "/asd/version2",
-                                    "/asd/version3",
-                                    "/foo/version1",
-                                    "/bar/version1",
-                                    "/asd/version1",
-                                    "/foo/version2"
-                                ]
-                            }
-                        }
-                    };
-
-                };
-
-                it("returns the refered comment items from the adhocracy_core.sheets.comment.ICommentable sheet", () => {
-                    jasmine.addMatchers(JasmineHelpers.customMatchers);
-
-                    var resource = generateResource();
-                    var result = adapter.elemRefs(resource);
-                    (<any>expect(result)).toSetEqual(["/asd", "/foo", "/bar"]);
-                });
-
-                it("does not modify the resource", () => {
-                    var resource = generateResource();
-                    adapter.elemRefs(resource);
-                    expect(resource).toEqual(generateResource());
                 });
             });
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -96,18 +96,19 @@ export var update = (
 
         scope.item = item;
 
-        scope.data = {
-            path: version.path,
-            itemPath: item.path,
-            content: adapter.content(version),
-            creator: adapter.creator(item),
-            creationDate: adapter.creationDate(version),
-            modificationDate: adapter.modificationDate(version),
-            commentCount: adapter.commentCount(version),
-            comments: [],
-            replyPoolPath: adapter.poolPath(version),
-            edited: adapter.edited(version)
-        };
+        if (!scope.data) {
+            scope.data = <any>{};
+        }
+
+        scope.data.path = version.path;
+        scope.data.itemPath = item.path;
+        scope.data.content = adapter.content(version);
+        scope.data.creator = adapter.creator(item);
+        scope.data.creationDate = adapter.creationDate(version);
+        scope.data.modificationDate = adapter.modificationDate(version);
+        scope.data.commentCount = adapter.commentCount(version);
+        scope.data.replyPoolPath = adapter.poolPath(version);
+        scope.data.edited = adapter.edited(version);
 
         return adapter.elemRefs(adhHttp, version).then((comments) => {
             scope.data.comments = comments;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -86,11 +86,10 @@ export var update = (
     $q : angular.IQService
 ) => (
     scope : ICommentResourceScope,
-    itemPath : string
+    versionPath : string
 ) : angular.IPromise<void> => {
-    var p1 = adhHttp.get(itemPath);
-    var p2 = adhHttp.getNewestVersionPathNoFork(itemPath)
-        .then((path) => adhHttp.get(path));
+    var p1 = adhHttp.get(AdhUtil.parentPath(versionPath));
+    var p2 = adhHttp.get(versionPath);
     return $q.all([p1, p2]).then((args : any[]) => {
         var item = args[0];
         var version = args[1];
@@ -125,9 +124,9 @@ export var bindPath = (
     pathKey : string = "path"
 ) : void => {
     var _update = update(adapter, adhHttp, $q);
-    scope.$watch(pathKey, (itemPath : string) => {
-        if (itemPath) {
-            _update(scope, itemPath);
+    scope.$watch(pathKey, (versionPath : string) => {
+        if (versionPath) {
+            _update(scope, versionPath);
         }
     });
 };
@@ -202,7 +201,7 @@ export var commentDetailDirective = (
         scope.$on("$destroy", adhTopLevelState.on("commentUrl", (commentVersionUrl) => {
             if (!commentVersionUrl) {
                 scope.selectedState = "";
-            } else if (AdhUtil.parentPath(commentVersionUrl) === scope.path) {
+            } else if (commentVersionUrl === scope.path) {
                 scope.selectedState = "is-selected";
             } else {
                 scope.selectedState = "is-not-selected";
@@ -347,7 +346,7 @@ export var adhCommentListing = (
                     params[SIComment.nick + ":refers_to"] = commentable.path;
                     scope.poolPath = commentable.data[SICommentable.nick].post_pool;
                     return adhHttp.get(scope.poolPath, params).then((pool) => {
-                        scope.elements = _.map(pool.data[SIPool.nick].elements, AdhUtil.parentPath);
+                        scope.elements = pool.data[SIPool.nick].elements;
                     });
                 });
             };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -334,25 +334,26 @@ export var adhCommentListing = (
         link: (scope) => {
             adhTopLevelState.setCameFrom($location.url());
 
-            scope.update = () => {
+            scope.contentType = RICommentVersion.content_type;
+            scope.sorts = [{
+                key: "date",
+                name: "TR__CREATION_DATE",
+                index: "item_creation_date",
+                reverse: true
+            }];
+            scope.params = {};
+
+            var update = () => {
                 return adhHttp.get(scope.path).then((commentable) => {
-                    var params = {
-                        depth: 2,
-                        tag: "LAST",
-                        content_type: RICommentVersion.content_type,
-                        sort: "item_creation_date",
-                        reverse: true
-                    };
-                    params[SIComment.nick + ":refers_to"] = commentable.path;
+                    scope.params[SIComment.nick + ":refers_to"] = scope.path;
                     scope.poolPath = commentable.data[SICommentable.nick].post_pool;
-                    return adhHttp.get(scope.poolPath, params).then((pool) => {
-                        scope.elements = pool.data[SIPool.nick].elements;
-                    });
+                    scope.custom = {
+                        refersTo: scope.path
+                    };
                 });
             };
 
-            scope.$watch("path", scope.update);
-            adhPermissions.bindScope(scope, () => scope.poolPath, "poolOptions");
+            scope.$watch("path", update);
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -14,6 +14,7 @@ import * as ResourcesBase from "../../ResourcesBase";
 
 import RIExternalResource from "../../Resources_/adhocracy_core/resources/external_resource/IExternalResource";
 import RICommentVersion from "../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
+import * as SIComment from "../../Resources_/adhocracy_core/sheets/comment/IComment";
 import * as SICommentable from "../../Resources_/adhocracy_core/sheets/comment/ICommentable";
 import * as SIPool from "../../Resources_/adhocracy_core/sheets/pool/IPool";
 
@@ -332,8 +333,18 @@ export var adhCommentListing = (
 
             scope.update = () => {
                 return adhHttp.get(scope.path).then((commentable) => {
-                    scope.elements = AdhUtil.eachItemOnce(commentable.data[SICommentable.nick].comments);
+                    var params = {
+                        depth: 2,
+                        tag: "LAST",
+                        content_type: RICommentVersion.content_type,
+                        sort: "item_creation_date",
+                        reverse: true
+                    };
+                    params[SIComment.nick + ":refers_to"] = commentable.path;
                     scope.poolPath = commentable.data[SICommentable.nick].post_pool;
+                    return adhHttp.get(scope.poolPath, params).then((pool) => {
+                        scope.elements = _.map(pool.data[SIPool.nick].elements, AdhUtil.parentPath);
+                    });
                 });
             };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -241,6 +241,9 @@ export var commentDetailDirective = (
         scope.submit = () => {
             return _postEdit(scope, scope.item).then(() => {
                 scope.update();
+                if (scope.onSubmit) {
+                    scope.onSubmit();
+                }
                 scope.mode = 0;
             });
         };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -344,6 +344,10 @@ export var adhCommentListing = (
                 name: "TR__CREATION_DATE",
                 index: "item_creation_date",
                 reverse: true
+            }, {
+                key: "rates",
+                name: "TR__RATES",
+                index: "rates"
             }];
             scope.params = {};
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -35,7 +35,7 @@ export interface ICommentAdapter<T extends ResourcesBase.Resource> {
     modificationDate(resource : T) : string;
     commentCount(resource : T) : number;
     edited(resource : T) : boolean;
-    elemRefs(any) : string[];
+    elemRefs(adhHttp : AdhHttp.Service<any>, any) : angular.IPromise<string[]>;
     poolPath(any) : string;
 }
 
@@ -105,10 +105,14 @@ export var update = (
             creationDate: adapter.creationDate(version),
             modificationDate: adapter.modificationDate(version),
             commentCount: adapter.commentCount(version),
-            comments: adapter.elemRefs(version),
+            comments: [],
             replyPoolPath: adapter.poolPath(version),
             edited: adapter.edited(version)
         };
+
+        return adapter.elemRefs(adhHttp, version).then((comments) => {
+            scope.data.comments = comments;
+        });
     });
 };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -75,7 +75,7 @@
 
     <div class="comment-children">
         <adh-comment
-            data-ng-repeat="comment in data.comments | orderBy:'-'"
+            data-ng-repeat="comment in data.comments"
             data-path="{{comment}}"
             data-on-submit="update">
         </adh-comment>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Listing.html
@@ -1,23 +1,23 @@
-<div class="comment-listing">
-    <div class="listing">
-        <div class="listing-create-form" data-ng-if="poolOptions.POST">
-            <adh-comment-create
-                data-refers-to="{{path}}"
-                data-pool-path="{{poolPath}}"
-                data-on-submit="update"
-                data-hide-cancel="true">
-            </adh-comment-create>
-        </div>
-        <ol class="listing-elements">
-            <li class="listing-element" data-ng-repeat="element in elements">
-                <adh-comment
-                    data-path="{{element}}"
-                    data-on-submit="update">
-                </adh-comment>
-            </li>
-        </ol>
-        <div class="listing-empty-text" data-ng-if="elements.length === 0">
-            {{ "TR__COMMENT_EMPTY_TEXT" | translate }}
-        </div>
+<adh-listing
+    data-path="{{poolPath}}"
+    data-content-type="{{contentType}}"
+    data-sorts="sorts"
+    data-params="params"
+    data-custom="custom"
+    data-empty-text="{{ 'TR__COMMENT_EMPTY_TEXT' | translate }}"
+>
+    <div data-ng-switch="transclusionId">
+        <adh-comment-create
+            data-ng-switch-when="create-form-id"
+            data-refers-to="{{custom.refersTo}}"
+            data-pool-path="{{poolPath}}"
+            data-on-submit="onCreate"
+            data-hide-cancel="true">
+        </adh-comment-create>
+        <adh-comment
+            data-ng-switch-when="element-id"
+            data-path="{{element}}"
+            data-on-submit="update">
+        </adh-comment>
     </div>
-</div>
+</adh-listing>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Listing.html
@@ -9,7 +9,7 @@
             </adh-comment-create>
         </div>
         <ol class="listing-elements">
-            <li class="listing-element" data-ng-repeat="element in elements | orderBy:'-'">
+            <li class="listing-element" data-ng-repeat="element in elements">
                 <adh-comment
                     data-path="{{element}}"
                     data-on-submit="update">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -137,7 +137,8 @@ export class Listing<Container extends ResourcesBase.Resource> {
                 initialLimit: "=?",
                 params: "=?",
                 noCreateForm: "=?",
-                emptyText: "@"
+                emptyText: "@",
+                custom: "=?"
             },
             transclude: true,
             link: (scope, element, attrs, controller, transclude) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -138,6 +138,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
                 params: "=?",
                 noCreateForm: "=?",
                 emptyText: "@",
+                // use this to pass custom data to the injected templates
                 custom: "=?"
             },
             transclude: true,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
@@ -84,17 +84,6 @@ export function formatString(format : string, ...args : string[]) {
 }
 
 
-/**
- * Given a list of version paths this function returns a list of corresponding
- * items, but each item only once.
- */
-export function eachItemOnce(refs : string[]) : string[] {
-    "use strict";
-
-    return _.uniq(_.map(refs, parentPath));
-};
-
-
 export interface IVertex<vertexType> {
     content : vertexType;
     incoming : string[];

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/UtilSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/UtilSpec.ts
@@ -1,7 +1,5 @@
 /// <reference path="../../../lib/DefinitelyTyped/jasmine/jasmine.d.ts"/>
 
-import * as JasmineHelpers from "../../JasmineHelpers";
-
 import * as q from "q";
 
 import * as AdhUtil from "./Util";
@@ -61,36 +59,6 @@ export var register = () => {
             });
             it("does not replace {n} if there is no n-th parameter", () => {
                 expect(AdhUtil.formatString("Hello {0} from {1}", "World")).toBe("Hello World from {1}");
-            });
-        });
-
-        describe("eachItemOnce", () => {
-            var testCase = [
-                "/asd/version2",
-                "/asd/version3",
-                "/foo/version1",
-                "/bar/version1",
-                "/asd/version1",
-                "/foo/version2"
-            ];
-
-            it("returns only the most recent versions from the adhocracy_core.sheets.comment.ICommentable sheet", () => {
-                jasmine.addMatchers(JasmineHelpers.customMatchers);
-
-                var result = AdhUtil.eachItemOnce(testCase);
-                (<any>expect(result)).toSetEqual(["/asd", "/foo", "/bar"]);
-            });
-
-            it("does not alter the input list", () => {
-                AdhUtil.eachItemOnce(testCase);
-                expect(testCase).toEqual([
-                    "/asd/version2",
-                    "/asd/version3",
-                    "/foo/version1",
-                    "/bar/version1",
-                    "/asd/version1",
-                    "/foo/version2"
-                ]);
             });
         });
 


### PR DESCRIPTION
In order to change how comments are sorted, @xi and me

- stopped using `ICommentable.comments` in adhCommentListing and replaced it with a query on `ICommentable.post_pool`, - this paves the way for #1957 -
- removed the tests for `elemRefs`, because we changed its definition so it expected promises instead of strings,
- changed the comment detail directive to expect version paths instead of item paths - so that we could use `adhListing`. This triggered a problem: edits weren't displayed immediately anymore, since we still loaded the same version after editing. We solved that by calling the `onSubmit()` in the comment detail directive. This way, the containing directive can update itself.
- We changed `adhCommentListing` to use `adhListing` internally.
- In order to do this, we added the parameter `custom` to `adhListing`, that can be used to pass data to the injected templates.
- We included a UI in which the user can choose the sorting parameters `rates` besides the default parameter `item_creation_date`. Replies are always sorted in chronological order.

To do:
- We found a lot of potential for refactoring: remove `Adapter` in `Listing` and `Comment`, maybe refactor `EditComment`.