### PR TITLE
fix captcha register

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -32,6 +32,7 @@ export var logBackendError : (response : angular.IHttpPromiseCallbackArg<IBacken
 
 export interface IHttpConfig {
     noCredentials? : boolean;
+    noExport? : boolean;
 }
 
 export interface IHttpOptionsConfig extends IHttpConfig {
@@ -245,7 +246,11 @@ export class Service<Content extends ResourcesBase.Resource> {
     public put(path : string, obj : Content, config : IHttpPutConfig = {}) : angular.IPromise<Content> {
         var _self = this;
 
-        return this.putRaw(path, AdhConvert.exportContent(this.adhMetaApi, obj, config.keepMetadata), config)
+        if (!config.noExport) {
+            obj = AdhConvert.exportContent(_self.adhMetaApi, obj, config.keepMetadata);
+        }
+
+        return this.putRaw(path, obj, config)
             .then(
                 (response) => {
                     _self.adhCache.invalidateUpdated(response.data.updated_resources);
@@ -307,7 +312,11 @@ export class Service<Content extends ResourcesBase.Resource> {
     public post(path : string, obj : Content, config : IHttpConfig = {}) : angular.IPromise<Content> {
         var _self = this;
 
-        return _self.postRaw(path, AdhConvert.exportContent(_self.adhMetaApi, obj), config)
+        if (!config.noExport) {
+            obj = AdhConvert.exportContent(_self.adhMetaApi, obj);
+        }
+
+        return _self.postRaw(path, obj, config)
             .then(
                 (response) => {
                     this.adhCache.invalidateUpdated(response.data.updated_resources);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/User.ts
@@ -116,7 +116,9 @@ export class Service {
             };
         }
 
-        return _self.adhHttp.post("/principals/users/", resource);
+        return _self.adhHttp.post("/principals/users/", resource, {
+            noExport: true
+        });
     }
 
     public activate(path : string) : angular.IPromise<void> {


### PR DESCRIPTION
This works around the following issue:

If captchas are enabled, `IUser` requires an `ICaptcha` sheet. If captchas are not enabled, this sheet is not even available.

The frontend stripps all unavailable sheets from a resource before it is posted (`exportContent`). For this, it uses a dump of the meta api that is part of the frontend distrubution. If this dump was created on a setup without captchas, registration will fail in a setup with captchas enabled.

A proper fix could be to completely remove the `exportContent`/`importContent` magic.