### PR TITLE
fix mercator2016 edit if heard_from contains "other"

### DIFF
--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Create.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Create.html
@@ -993,6 +993,7 @@
                             data-msd-elastic=""
                             data-ng-model="data.impact.extraInfo"
                             name="impact-extrainfo"
+                            minlength="3"
                             maxlength="500"
                             placeholder="{{ 'TR__MAX_CHARS_500' | translate }}"></textarea>
                     </label>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -401,6 +401,8 @@ var edit = (
         return adhHttp.withTransaction((transaction) => {
             var proposal = new RIMercatorProposal({preliminaryNames: adhPreliminaryNames});
             fill(data, proposal);
+            // ICommunity can and should not be changed on edit
+            delete proposal.data[SICommunity.nick];
             transaction.put(oldProposal.path, proposal);
 
             _.forEach({


### PR DESCRIPTION
Some users reported the message `Required if "other" in heard_froms` when they tried to edit their proposals.

I fixed this by removing the `ICommunity` sheet from the post data on edit since it can not be changed anyway.

I also added some unrelated frontend validation that was missing.