### PR TITLE
Remove authentication header 'X-User-Path'  

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -156,7 +156,7 @@ class TokenHeaderAuthenticationPolicy(CallbackAuthenticationPolicy):
     """A :term:`authentication policy` based on the the X-User-* header.
 
     To authenticate the client has to send http header with `X-User-Token`
-    and `X-User-Path`.
+    and the optional `X-User-Path`.
 
     Constructor Arguments
 
@@ -187,8 +187,8 @@ class TokenHeaderAuthenticationPolicy(CallbackAuthenticationPolicy):
         self.hashalg = hashalg
 
     def unauthenticated_userid(self, request):
-        """Return unauthenticated userid."""
-        return _get_raw_x_user_headers(request)[0]
+        """Return authenticated userid because we don't have one."""
+        return self.authenticated_userid(request)
 
     def authenticated_userid(self, request):
         """Return authenticated userid."""
@@ -211,8 +211,6 @@ class TokenHeaderAuthenticationPolicy(CallbackAuthenticationPolicy):
         with statsd_timer('authentication.user', rate=.1):
             authenticated_userid = \
                 tokenmanager.get_user_id(token, timeout=self.timeout)
-        if authenticated_userid != userid:
-            raise KeyError
         return authenticated_userid
 
     def remember(self, request, userid, **kw) -> dict:

--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -2,21 +2,18 @@
 import hashlib
 from datetime import datetime
 
-from colander import Invalid
 from persistent.dict import PersistentDict
 from pyramid.authentication import CallbackAuthenticationPolicy
 from pyramid.interfaces import IAuthenticationPolicy
-from pyramid.request import Request
+from pyramid.interfaces import IRequest
 from pyramid.traversal import resource_path
 from pyramid.security import Everyone
 from pyramid.settings import asbool
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.component import ComponentLookupError
-from substanced.stats import statsd_timer
 
 from adhocracy_core.interfaces import ITokenManger
-from adhocracy_core.interfaces import IRolesUserLocator
 from adhocracy_core.schema import Resource
 
 
@@ -68,18 +65,20 @@ class TokenMangerAnnotationStorage:
         return time_bytes + secret_bytes + user_bytes
 
     def get_user_id(self, token: str, timeout: float=None) -> str:
-        """Get user_id for authentication token.
+        """Get user_id for authentication token or None.
 
         :param timeout:  Maximum number of seconds which a newly create token
                         will be considered valid.
                         The `None` value is allowed to disable the timeout.
-        :returns: user id for this token
-        :raises KeyError: if there is no corresponding user_id
+        :returns: user id for `token` or None.
         """
-        userid, timestamp = self.token_to_user_id_timestamp[token]
+        userid, timestamp = self.token_to_user_id_timestamp.get(token,
+                                                                (None, None))
+        if userid is None:
+            return userid
         if self._is_expired(timestamp, timeout):
             del self.token_to_user_id_timestamp[token]
-            raise KeyError
+            userid = None
         return userid
 
     def _is_expired(self, timestamp: datetime, timeout: float=None) -> bool:
@@ -103,13 +102,10 @@ class TokenMangerAnnotationStorage:
             self.delete_token(token)
 
 
-def get_tokenmanager(request: Request, **kwargs) -> ITokenManger:
-    """Adapter request.root to ITokenmanager and return it.
-
-    :returns: :class:'adhocracy_core.interfaces.ITokenManager or None.
-    """
-    # allow to run pyramid scripts without authentication
+def get_tokenmanager(request: IRequest) -> ITokenManger:
+    """Adapt request.root to ITokenmanager and return it or None."""
     if getattr(request, 'root', None) is None:
+        # allow to run pyramid scripts without authentication
         return None
     try:
         return ITokenManger(request.root)
@@ -117,46 +113,11 @@ def get_tokenmanager(request: Request, **kwargs) -> ITokenManger:
         return None
 
 
-def _get_raw_x_user_headers(request: Request) -> tuple:
-    """Return not validated tuple with the X-User-Path/Token values."""
-    user_url = request.headers.get('X-User-Path', '')
-    # TODO find a proper solution, userid should just be an identifier.
-    # user_url/path as userid does not work
-    # well with the pyramid authentication system. We don't have the
-    # a context or root object to resolve the resource path when processing
-    # the unauthenticated_userid and effective_principals methods.
-    app_url_length = len(request.application_url)
-    user_path = None
-    if user_url.startswith('/'):
-        user_path = user_url
-    elif len(user_url) >= app_url_length:
-        user_path = user_url[app_url_length:][:-1]
-    token = request.headers.get('X-User-Token', None)
-    return user_path, token
-
-
-def _get_x_user_headers(request: Request) -> tuple:
-    """Return tuple with the X-User-Path/Token values or (None, None)."""
-    schema = Resource().bind(request=request, context=request.context)
-    user_url = request.headers.get('X-User-Path', None)
-    user_path = None
-    if user_url is not None:
-        try:
-            user = schema.deserialize(user_url)
-            user_path = resource_path(user)
-        except Invalid:
-            # TODO: raise a proper colander error.
-            pass
-    token = request.headers.get('X-User-Token', None)
-    return (user_path, token)
-
-
 @implementer(IAuthenticationPolicy)
 class TokenHeaderAuthenticationPolicy(CallbackAuthenticationPolicy):
-    """A :term:`authentication policy` based on the the X-User-* header.
+    """A :term:`authentication policy` based on X-User-* request headers.
 
-    To authenticate the client has to send http header with `X-User-Token`
-    and the optional `X-User-Path`.
+    To authenticate the client has to send http header with `X-User-Token`.
 
     Constructor Arguments
 
@@ -171,6 +132,10 @@ class TokenHeaderAuthenticationPolicy(CallbackAuthenticationPolicy):
                              :class:`adhocracy_core.interfaces.ITokenManager`.
     :param hashalg: Any hash algorithm supported by :func: `hashlib.new`.
                     This is used to create the authentication token.
+
+    This Policy implements :class:`pyramid.interfaces.IAuthentictionPolicy`
+    except that not authenticated user get the additional principal
+    `system.Anynymous`.
     """
 
     def __init__(self, secret: str,
@@ -186,62 +151,50 @@ class TokenHeaderAuthenticationPolicy(CallbackAuthenticationPolicy):
         self.get_tokenmanager = get_tokenmanager
         self.hashalg = hashalg
 
-    def unauthenticated_userid(self, request):
-        """Return authenticated userid because we don't have one."""
+    def unauthenticated_userid(self, request) -> str:
+        """Return authenticated userid or None.
+
+        The authenticated userid is returned because the client does not
+        provide a userid.
+        """
         return self.authenticated_userid(request)
 
-    def authenticated_userid(self, request):
-        """Return authenticated userid."""
+    def authenticated_userid(self, request) -> str:
+        """Return authenticated userid or None."""
+        settings = request.registry.settings
+        if not asbool(settings.get('adhocracy.validate_user_token', True)):
+            # used for work in progress thentos integration
+            userid = get_user_path(request)
+            return userid
         tokenmanager = self.get_tokenmanager(request)
         if tokenmanager is None:
             return None
-        try:
-            return self._get_authenticated_user_id(request, tokenmanager)
-        except KeyError:
-            return None
+        token = get_user_token(request)
+        userid = tokenmanager.get_user_id(token, timeout=self.timeout)
+        return userid
+        # TODO cache
 
-    def _get_authenticated_user_id(self, request: Request,
-                                   tokenmanager: ITokenManger) -> str:
-        userid, token = _get_x_user_headers(request)
-        settings = request.registry.settings
-        if not asbool(settings.get('adhocracy.validate_user_token', True)):
-            return userid
-        if token is None:
-            raise KeyError
-        with statsd_timer('authentication.user', rate=.1):
-            authenticated_userid = \
-                tokenmanager.get_user_id(token, timeout=self.timeout)
-        return authenticated_userid
-
-    def remember(self, request, userid, **kw) -> dict:
+    def remember(self, request, userid, **kw) -> [tuple]:
+        """Create persistent user session and return authentication headers."""
         tokenmanager = self.get_tokenmanager(request)
         if tokenmanager:  # for testing
-            token = tokenmanager.create_token(userid, secret=self.secret,
+            token = tokenmanager.create_token(userid,
+                                              secret=self.secret,
                                               hashalg=self.hashalg)
         else:
             token = None
-        locator = request.registry.queryMultiAdapter(
-            (request.context, request), IRolesUserLocator)
-        if locator is not None:  # for testing
-            user = locator.get_user_by_userid(userid)
-        else:
-            user = None
-        if user is not None:
-            url = request.resource_url(user)
-        else:
-            url = None
-        return {'X-User-Path': url,
-                'X-User-Token': token}
+        return [('X-User-Token', token)]
 
-    def forget(self, request):
+    def forget(self, request) -> [tuple]:
+        """Remove user session and return "forget this session" headers."""
         tokenmanager = self.get_tokenmanager(request)
         if tokenmanager:
-            token = _get_x_user_headers(request)[0]
+            token = get_user_token(request)
             tokenmanager.delete_token(token)
-        return {}
+        return []  # forget user session headers are not implemented
 
-    def effective_principals(self, request: Request) -> list:
-        """Return roles and groups for the current user.
+    def effective_principals(self, request: IRequest) -> list:
+        """Return userid, roles and groups for the authenticated user.
 
         THE RESULT IS CACHED for the current request in the request attribute
         called: __cached_principals__ .
@@ -250,12 +203,29 @@ class TokenHeaderAuthenticationPolicy(CallbackAuthenticationPolicy):
         if cached_principals:
             return cached_principals
         if self.authenticated_userid(request) is None:
-            # FIXME this should go to principals.groups_and_roles_finder
-            # to make adhocracy work with other authentication polices.
-            return [Everyone, Anonymous]
-        principals = super().effective_principals(request)
+            principals = [Everyone, Anonymous]
+        else:
+            principals = super().effective_principals(request)
         request.__cached_principals__ = principals
         return principals
+
+
+def get_user_path(request: IRequest) -> str:
+    """Return normalised X-User-Path request header or None."""
+    user_path_header = request.headers.get('X-User-Path', None)
+    user_path = None
+    if user_path_header is not None:
+        schema = Resource().bind(request=request,
+                                 context=request.context)
+        user = schema.deserialize(user_path_header)
+        user_path = resource_path(user)
+    return user_path
+
+
+def get_user_token(request: IRequest) -> str:
+    """Return X-User-Token request header or None."""
+    user_token = request.headers.get('X-User-Token', None)
+    return user_token
 
 
 def includeme(config):

--- a/src/adhocracy_core/adhocracy_core/authentication/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/test_init.py
@@ -179,6 +179,19 @@ class TokenHeaderAuthenticationPolicy(unittest.TestCase):
                                 'X-User-Token': 'whatever'}
         assert inst.authenticated_userid(self.request) == self.userid
 
+    def test_authenticated_userid_set_cached_userid(self):
+        tokenmanager = Mock()
+        tokenmanager.get_user_id.return_value = self.userid
+        inst = self.make_one('', get_tokenmanager=lambda x: tokenmanager)
+        self.request.headers = self.token_headers
+        inst.authenticated_userid(self.request)
+        assert self.request.__cached_userid__ == self.userid
+
+    def test_authenticated_userid_get_cached_userid(self):
+        self.request.__cached_userid__ = self.userid
+        inst = self.make_one('', get_tokenmanager=lambda x: None)
+        assert inst.authenticated_userid(self.request) == self.userid
+
     def test_effective_principals_without_headers(self):
         from pyramid.security import Everyone
         from . import Anonymous

--- a/src/adhocracy_core/adhocracy_core/rest/batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/batchview.py
@@ -174,6 +174,7 @@ class BatchView(RESTView):
         set_batchmode(request)
         self.copy_attr_if_exists('root', request)
         self.copy_attr_if_exists('__cached_principals__', request)
+        self.copy_attr_if_exists('__cached_userid__', request)
         self.copy_header_if_exists('X-User-Path', request)
         self.copy_header_if_exists('X-User-Token', request)
 

--- a/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
@@ -108,6 +108,7 @@ class TestBatchView:
         request_.body = self._make_json_with_subrequest_cstructs(
             path='http://a.org/virtual/adhocracy/blah')
         request_.__cached_principals__ = [1]
+        request_.__cached_userid__ = '/user'
         date = object()
         request_.headers['X-User-Path'] = 2
         request_.headers['X-User-Token'] = 3
@@ -125,6 +126,7 @@ class TestBatchView:
         subrequest  = mock_invoke_subrequest.call_args[0][0]
         assert is_batchmode(subrequest)
         assert subrequest.__cached_principals__ == [1]
+        assert subrequest.__cached_userid__ == '/user'
         assert subrequest.headers.get('X-User-Path') == 2
         assert subrequest.headers.get('X-User-Token') == 3
         assert subrequest.script_name == '/virtual'

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1350,11 +1350,10 @@ class TestLoginUserName:
             inst.post()
 
     def test_post_with_token_authentication_policy(self, request, context, mock_authpolicy):
-        mock_authpolicy.remember.return_value = {'X-User-Path': '/user',
-                                                 'X-User-Token': 'token'}
+        mock_authpolicy.remember.return_value = [('X-User-Token', 'token')]
         inst = self.make_one(context, request)
         assert inst.post() == {'status': 'success',
-                               'user_path': '/user',
+                               'user_path': 'http://example.com/',
                                'user_token': 'token'}
 
     def test_options(self, request, context):
@@ -1379,11 +1378,10 @@ class TestLoginEmailView:
             inst.post()
 
     def test_post_with_token_authentication_policy(self, request, context, mock_authpolicy):
-        mock_authpolicy.remember.return_value = {'X-User-Path': '/user',
-                                                 'X-User-Token': 'token'}
+        mock_authpolicy.remember.return_value = [('X-User-Token', 'token')]
         inst = self.make_one(context, request)
         assert inst.post() == {'status': 'success',
-                               'user_path': '/user',
+                               'user_path': 'http://example.com/',
                                'user_token': 'token'}
 
     def test_options(self, request, context):
@@ -1448,11 +1446,10 @@ class TestActivateAccountView:
         return ActivateAccountView(context, request)
 
     def test_post(self, request, context, mock_authpolicy):
-        mock_authpolicy.remember.return_value = {'X-User-Path': '/user',
-                                                 'X-User-Token': 'token'}
+        mock_authpolicy.remember.return_value = [('X-User-Token', 'token')]
         inst = self.make_one(context, request)
         assert inst.post() == {'status': 'success',
-                               'user_path': '/user',
+                               'user_path': 'http://example.com/',
                                'user_token': 'token'}
 
     def test_options(self, request, context):
@@ -1674,15 +1671,14 @@ class TestPasswordResetView:
         request_.validated['user'] = testing.DummyResource()
         request_.validated['path'] = mock_reset
         request_.validated['password'] = 'password'
-        mock_remember.return_value = {'X-User-Path': '/',
-                                      'X-User-Token': 'token'}
+        mock_remember.return_value = [('X-User-Token', 'token')]
         inst = self.make_one(context, request_)
         result = inst.post()
         mock_reset.reset_password.assert_called()
         mock_remember.assert_called_with(request_, '/')
         mock_reset.reset_password.assert_called_with('password')
         assert result == {'status': 'success',
-                          'user_path': '/',
+                          'user_path': 'http://example.com/',
                           'user_token': 'token'}
 
     def test_options(self, request_, context):

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -1066,12 +1066,12 @@ def _login_user(request: Request) -> dict:
     """Log-in a user and return a response indicating success."""
     user = request.validated['user']
     userid = resource_path(user)
-    headers = remember(request, userid) or {}
-    user_path = headers['X-User-Path']
-    user_token = headers['X-User-Token']
+    authentication_headers = dict(remember(request, userid))
+    url = request.resource_url(user)
+    token = authentication_headers['X-User-Token']
     return {'status': 'success',
-            'user_path': user_path,
-            'user_token': user_token}
+            'user_path': url,
+            'user_token': token}
 
 
 @view_defaults(

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -34,11 +34,11 @@ from adhocracy_core.resources.root import IRootPool
 # Integration/Function test helper  #
 #####################################
 
-god_header = {'X-User-Path': '/principals/users/0000000',
-              'X-User-Token': 'SECRET_GOD'}
+god_header = {'X-User-Token': 'SECRET_GOD'}
 """The authentication headers for the `god` user, used by functional fixtures.
 This assumes the initial user is created and has the `god` role.
 """
+god_path = '/principals/users/0000000'
 god_login = 'god'
 """The login name for the god user, default value."""
 god_password = 'password'
@@ -46,36 +46,35 @@ god_password = 'password'
 god_email = 'sysadmin@test.de'
 """The email for the god user, default value."""
 
-participant_header = {'X-User-Path': '/principals/users/0000001',
-                      'X-User-Token': 'SECRET_PARTICIPANT'}
+participant_header = {'X-User-Token': 'SECRET_PARTICIPANT'}
 """The authentication headers for the `participant`, used by funct. fixtures.
-This assumes the user exists with path == 'X-User-Path'.
+This assumes the user exists with the given path.
 """
+participant_path = '/principals/users/0000001'
 participant_login = 'participant'
 participant_password = 'password'
 
-moderator_header = {'X-User-Path': '/principals/users/0000002',
-                    'X-User-Token': 'SECRET_MODERATOR'}
+moderator_header = {'X-User-Token': 'SECRET_MODERATOR'}
+moderator_path = '/principals/users/0000002'
 moderator_login = 'moderator'
 moderator_password = 'password'
 
-initiator_header = {'X-User-Path': '/principals/users/0000003',
-                    'X-User-Token': 'SECRET_INITIATOR'}
+initiator_header = {'X-User-Token': 'SECRET_INITIATOR'}
+initiator_path = '/principals/users/0000003'
 initiator_login = 'initiator'
 initiator_password = 'password'
 
-admin_header = {'X-User-Path': '/principals/users/0000004',
-                'X-User-Token': 'SECRET_ADMIN'}
+admin_header = {'X-User-Token': 'SECRET_ADMIN'}
+admin_path = '/principals/users/0000004'
 admin_login = 'admin'
 admin_password = 'password'
 
-participant2_header = {'X-User-Path': '/principals/users/0000005',
-                       'X-User-Token': 'SECRET_PARTICIPANT2'}
+participant2_header = {'X-User-Token': 'SECRET_PARTICIPANT2'}
+participant2_path = '/principals/users/0000005'
 participant2_login = 'participant2'
 participant2_password = 'password'
 
-broken_header = {'X-User-Path': '/principals/users/0000001',
-                 'X-User-Token': ''}
+broken_header = {'X-User-Token': ''}
 
 batch_url = '/batch'
 
@@ -617,38 +616,38 @@ def add_user(root, login: str=None, password: str=None, email: str=None,
 def add_test_users(root, registry):
     """Add test user and dummy authentication token for every role."""
     add_user_token(root,
-                   god_header['X-User-Path'],
+                   god_path,
                    god_header['X-User-Token'],
                    registry)
     add_user(root, login=participant_login, password=participant_password,
              email='participant@example.org', roles=['participant'],
              registry=registry)
     add_user_token(root,
-                   participant_header['X-User-Path'],
+                   participant_path,
                    participant_header['X-User-Token'],
                    registry)
     add_user(root, login=moderator_login, password=moderator_password,
              email='moderator@example.org', roles=['moderator'],
              registry=registry)
     add_user_token(root,
-                   moderator_header['X-User-Path'],
+                   moderator_path,
                    moderator_header['X-User-Token'],
                    registry)
     add_user(root, login=initiator_login, password=initiator_password,
              email='initiator@example.org', roles=['initiator'],
              registry=registry)
     add_user_token(root,
-                   initiator_header['X-User-Path'],
+                   initiator_path,
                    initiator_header['X-User-Token'],
                    registry)
     add_user(root, login=admin_login, password=admin_password,
              email='admin@example.org', roles=['admin'], registry=registry)
     add_user_token(root,
-                   admin_header['X-User-Path'],
+                   admin_path,
                    admin_header['X-User-Token'],
                    registry)
     add_user_token(root,
-                   participant2_header['X-User-Path'],
+                   participant2_path,
                    participant2_header['X-User-Token'],
                    registry)
     add_user(root, login=participant2_login, password=participant2_password,
@@ -787,7 +786,9 @@ class AppUser:
                  app_router: Router,
                  rest_url: str='http://localhost',
                  base_path: str='/',
-                 header: dict=None):
+                 header: dict=None,
+                 user_path: str='',
+                 ):
         """Initialize self."""
         self.app_router = app_router
         """The adhocracy wsgi application"""
@@ -799,6 +800,8 @@ class AppUser:
         """path prefix to generate request urls."""
         self.header = header or {}
         """default header for requests, mostly for authentication."""
+        self.user_path = user_path
+        """path to authenticated user."""
         self._resolver = DottedNameResolver()
 
     def post_resource(self, path: str,
@@ -881,37 +884,45 @@ def app_broken_token(app_router) -> TestApp:
 @fixture(scope='class')
 def app_participant(app_router) -> TestApp:
     """Return backend test app wrapper with participant authentication."""
-    return AppUser(app_router, header=participant_header)
+    return AppUser(app_router,
+                   header=participant_header,
+                   user_path=participant_path)
 
 
 @fixture(scope='class')
 def app_participant2(app_router) -> TestApp:
     """Return backend test app wrapper with participant authentication."""
-    return AppUser(app_router, header=participant2_header)
+    return AppUser(app_router,
+                   header=participant2_header,
+                   user_path=participant2_path)
 
 
 @fixture(scope='class')
 def app_moderator(app_router):
     """Return backend test app wrapper with moderator authentication."""
-    return AppUser(app_router, header=moderator_header)
+    return AppUser(app_router,
+                   header=moderator_header,
+                   user_path=moderator_path)
 
 
 @fixture(scope='class')
 def app_initiator(app_router):
     """Return backend test app wrapper with initiator authentication."""
-    return AppUser(app_router, header=initiator_header)
+    return AppUser(app_router,
+                   header=initiator_header,
+                   user_path=initiator_path)
 
 
 @fixture(scope='class')
 def app_admin(app_router):
     """Return backend test app wrapper with admin authentication."""
-    return AppUser(app_router, header=admin_header)
+    return AppUser(app_router, header=admin_header, user_path=admin_path)
 
 
 @fixture(scope='class')
 def app_god(app_router):
     """Return backend test app wrapper with god authentication."""
-    return AppUser(app_router, header=god_header)
+    return AppUser(app_router, header=god_header, user_path=god_path)
 
 
 @fixture(scope='class')

--- a/src/adhocracy_core/docs/authentication_api.rst
+++ b/src/adhocracy_core/docs/authentication_api.rst
@@ -192,7 +192,7 @@ User Authentication
 -------------------
 
 Once the user is logged in, the backend must add add header field to all
-HTTP requests made for the user: "X-User-Token". It`s value
+HTTP requests made for the user: "X-User-Token". Its value
 is the received "user_token",
 respectively. The backend validates the token. If it's valid and not
 expired, the requested action is performed in the name and with the rights

--- a/src/adhocracy_core/docs/badges.rst
+++ b/src/adhocracy_core/docs/badges.rst
@@ -107,7 +107,7 @@ To get assignable badges we send an options request to this post pool::
 
 The user is typically the current logged in user::
 
-    >>> user = initiator.header['X-User-Path']
+    >>> user = initiator.user_path
 
 Now we can post the assignment to a proposal version::
 
@@ -213,14 +213,14 @@ There the admin can create badges::
 
 The user gives us the badge assignment post pool::
 
-    >>> user_with_badge = initiator.header['X-User-Path']
+    >>> user_with_badge = initiator.user_path
     >>> resp = initiator.get(user_with_badge).json
     >>> post_pool = resp['data']['adhocracy_core.sheets.badge.IBadgeable']['post_pool']
 
 
 to create badge assignments::
 
-    >>> user = admin.header['X-User-Path']
+    >>> user = admin.user_path
     >>> prop = {'content_type': 'adhocracy_core.resources.badge.IBadgeAssignment',
     ...         'data': {'adhocracy_core.sheets.badge.IBadgeAssignment':
     ...                      {'subject': user,

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -16,6 +16,7 @@ Some imports to work with rest api calls::
     >>> import requests
     >>> from pprint import pprint
     >>> from adhocracy_core.testing import god_header
+    >>> from adhocracy_core.testing import god_path
 
 Start Adhocracy testapp::
 
@@ -1549,7 +1550,7 @@ custom filters:
   Valid query comparable: 'eq'
   Supports sorting.
 
-    >>> resp_data = testapp.get('/Documents', params={'creator': god_header['X-User-Path']}).json
+    >>> resp_data = testapp.get('/Documents', params={'creator': god_path}).json
     >>> pprint(resp_data['data']['adhocracy_core.sheets.pool.IPool']['elements'])
     ['http://localhost/Documents/document_0000000/']
 


### PR DESCRIPTION
API-CHANGE:

The authentication header 'X-User-Path' is not validated anymore.

There is an exception if you set the config option
'adhocracy.validate_user_token' to false. This is a hack to make
adhocracy work with thentos and should be replaced with a proper setup
for `pyramid.authentication.IExternalAuthentication policy.

Internal Changes:

- cache authenticated_userid method for one request (its called for every permission check)
- refactor adhocracy_core.authentication, more strict  IAuthentictionPolicy implementation, no dependencies to other packages