### PR TITLE
2016 02 js add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,9 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+
+# this doesn't work with most editors, but one can always hope...
 trim_trailing_whitespace = true
+
+[*.json]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# Reference: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/src/adhocracy_frontend/adhocracy_frontend/static/embed.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/embed.html
@@ -26,7 +26,7 @@
         <!--
             it is possible to embed several snippets in parallel.  the
             following crude example works if you adjust the path of
-            the paragraph version so something that exists in your
+            the paragraph version to something that exists in your
             database backend:
 
             <div class="adhocracy_marker" data-widget="paragraph-version-detail" data-ref="/adhocracy/wef0/paragraph0/VERSION_0000001" data-viewmode="display"></div>


### PR DESCRIPTION
@xi and I think Editorconfig can help unify the whitespace/ newline settings of the development team. You probably need a plugin to use it in your editor - check editorconfig.org.