### PR TITLE
euth idea collection image upload

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -129,7 +129,7 @@ export var showImageDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<img class=\"{{ cssClass }}\" data-ng-src=\"{{ imageUrl }}\" alt=\"{{alt}}\" />",
+        template: "<img class=\"{{ cssClass }}\" data-ng-if=\"imageUrl\" data-ng-src=\"{{ imageUrl }}\" alt=\"{{alt}}\" />",
         scope: {
             path: "@", // of the attachment resource
             cssClass: "@",
@@ -137,6 +137,7 @@ export var showImageDirective = (
             format: "@?", // defaults to "detail"
             imageMetadataNick: "@?", // defaults to SIImageMetadata.nick
             fallbackUrl: "@?", // defaults to "/static/fallback_$format.jpg";
+            noFallback: "=?",
             didFailToLoadImage: "&?"
         },
         link: (scope) => {
@@ -145,7 +146,11 @@ export var showImageDirective = (
             var imageMetadataNick = () =>
                 scope.imageMetadataNick ? scope.imageMetadataNick : SIImageMetadata.nick;
             var format = () => scope.format || "detail";
-            var fallbackUrl = () => scope.fallbackUrl || ("/static/fallback_" + format() + ".jpg");
+            var fallbackUrl = () => {
+                if (!scope.noFallback) {
+                    return scope.fallbackUrl || ("/static/fallback_" + format() + ".jpg");
+                }
+            };
             scope.imageUrl = fallbackUrl(); // show fallback till real image is loaded
 
             scope.$watch("path", (path) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -2,6 +2,7 @@ import * as _ from "lodash";
 
 import * as AdhConfig from "../Config/Config";
 import * as AdhHttp from "../Http/Http";
+import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 
 import RIImage from "../../Resources_/adhocracy_core/resources/image/IImage";
 import * as SIHasAssetPool from "../../Resources_/adhocracy_core/sheets/asset/IHasAssetPool";
@@ -95,8 +96,10 @@ export var addImage = (
 export var uploadImageDirective = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service,
     adhUploadImage,
-    flowFactory
+    flowFactory,
+    adhResourceUrl
 ) => {
     return {
         restrict: "E",
@@ -115,10 +118,16 @@ export var uploadImageDirective = (
                 return false;
             });
 
+            scope.goToCameFrom = () => {
+                var url = adhResourceUrl(scope.path);
+                adhTopLevelState.goToCameFrom(url);
+            };
+
             scope.submit = () => {
                 return adhUploadImage(scope.poolPath, scope.$flow)
                     .then((imagePath : string) => addImage(adhHttp)(scope.path, imagePath)
-                        .then(scope.didCompleteUpload));
+                        .then(scope.didCompleteUpload)
+                        .then(scope.goToCameFrom));
             };
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Module.ts
@@ -1,5 +1,6 @@
 import * as AdhEmbedModule from "../Embed/Module";
 import * as AdhHttpModule from "../Http/Module";
+import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 
 import * as AdhEmbed from "../Embed/Embed";
 
@@ -12,12 +13,14 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhEmbedModule.moduleName,
+            AdhTopLevelStateModule.moduleName,
             AdhHttpModule.moduleName
         ])
         .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
             adhEmbedProvider.registerDirective("upload-image");
         }])
         .factory("adhUploadImage", ["adhHttp", AdhImage.uploadImageFactory])
-        .directive("adhUploadImage", ["adhConfig", "adhHttp", "adhUploadImage", "flowFactory", AdhImage.uploadImageDirective])
+        .directive("adhUploadImage", ["adhConfig", "adhHttp", "adhTopLevelState", "adhUploadImage",
+            "flowFactory", "adhResourceUrlFilter", AdhImage.uploadImageDirective])
         .directive("adhShowImage", ["adhHttp", AdhImage.showImageDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
@@ -1,20 +1,20 @@
-<form name="imageUpload" data-ng-submit="submit()" data-ng-if="$flow.support">
+<form name="imageUpload" data-ng-submit="submit()" data-ng-if="$flow.support" class="image-upload m-standalone">
     <span class="label-text">{{ "TR__IMAGE_UPLOAD" | translate }}</span>
     <div
         data-flow-init=""
         data-flow-object="$flow">
         <span
-            class="button-cta-secondary"
+            class="button-cta-secondary image-upload-button"
             data-flow-btn=""
             data-flow-attrs="{accept:'image/*'}">
             <span data-ng-if="$flow.files.length > 0">{{ "TR__IMAGE_CHANGE" | translate }}</span>
             <span data-ng-if="!$flow.files.length || $flow.files.length === 0">{{ "TR__IMAGE_CHOOSE" | translate }}</span>
         </span>
-        <div data-ng-repeat="file in $flow.files">
+        <div data-ng-repeat="file in $flow.files" class="image-upload-preview">
             <img data-flow-img="file" height="120" alt="{{ 'TR__IMAGE_SELECTED' | translate }}" /><br/>{{file.name}}
         </div>
         <div class="form-footer">
-            <input type="submit" ng-value="{{'TR__SUBMIT' | translate}}" class="button" data-ng-disabled="0 === $flow.files.length" />
+            <input type="submit" ng-value="{{'TR__SUBMIT' | translate}}" class="button-cta image-upload-submit-button" data-ng-disabled="0 === $flow.files.length" />
             <input type="reset" ng-value="{{'TR__CANCEL' | translate }}" class="button" ng-click="didCancelUpload()"/>
         </div>
     </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_image_upload.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_image_upload.scss
@@ -13,6 +13,19 @@ category: Widgets
 */
 .image-upload {
     @include rem(margin, 1.4rem 0);
+
+    .form-footer {
+        @include rem(margin-top, 1rem);
+    }
+
+    &.m-standalone {
+        @include rem(margin-left, 1rem);
+        @include rem(margin-right, 1rem);
+    }
+}
+
+.image-upload-submit-button {
+    @include rem(margin-right, 1rem);
 }
 
 .image-upload-preview {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_proposal_detail.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_proposal_detail.scss
@@ -135,5 +135,21 @@ Proposal detail article.
 .proposal-detail {
     .rate {
         float: right;
+        margin-right: 0;
+    }
+}
+
+.proposal-detail-image-clip {
+    position: relative;
+    height: 200px;
+    overflow: hidden;
+
+    img {
+        left: 0;
+        position: absolute;
+        top: 0;
+        height: auto;
+        min-height: 200px;
+        max-width: 100%;
     }
 }

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Detail.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Detail.html
@@ -1,6 +1,10 @@
 <article class="proposal-detail">
     <header class="proposal-detail-header">
 
+        <adh-show-image
+            data-css-path="proposal-detail-image"
+            data-path="{{data.picture}}"
+        ></adh-show-image>
         <span
             data-ng-repeat="assignment in data.assignments"
             class="badge">{{ assignment.title }}</span>

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Detail.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Detail.html
@@ -1,11 +1,13 @@
 <article class="proposal-detail">
     <header class="proposal-detail-header">
 
-        <adh-show-image
-            data-css-path="proposal-detail-image"
-            data-no-fallback="true"
-            data-path="{{data.picture}}"
-        ></adh-show-image>
+        <div class="proposal-detail-image-clip" data-ng-if="data.picture">
+            <adh-show-image
+                data-css-path="proposal-detail-image"
+                data-no-fallback="true"
+                data-path="{{data.picture}}"
+            ></adh-show-image>
+        </div>
         <span
             data-ng-repeat="assignment in data.assignments"
             class="badge">{{ assignment.title }}</span>
@@ -16,7 +18,7 @@
                     <i class="icon-speechbubble"></i> {{ data.commentCount }} {{ "TR__COMMENTS" | translate }}
                 </a>
             </li>
-            <li class="meta-list-item proposal-detail-meta-participation">
+            <li class="meta-list-item proposal-detail-meta-participation rate">
                 <adh-rate data-refers-to="{{path}}"></adh-rate>
             </li>
         </ul>

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Detail.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Detail.html
@@ -3,6 +3,7 @@
 
         <adh-show-image
             data-css-path="proposal-detail-image"
+            data-no-fallback="true"
             data-path="{{data.picture}}"
         ></adh-show-image>
         <span

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/ListItem.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/ListItem.html
@@ -1,6 +1,11 @@
 <!-- FIXME: may contain links in adh-user-meta -->
 <a class="proposal-list-item {{selectedState}}" href="{{path | adhParentPath | adhResourceUrl }}">
-    <div class="proposal-list-item-col-left">
+    <adh-show-image
+        data-css-class="proposal-list-item-image"
+        data-path="{{data.picture}}"
+        data-format="thumbnail"
+    ></adh-show-image>
+    <div class="proposal-list-item-body">
         <span
                 data-ng-repeat="assignment in data.assignments"
                 class="badge">{{ assignment.title }}</span>
@@ -9,9 +14,7 @@
         <adh-user-meta data-path="{{data.creator}}" data-ng-if="data.creator"></adh-user-meta>
         {{ "TR__ON" | translate }}
         <adh-time data-datetime="data.creationDate" data-format="L"></adh-time></p>
-    </div>
-    <div class="proposal-list-item-col-right">
-        <ul class="meta-list m-vertical">
+        <ul class="meta-list">
             <li class="meta-list-item"><i class="proposal-list-meta-item-icon icon-speechbubble-unfilled"></i
             > {{ data.commentCount }} {{ "TR__COMMENTS" | translate }}</li>
             <li class="meta-list-item"><i class="proposal-list-meta-item-icon icon-voting"></i

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Proposal.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Proposal.ts
@@ -51,43 +51,43 @@ var bindPath = (
     scope: IScope,
     pathKey: string = "path"
 ): void => {
-        scope.$watch(pathKey, (value: string) => {
-            if (value) {
-                adhHttp.get(value).then((resource) => {
-                    scope.resource = resource;
+    scope.$watch(pathKey, (value: string) => {
+        if (value) {
+            adhHttp.get(value).then((resource) => {
+                scope.resource = resource;
 
-                    var titleSheet: SITitle.Sheet = resource.data[SITitle.nick];
-                    var descriptionSheet: SIDescription.Sheet = resource.data[SIDescription.nick];
-                    var metadataSheet: SIMetadata.Sheet = resource.data[SIMetadata.nick];
-                    var rateableSheet: SIRateable.Sheet = resource.data[SIRateable.nick];
+                var titleSheet: SITitle.Sheet = resource.data[SITitle.nick];
+                var descriptionSheet: SIDescription.Sheet = resource.data[SIDescription.nick];
+                var metadataSheet: SIMetadata.Sheet = resource.data[SIMetadata.nick];
+                var rateableSheet: SIRateable.Sheet = resource.data[SIRateable.nick];
 
-                    $q.all([
-                        adhRate.fetchAggregatedRates(rateableSheet.post_pool, resource.path),
-                        adhGetBadges(resource)
-                    ]).then((args: any[]) => {
-                        var rates = args[0];
-                        var assignments = args[1];
+                $q.all([
+                    adhRate.fetchAggregatedRates(rateableSheet.post_pool, resource.path),
+                    adhGetBadges(resource)
+                ]).then((args: any[]) => {
+                    var rates = args[0];
+                    var assignments = args[1];
 
-                        // FIXME: an adapter should take care of this
-                        var ratesPro = rates["1"] || 0;
-                        var ratesContra = rates["-1"] || 0;
+                    // FIXME: an adapter should take care of this
+                    var ratesPro = rates["1"] || 0;
+                    var ratesContra = rates["-1"] || 0;
 
-                        scope.data = {
-                            title: titleSheet.title,
-                            detail: descriptionSheet.description,
-                            rateCount: ratesPro - ratesContra,
-                            creator: metadataSheet.creator,
-                            creationDate: metadataSheet.item_creation_date,
-                            commentCount: resource.data[SICommentable.nick].comments_count,
-                            assignments: assignments,
-                            picture: resource.data[SIImageReference.nick].picture
-                        };
-                    });
+                    scope.data = {
+                        title: titleSheet.title,
+                        detail: descriptionSheet.description,
+                        rateCount: ratesPro - ratesContra,
+                        creator: metadataSheet.creator,
+                        creationDate: metadataSheet.item_creation_date,
+                        commentCount: resource.data[SICommentable.nick].comments_count,
+                        assignments: assignments,
+                        picture: resource.data[SIImageReference.nick].picture
+                    };
                 });
-            }
-            adhPermissions.bindScope(scope, () => scope[pathKey]);
-        });
-    };
+            });
+        }
+        adhPermissions.bindScope(scope, () => scope[pathKey]);
+    });
+};
 
 var fill = (
     scope: IScope,

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Proposal.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Proposal.ts
@@ -11,6 +11,7 @@ import * as AdhUtil from "../../../Util/Util";
 
 import * as SICommentable from "../../../../Resources_/adhocracy_core/sheets/comment/ICommentable";
 import * as SIDescription from "../../../../Resources_/adhocracy_core/sheets/description/IDescription";
+import * as SIImageReference from "../../../../Resources_/adhocracy_core/sheets/image/IImageReference";
 import * as SIMetadata from "../../../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
 import * as SIRateable from "../../../../Resources_/adhocracy_core/sheets/rate/IRateable";
 import * as SITitle from "../../../../Resources_/adhocracy_core/sheets/title/ITitle";
@@ -33,6 +34,7 @@ export interface IScope extends angular.IScope {
         creationDate: string;
         commentCount: number;
         assignments: AdhBadge.IBadge[];
+        picture? : string;
     };
     selectedState?: string;
     resource: any;
@@ -77,7 +79,8 @@ var bindPath = (
                             creator: metadataSheet.creator,
                             creationDate: metadataSheet.item_creation_date,
                             commentCount: resource.data[SICommentable.nick].comments_count,
-                            assignments: assignments
+                            assignments: assignments,
+                            picture: resource.data[SIImageReference.nick].picture
                         };
                     });
                 });

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Module.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Module.ts
@@ -40,5 +40,7 @@ export var register = (angular) => {
         .directive("adhPcompassProposalDetailColumn", ["adhConfig", "adhHttp", "adhPermissions", Workbench.proposalDetailColumnDirective])
         .directive("adhPcompassProposalCreateColumn", ["adhConfig", Workbench.proposalCreateColumnDirective])
         .directive("adhPcompassProposalEditColumn", ["adhConfig", Workbench.proposalEditColumnDirective])
+        .directive("adhPcompassProposalImageColumn", [
+            "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", "adhParentPathFilter", Workbench.proposalImageColumnDirective])
         .directive("adhPcompassProcessDetailColumn", ["adhConfig", "adhPermissions", Workbench.processDetailColumnDirective]);
 };

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -4,6 +4,7 @@
             <i class="icon-document moving-column-icon"></i>
         </div>
         <a class="moving-column-menu-button" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'edit' }}">{{ "TR__EDIT" | translate }}</a>
+        <a class="moving-column-menu-button" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'image' }}">{{ "TR__IMAGE" | translate }}</a>
         <a
             class="moving-column-menu-button"
             data-ng-if="badgeAssignmentPoolOptions.POST"

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -4,7 +4,7 @@
             <i class="icon-document moving-column-icon"></i>
         </div>
         <a class="moving-column-menu-button" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'edit' }}">{{ "TR__EDIT" | translate }}</a>
-        <a class="moving-column-menu-button" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'image' }}">{{ "TR__IMAGE" | translate }}</a>
+        <a class="moving-column-menu-button" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'image' }}">{{ "TR__IMAGE_UPLOAD" | translate }}</a>
         <a
             class="moving-column-menu-button"
             data-ng-if="badgeAssignmentPoolOptions.POST"

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalImageColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalImageColumn.html
@@ -1,0 +1,24 @@
+<div data-ng-switch="transclusionId">
+    <div data-ng-switch-when="menu">
+        <div class="moving-column-tab">
+            <i class="icon-document moving-column-icon"></i>
+        </div>
+        <a class="moving-column-menu-button" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
+
+        <div class="moving-column-menu-nav">
+            <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
+        </div>
+    </div>
+
+    <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">
+        <i class="icon-document moving-column-icon"></i>
+    </a>
+
+    <adh-upload-image
+        data-ng-switch-when="body"
+        data-ng-if="proposalUrl"
+        data-path="{{proposalUrl}}"
+        data-pool-path="{{processUrl}}"
+        data-did-complete-upload="goBack()"
+    ></adh-upload-image>
+</div>

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.html
@@ -5,7 +5,8 @@
     <adh-moving-column>
         <adh-pcompass-proposal-create-column data-ng-if="view === 'create_proposal'"></adh-pcompass-proposal-create-column>
         <adh-pcompass-proposal-edit-column data-ng-if="view === 'edit'"></adh-pcompass-proposal-edit-column>
-        <adh-pcompass-proposal-detail-column data-ng-if="view !== 'create_proposal' && view !== 'edit'"></adh-pcompass-proposal-detail-column>
+        <adh-pcompass-proposal-image-column data-ng-if="view === 'image'"></adh-pcompass-proposal-image-column>
+        <adh-pcompass-proposal-detail-column data-ng-if="view !== 'create_proposal' && view !== 'edit' && view !== 'image'"></adh-pcompass-proposal-detail-column>
     </adh-moving-column>
     <adh-moving-column>
         <adh-comment-column></adh-comment-column>

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.ts
@@ -84,6 +84,26 @@ export var proposalEditColumnDirective = (
     };
 };
 
+export var proposalImageColumnDirective = (
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhResourceUrl,
+    adhParentPath
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalImageColumn.html",
+        require: "^adhMovingColumn",
+        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.goBack = () => {
+                var url = adhResourceUrl(adhParentPath(scope.proposalUrl));
+                adhTopLevelState.goToCameFrom(url);
+            };
+        }
+    };
+};
+
 export var processDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
     adhPermissions : AdhPermissions.Service
@@ -128,6 +148,22 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide"
         })
         .specificVersionable(RIProposal, RIProposalVersion, "edit", processType, context, [
+            "adhHttp", (adhHttp : AdhHttp.Service<any>) => (item : RIProposal, version : RIProposalVersion) => {
+                return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
+                    if (!options.POST) {
+                        throw 401;
+                    } else {
+                        return {
+                            proposalUrl: version.path
+                        };
+                    }
+                });
+            }])
+        .defaultVersionable(RIProposal, RIProposalVersion, "image", processType, context, {
+            space: "content",
+            movingColumns: "is-show-show-hide"
+        })
+        .specificVersionable(RIProposal, RIProposalVersion, "image", processType, context, [
             "adhHttp", (adhHttp : AdhHttp.Service<any>) => (item : RIProposal, version : RIProposalVersion) => {
                 return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
                     if (!options.POST) {


### PR DESCRIPTION
This adds a simple image upload to the euth idea collection process. Note that with this change it is no longer identical to the pcompass process.

Some styling is missing, especially for the detail view. The upload widget does not look to nice either, but I fear there is not much we can do about that at this moment.