### PR TITLE
rm count parameter from pool queries

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -157,7 +157,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
 
                 $scope.createPath = adhPreliminaryNames.nextPreliminary();
 
-                var getElements = (count? : boolean, limit? : number, offset? : number) : angular.IPromise<Container> => {
+                var getElements = (limit? : number, offset? : number) : angular.IPromise<Container> => {
                     var params = <any>{};
 
                     params.elements = "paths";
@@ -209,9 +209,6 @@ export class Listing<Container extends ResourcesBase.Resource> {
                             params.offset = offset;
                         }
                     }
-                    if (count) {
-                        params.count = "true";
-                    }
                     return adhHttp.get($scope.path, params, {
                         warmupPoolCache: true
                     });
@@ -257,7 +254,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
                             $scope.currentLimit = $scope.initialLimit;
                         }
                     }
-                    return getElements(true, $scope.currentLimit).then((container) => {
+                    return getElements($scope.currentLimit).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = $scope.container.path;
                         $scope.totalCount = $scope.container.data[SIPool.nick].count;
@@ -276,7 +273,7 @@ export class Listing<Container extends ResourcesBase.Resource> {
 
                 $scope.loadMore = () : void => {
                     if ($scope.currentLimit < $scope.totalCount) {
-                        getElements(false, $scope.initialLimit, $scope.currentLimit).then((container) => {
+                        getElements($scope.initialLimit, $scope.currentLimit).then((container) => {
                             var elements = _.clone(container.data[SIPool.nick].elements);
                             $scope.elements = $scope.elements.concat(elements);
                             $scope.currentLimit += $scope.initialLimit;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/ListingSpec.ts
@@ -125,8 +125,7 @@ export var register = () => {
 
                         it("updates scope.container from server", () => {
                             expect(adhHttpMock.get).toHaveBeenCalledWith(path, {
-                                elements: "paths",
-                                count: "true"
+                                elements: "paths"
                             }, {warmupPoolCache: true});
                             expect(scope.container).toBe(container);
                         });
@@ -152,8 +151,7 @@ export var register = () => {
                         it("updates scope.container from server", () => {
                             expect(adhHttpMock.get).toHaveBeenCalledWith(path, {
                                 elements: "paths",
-                                content_type: "some_content_type",
-                                count: "true"
+                                content_type: "some_content_type"
                             }, {warmupPoolCache: true});
                             expect(scope.container).toBe(container);
                         });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Rate/Rate.ts
@@ -121,7 +121,6 @@ export class Service {
             content_type: RIRateVersion.content_type,
             depth: "all",
             tag: "LAST",
-            count: "true",
             aggregateby: "rate"
         };
         query[SIRate.nick + ":object"] = object;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -760,7 +760,6 @@ export var adhUserActivityOverviewDirective = (
 
                 var params = {
                     depth: "all",
-                    count: true,
                     content_type: contentType.content_type
                 };
                 params[SIMetadata.nick + ":creator"] = scope.path;

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -196,7 +196,6 @@ export var countSupporters = (adhHttp : AdhHttp.Service<any>, postPoolPath : str
         depth: "2",
         tag: "LAST",
         rate: "1",
-        count: "true",
         elements: "omit"
     };
     query[SIRate.nick + ":object"] = objectPath;


### PR DESCRIPTION
this is sensible because since #2020 the `count` parameter is always shown by default.