### PR TITLE
custom header infrastructure

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -28,12 +28,14 @@ export class Provider implements angular.IServiceProvider {
         type? : string;
     }};
     public templates : {[embedContext : string]: any};
+    public customHeaders : {[processType : string]: string};
 
     constructor() {
         var self = this;
         this.defaults = {};
         this.specifics = {};
         this.templates = {};
+        this.customHeaders = {};
         this.$get = ["$q", "$injector", "$location", "adhHttp", "adhConfig", "adhEmbed", "adhResourceUrlFilter",
             ($q, $injector, $location, adhHttp, adhConfig, adhEmbed, adhResourceUrlFilter) => new Service(
         self, $q, $injector, $location, adhHttp, adhConfig, adhEmbed, adhResourceUrlFilter)];
@@ -106,6 +108,11 @@ export class Provider implements angular.IServiceProvider {
 
     public template(embedContext : string, templateFn : any) : Provider {
         this.templates[embedContext] = templateFn;
+        return this;
+    }
+
+    public customHeader(processType : string, templateUrl : string) : Provider {
+        this.customHeaders[processType] = templateUrl;
         return this;
     }
 }
@@ -352,6 +359,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
                 var defaults : Dict = self.getDefaults(resource.content_type, view, processType, embedContext);
 
                 var meta : Dict = {
+                    customHeader: self.provider.customHeaders[processType],
                     embedContext: embedContext,
                     processType: processType,
                     processUrl: processUrl,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/Module.ts
@@ -15,7 +15,7 @@ export var register = (angular) => {
             AdhTrackingModule.moduleName
         ])
         .provider("adhTopLevelState", AdhTopLevelState.Provider)
-        .directive("adhPageWrapper", ["adhConfig", AdhTopLevelState.pageWrapperDirective])
+        .directive("adhPageWrapper", ["adhConfig", "adhTopLevelState", AdhTopLevelState.pageWrapperDirective])
         .directive("adhRoutingError", ["adhConfig", AdhTopLevelState.routingErrorDirective])
         .directive("adhSpace", ["adhTopLevelState", AdhTopLevelState.spaceDirective])
         .directive("adhView", ["adhTopLevelState", "$compile", AdhTopLevelState.viewFactory]);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -440,7 +440,10 @@ export var spaceDirective = (adhTopLevelState : Service) => {
 };
 
 
-export var pageWrapperDirective = (adhConfig : AdhConfig.IService) => {
+export var pageWrapperDirective = (
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : Service
+) => {
     return {
         restrict: "E",
         transclude: true,
@@ -448,6 +451,7 @@ export var pageWrapperDirective = (adhConfig : AdhConfig.IService) => {
         link: (scope) => {
             scope.hideHeader = adhConfig.custom["hide_header"];
             scope.headerTemplateUrl = adhConfig.pkg_path + pkgLocation + "/templates/" + "Header.html";
+            scope.$on("$destroy", adhTopLevelState.bind("customHeader", scope));
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/templates/Header.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/templates/Header.html
@@ -1,4 +1,7 @@
 <header data-ng-hide="hideHeader" class="l-header main-header">
+    <div class="l-header-left">
+        <ng-include data-ng-if="customHeader" src="customHeader"></ng-include>
+    </div>
     <div class="l-header-right">
         <adh-user-indicator></adh-user-indicator>
         <adh-help-link></adh-help-link>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/templates/Header.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/templates/Header.html
@@ -1,5 +1,5 @@
-<header class="l-header main-header">
-    <div data-ng-hide="hideHeader" class="l-header-right">
+<header data-ng-hide="hideHeader" class="l-header main-header">
+    <div class="l-header-right">
         <adh-user-indicator></adh-user-indicator>
         <adh-help-link></adh-help-link>
     </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/TopLevelState/templates/Header.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/TopLevelState/templates/Header.html
@@ -1,8 +1,9 @@
-<header class="l-header main-header">
+<header data-ng-hide="hide_header === 'true'" class="l-header main-header">
     <div class="l-header-left">
         <a href="https://mein.berlin.de/" target="_top"><i class="header-logo icon-meinberlin-logo" title="mein Berlin"></i></a>
     </div>
     <div class="l-header-right">
+        <ng-include data-ng-if="customHeader" src="customHeader"></ng-include>
         <adh-user-indicator></adh-user-indicator>
         <adh-help-link></adh-help-link>
     </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/TopLevelState/templates/Header.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/TopLevelState/templates/Header.html
@@ -1,4 +1,4 @@
-<header data-ng-hide="hide_header === 'true'" class="l-header main-header">
+<header data-ng-hide="hideHeader" class="l-header main-header">
     <div class="l-header-left">
         <a href="https://mein.berlin.de/" target="_top"><i class="header-logo icon-meinberlin-logo" title="mein Berlin"></i></a>
     </div>


### PR DESCRIPTION
This is the part of #2109 that provides the common infrastructure for custom headers.

The idea is that you can register a template url for a "custom header" for a process. The template will be included in the header.

In the next steps we want to use this to show buttons in the header. These buttons are already there, but the way they are injected requires a lot of boilerplate code and is counter-intuitive (they are bound to context, not process).

Another step would be to harmonize the interfaces of `adhResourceAreaProvider.template()` and `adhResourceAreaProvider.customHeader()`.