### PR TITLE
Fix element count when using sort and limit

### DIFF
--- a/src/adhocracy_core/adhocracy_core/catalog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/__init__.py
@@ -228,8 +228,7 @@ class CatalogsServiceAdhocracy(CatalogsService):
             # hypatia.field.FieldIndex is missing this interface.
             assert 'sort' in sort_index.__dir__()
             elements = elements.sort(sort_index,
-                                     reverse=query.reverse,
-                                     limit=query.limit or None)
+                                     reverse=query.reverse)
         return elements
 
     def _get_slice(self, elements: Iterable, query: IResultSet) -> Iterable:

--- a/src/adhocracy_core/adhocracy_core/catalog/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_init.py
@@ -536,3 +536,13 @@ class TestCatalogsServiceAdhocracy:
                                             allows=(['principal'], 'view')))
         assert list(result.elements) == [child]
 
+    def test_search_count_with_limit_and_sort(self, registry, pool, inst,
+                                              query):
+        from adhocracy_core.interfaces import IPool
+        child = self._make_resource(registry, parent=pool)
+        child2 = self._make_resource(registry, parent=pool)
+        result = inst.search(query._replace(interfaces=IPool,
+                                            limit=1,
+                                            sort_by='name'))
+        assert result.count == 2
+


### PR DESCRIPTION
Limit must not be applied when sorting, as element count computation and
slicing is done later.