### PR TITLE
replace get workflow state

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -11,6 +11,7 @@ import * as AdhUtil from "../Util/Util";
 import RIProcess from "../../Resources_/adhocracy_core/resources/process/IProcess";
 import * as SITags from "../../Resources_/adhocracy_core/sheets/tags/ITags";
 import * as SIVersionable from "../../Resources_/adhocracy_core/sheets/versions/IVersionable";
+import * as SIWorkflowAssignment from "../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
 
 var pkgLocation = "/ResourceArea";
 
@@ -350,6 +351,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
 
             var processType = process ? process.content_type : "";
             var processUrl = process ? process.path : "/";
+            var processState = process ? process.data[SIWorkflowAssignment.nick].workflow_state : "";
 
             if (hasRedirected) {
                 return;
@@ -363,6 +365,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
                     embedContext: embedContext,
                     processType: processType,
                     processUrl: processUrl,
+                    processState: processState,
                     platformUrl: self.adhConfig.rest_url + "/" + segs[1],
                     contentType: resource.content_type,
                     resourceUrl: resourceUrl,

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/AddProposalButton.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/AddProposalButton.html
@@ -1,7 +1,7 @@
 <a
     class="button button-cta m-add"
     data-ng-click="setCameFrom()"
-    data-ng-if="processOptions.POST || (!processOptions.loggedIn && participate)"
+    data-ng-if="processOptions.POST || (!processOptions.loggedIn && processState === 'participate')"
     data-ng-href="{{ processUrl | adhResourceUrl:'create_proposal' }}">
     {{ "TR__PROPOSAL_ADD" | translate }}
 </a>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Module.ts
@@ -105,8 +105,7 @@ export var register = (angular) => {
             }])
         .directive("adhMercator2015ProposalListing", ["adhConfig", Proposal.listing])
         .directive("adhMercator2015UserProposalListing", ["adhConfig", Proposal.userListing])
-        .directive("adhMercator2015AddProposalButton", [
-            "adhConfig", "adhHttp", "adhTopLevelState", "adhPermissions", "$q", Proposal.addProposalButton])
+        .directive("adhMercator2015AddProposalButton", ["adhConfig", "adhPermissions", "adhTopLevelState", Proposal.addProposalButton])
         .controller("mercatorProposalFormController", [
             "$scope", "$element", "$window", "adhShowError", "adhSubmitIfValid", Proposal.mercatorProposalFormController]);
 };

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Module.ts
@@ -68,7 +68,7 @@ export var register = (angular) => {
             };
         }])
         // NOTE: we do not use a Widget based directive here for performance reasons
-        .directive("adhMercator2015Proposal", ["$q", "adhConfig", "adhHttp", "adhTopLevelState", "adhGetBadges", Proposal.listItem])
+        .directive("adhMercator2015Proposal", ["adhConfig", "adhHttp", "adhTopLevelState", "adhGetBadges", Proposal.listItem])
         .directive("adhMercator2015ProposalDetailView", [
             "adhConfig",
             "adhHttp",

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -928,7 +928,7 @@ export var listItem = (
 export var addProposalButton = (
     adhConfig : AdhConfig.IService,
     adhPermissions : AdhPermissions.Service,
-    adhTopLevelState : AdhTopLevelState.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -955,19 +955,15 @@ export var listItem = (
 
 export var addProposalButton = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>,
-    adhTopLevelState : AdhTopLevelState.Service,
     adhPermissions : AdhPermissions.Service,
-    $q : angular.IQService
+    adhTopLevelState : AdhTopLevelState.Service,
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/AddProposalButton.html",
         link: (scope) => {
-            getWorkflowState(adhHttp, adhTopLevelState, $q)().then((workflowState) => {
-                scope.participate = workflowState === "participate";
-            });
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("processState", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             scope.setCameFrom = () => adhTopLevelState.setCameFrom();
         }

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -351,7 +351,7 @@ export class Widget<R extends ResourcesBase.Resource> extends AdhResourceWidgets
             data.winnerBadgeAssignment = communityAssignment || winningAssignment;
         });
 
-        instance.scope.$on("$destroy", this.adhTopLevelState.bind("processState", data, "currentPhase"));
+        instance.scope.$on("$destroy", <any>this.adhTopLevelState.bind("processState", data, "currentPhase"));
 
         var subResourcePaths : SIMercatorSubResources.Sheet = mercatorProposalVersion.data[SIMercatorSubResources.nick];
         var subResourcePromises : angular.IPromise<ResourcesBase.Resource[]> = this.$q.all([

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
@@ -2,7 +2,7 @@
     <h2 class="print-only section-jump-cover-header" data-aria-hidden="true">{{ data.title }}</h2>
 
     <div class="section-jump-cover">
-        <ul class="meta-list mercator-proposal-detail-meta-list m-phase-{{data.currentPhase}}">
+        <ul class="meta-list mercator-proposal-detail-meta-list m-phase-{{processState}}">
             <li class="meta-list-item meta-list-item-total-comments">
                 <i class="icon-speechbubbles"></i>
                 {{ data.commentCountTotal }} {{ "TR__COMMENTS_TOTAL" | translate }}
@@ -11,12 +11,12 @@
                 <i class="icon-calendar m-definition-before" title="{{ 'TR__CREATION_DATE' | translate }}:"></i>
                 <adh-time data-datetime="data.creationDate" data-format="D/M/YYYY"></adh-time>
             </li>
-            <li data-ng-if="data.currentPhase && data.currentPhase != 'result'" class="meta-list-item meta-list-item-budget screen-only">
+            <li data-ng-if="processState && processState != 'result'" class="meta-list-item meta-list-item-budget screen-only">
                 <i class="icon-pig" title="{{ 'TR__MERCATOR_PROPOSAL_REQUESTED' | translate }}"></i>
                 {{data.finance.requestedFunding | number}} &euro;
             </li>
             <li class="meta-list-item meta-list-item-rate">
-                <adh-like data-refers-to="{{path}}" data-disabled="data.currentPhase != 'participate'"></adh-like>
+                <adh-like data-refers-to="{{path}}" data-disabled="processState != 'participate'"></adh-like>
             </li>
         </ul>
 

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -203,7 +203,6 @@ export interface IDetailData extends IData {
         difference : number;
         practicalrelevance : number;
     };
-    currentPhase : string;
     supporterCount : number;
     creationDate : string;
     creator : string;
@@ -520,7 +519,6 @@ var get = (
                 subs[key] = subresource;
             });
         })).then(() => $q.all([
-            AdhMercator2015Proposal.getWorkflowState(adhHttp, adhTopLevelState, $q)(),
             AdhMercator2015Proposal.countSupporters(adhHttp, path + "rates/", path),
             adhGetBadges(proposal).then((assignments : AdhBadge.IBadge[]) => {
                 var communityAssignment = _.find(assignments, (a) => a.name === "community");
@@ -546,8 +544,7 @@ var get = (
             };
 
             return {
-                currentPhase: args[0],
-                supporterCount: args[1],
+                supporterCount: args[0],
 
                 creationDate: proposal.data[SIMetaData.nick].item_creation_date,
                 creator: proposal.data[SIMetaData.nick].creator,
@@ -601,8 +598,8 @@ var get = (
                 }, {}),
                 winner: {
                     funding: (proposal.data[SIWinnerInfo.nick] || {}).funding,
-                    description: (args[2] || {}).description,
-                    name: (args[2] || {}).name
+                    description: (args[1] || {}).description,
+                    name: (args[1] || {}).name
                 },
                 introduction: {
                     pitch: subs.pitch.data[SIPitch.nick].pitch,
@@ -839,6 +836,7 @@ export var listItem = (
             path: "@"
         },
         link: (scope, element) => {
+            scope.$on("$destroy", adhTopLevelState.bind("processState", scope));
             get($q, adhHttp, adhTopLevelState, adhGetBadges)(scope.path).then((data) => {
 
                 scope.data = {
@@ -857,7 +855,6 @@ export var listItem = (
                     },
                     introduction: data.introduction,
                     commentCountTotal: data.commentCountTotal,
-                    currentPhase: data.currentPhase,
                     supporterCount: data.supporterCount
                 };
             });

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/AddProposalButton.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/AddProposalButton.html
@@ -1,7 +1,7 @@
 <a
     class="button button-cta m-add"
     data-ng-click="setCameFrom()"
-    data-ng-if="(processOptions.POST || (!processOptions.loggedIn && participate)) && processUrl !== '/'"
+    data-ng-if="processOptions.POST || (!processOptions.loggedIn && processState === 'participate')"
     data-ng-href="{{ processUrl | adhResourceUrl:'create_proposal' }}">
     {{ "TR__PROPOSAL_ADD" | translate }}
 </a>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
@@ -384,6 +384,7 @@ export var addProposalButton = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/AddProposalButton.html",
         link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("processState", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             scope.setCameFrom = () => adhTopLevelState.setCameFrom();
         }


### PR DESCRIPTION
This saves the workflow state of the containing process in `adhTopLevelState`. This is simpler than the old approach. It also fixes the mercator 2016 add proposal button (see #2117).

**Note** that using the state from this process may not be what we want in all cases. It may be better to explicitly request the state of the next ancestor process of the widget resource instead of the one from routing.