### PR TITLE
update pyramid from 1.5 to 1.6; use bpython for bin/pshell

### DIFF
--- a/src/adhocracy_core/adhocracy_core/rest/test_exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_exceptions.py
@@ -116,7 +116,7 @@ class TestHandleErrorX0XException:
 
     def test_forward_http_exception(self, request_):
         from pyramid.httpexceptions import HTTPException
-        error = HTTPException(status_code=204)
+        error = HTTPException(code=204)
         result_error = self.call_fut(error, request_)
         assert error is result_error
 
@@ -136,9 +136,9 @@ class TestHandleError40X_exception:
 
     def test_render_http_client_exception(self, request_):
         from pyramid.httpexceptions import HTTPClientError
-        error = HTTPClientError(status_code=400)
+        error = HTTPClientError(code=400)
         json_error = self.call_fut(error, request_)
-        assert json_error.status_code == 400
+        assert json_error.code == 400
         assert json_error.json_body == \
                {"status": "error",
                 "errors": [{"description": "{0} {1}".format(error.status, error),
@@ -154,7 +154,7 @@ class TestHandleError40X_exception:
     def create_dummy_app(self, config, error=None):
         def dummy_view(request):
             if error:
-                raise error()
+                raise error
             else:
                 return "{}"
         config.add_view(dummy_view, name='dummy_view')
@@ -166,15 +166,19 @@ class TestHandleError40X_exception:
     @mark.usefixtures('integration')
     def test_response_get_40X(self, integration):
         from pyramid.httpexceptions import HTTPClientError
-        app_dummy = self.create_dummy_app(integration, error=HTTPClientError)
+        app_dummy = self.create_dummy_app(
+            integration,
+            error=HTTPClientError(status_code=400, code=400))
         resp = app_dummy.get('/dummy_view', status=400)
-        assert '400' in resp.json['errors'][0]['description']\
+        assert '400' in resp.json['errors'][0]['description']
 
     @mark.usefixtures('integration')
     def test_response_options_40X(self, integration):
         from pyramid.httpexceptions import HTTPClientError
-        app_dummy = self.create_dummy_app(integration, error=HTTPClientError)
-        resp = app_dummy.get('/dummy_view', status=400)
+        app_dummy = self.create_dummy_app(
+            integration,
+            error=HTTPClientError(status_code=400, code=400))
+        resp = app_dummy.options('/dummy_view', status=400)
         assert '400' in resp.json['errors'][0]['description']
 
 
@@ -349,6 +353,6 @@ class TestHandleError400:
         assert inst.json ==\
                {"errors": [{"location":"b","name":"","description":""}],
                 "status": "error"}
-        assert inst.status_code == 400
+        assert inst.code == 400
 
 

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -14,6 +14,7 @@ requires = [
     'pyramid',
     'pyramid_debugtoolbar',
     'pyramid_exclog',
+    'pyramid_bpython',
     'gunicorn',
     'substanced',
     'pyramid_tm',

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -4,7 +4,7 @@ Jinja2 = 2.7.3
 MarkupSafe = 0.23
 PasteDeploy = 1.5.2
 Pygments = 2.0.2
-WebOb = 1.4
+WebOb = 1.5.1
 WebTest = 2.0.18
 astroid = 1.3.4
 bowerrecipe = 0.1.1
@@ -146,7 +146,8 @@ persistent = 4.1.1
 # adhocracy-core==0.0
 # pyramid-mako==1.0.2
 # pytest-pyramid==0.1.1
-pyramid = 1.5.2
+pyramid = 1.6.1
+pyramid_bython = 0.1
 
 # Required by:
 # adhocracy-frontend==0.0
@@ -159,7 +160,7 @@ pyramid-chameleon = 0.3
 
 # Required by:
 # adhocracy-core==0.0
-pyramid-debugtoolbar = 2.3
+pyramid-debugtoolbar = 2.4.2
 
 # Required by:
 # adhocracy-core==0.0
@@ -167,7 +168,7 @@ pyramid-exclog = 0.7
 
 # Required by:
 # substanced==0.0
-pyramid-mailer = 0.14
+pyramid-mailer = 0.14.1
 
 # Required by:
 # adhocracy-frontend==0.0
@@ -175,7 +176,7 @@ pyramid-mako = 1.0.2
 
 # Required by:
 # adhocracy-core==0.0
-pyramid-tm = 0.11
+pyramid-tm = 0.12.1
 
 # Required by:
 # pytest-pyramid==0.1.1


### PR DESCRIPTION
Python Updates:
----------------------

pyramid 1.5.2 -> 1.6:

   - build in cachebust support (we could remove pyramid_cachebust)

   - bython interactive shell support

   - Fix: subsribers and view memthods don't work with python 3 annotations

   - python 3.5 support

other changes not related adhocracy: http://docs.pylonsproject.org/projects/pyramid/en/1.6-branch/whatsnew-1.6.html

WebOjb  1.4 -> 1.5: minor changes

pyramid-tm: 0.11 -> 0.12.1: minor changes

pyramid-mailer 0.14 -> 0.14.1: minor changes

use bython instead of ipython for bin/pshell
--------------------------------------------------------

- might fix problems with bin/pshell autocompletion on productive server