### PR TITLE
activate pretty output for typescript

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -273,7 +273,7 @@ stop-on-error = True
 command =
     . ${source_env:output}
     git ls-files --other ${:jsdir}/Resources_ | xargs rm -f
-    ${buildout:bin-directory}/tsc --module commonjs --sourcemap ${:jsdir}/mkResources.ts
+    ${buildout:bin-directory}/tsc --module commonjs --pretty ${:jsdir}/mkResources.ts
     ${buildout:bin-directory}/node ${:jsdir}/mkResources.js ${meta_api:output} ${:jsdir}
 update-command = ${:command}
 jsdir = ${adhocracy:frontend.static_dir}/js
@@ -282,7 +282,7 @@ jsdir = ${adhocracy:frontend.static_dir}/js
 recipe = plone.recipe.command
 stop-on-error = True
 command =
-    ${buildout:bin-directory}/node ${buildout:bin-directory}/tsc -m umd --sourcemap ${adhocracy:frontend.static_dir}/js/Adhocracy*.ts
+    ${buildout:bin-directory}/node ${buildout:bin-directory}/tsc -m umd --sourcemap --pretty ${adhocracy:frontend.static_dir}/js/Adhocracy*.ts
 update-command = ${javascript:command}
 
 [gruntfile]


### PR DESCRIPTION
TypeScript 1.8 (see #2129) introduced the `--pretty` parameter for nicer command line output. In this pull request I activate this option in the buildout config.

Note that I have removed the `--sourcemap` parameter when building `mkResources.ts`. This file is not intended to run in the browser, so generating sourcemaps is unnecessary.