### PR TITLE
Fix acceptance test: changed sender email

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserPageSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserPageSpec.js
@@ -58,7 +58,7 @@ describe("user page", function() {
                 // console.log('mail', mail);
                 expect(mail.text).toContain(content);
                 expect(mail.subject).toContain(subject);
-                expect(mail.from[0].address).toContain("participant2");
+                expect(mail.from[0].address).toContain("noreply");
                 expect(mail.to[0].address).toContain("participant");
             });
         });


### PR DESCRIPTION
This is a fixup to #2128.