### PR TITLE
add mein.berlin.de context

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/Header.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/Header.html
@@ -1,0 +1,5 @@
+<header data-ng-hide="hideHeader" class="l-header main-header">
+    <div class="l-header-left">
+        <ng-include data-ng-if="customHeader" src="customHeader"></ng-include>
+    </div>
+</header>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/MeinberlinDe.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/MeinberlinDe.ts
@@ -1,0 +1,30 @@
+/// <reference path="../../../../lib2/types/angular.d.ts"/>
+
+import * as AdhConfig from "../../Config/Config";
+import * as AdhTopLevelState from "../../TopLevelState/TopLevelState";
+
+
+var pkgLocation = "/Meinberlin/MeinberlinDe";
+
+
+export var headerDirective = (
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Header.html",
+        scope: {},
+        link: (scope) => {
+            scope.hideHeader = adhConfig.custom["hide_header"];
+            scope.$on("$destroy", adhTopLevelState.bind("customHeader", scope));
+        }
+    };
+};
+
+export var areaTemplate = (
+    adhConfig: AdhConfig.IService,
+    $templateRequest: angular.ITemplateRequestService
+) => {
+    return $templateRequest(adhConfig.pkg_path + pkgLocation + "/template.html");
+};

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/Module.ts
@@ -1,0 +1,49 @@
+import * as AdhEmbedModule from "../../Embed/Module";
+import * as AdhResourceAreaModule from "../../ResourceArea/Module";
+import * as AdhTopLevelStateModule from "../../TopLevelState/Module";
+
+import * as AdhMeinberlinAlexanderplatzWorkbenchModule from "../Alexanderplatz/Workbench/Module";
+import * as AdhMeinberlinBuergerhaushaltWorkbenchModule from "../Buergerhaushalt/Workbench/Module";
+import * as AdhMeinberlinKiezkasseWorkbenchModule from "../Kiezkasse/Workbench/Module";
+
+import * as AdhEmbed from "../../Embed/Embed";
+import * as AdhResourceArea from "../../ResourceArea/ResourceArea";
+
+import * as AdhMeinberlinAlexanderplatzWorkbench from "../Alexanderplatz/Workbench/Workbench";
+import * as AdhMeinberlinBuergerhaushaltWorkbench from "../Buergerhaushalt/Workbench/Workbench";
+import * as AdhMeinberlinKiezkasseWorkbench from "../Kiezkasse/Workbench/Workbench";
+
+import RIAlexanderplatzProcess from "../../../Resources_/adhocracy_meinberlin/resources/alexanderplatz/IProcess";
+import RIBuergerhaushaltProcess from "../../../Resources_/adhocracy_meinberlin/resources/burgerhaushalt/IProcess";
+import RIKiezkasseProcess from "../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProcess";
+
+import * as AdhMeinberlinDe from "./MeinberlinDe";
+
+
+export var moduleName = "adhMeinberlinAlexanderplatzContext";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhEmbedModule.moduleName,
+            AdhMeinberlinAlexanderplatzWorkbenchModule.moduleName,
+            AdhMeinberlinBuergerhaushaltWorkbenchModule.moduleName,
+            AdhMeinberlinKiezkasseWorkbenchModule.moduleName,
+            AdhResourceAreaModule.moduleName,
+            AdhTopLevelStateModule.moduleName
+        ])
+        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+            adhEmbedProvider.registerContext("mein.berlin.de");
+        }])
+        .config(["adhResourceAreaProvider", (adhResourceAreaProvider: AdhResourceArea.Provider) => {
+            adhResourceAreaProvider
+                .template("mein.berlin.de", ["adhConfig", "$templateRequest", AdhMeinberlinDe.areaTemplate]);
+            AdhMeinberlinAlexanderplatzWorkbench.registerRoutes(
+                RIAlexanderplatzProcess.content_type, "mein.berlin.de")(adhResourceAreaProvider);
+            AdhMeinberlinBuergerhaushaltWorkbench.registerRoutes(
+                RIBuergerhaushaltProcess.content_type, "mein.berlin.de")(adhResourceAreaProvider);
+            AdhMeinberlinKiezkasseWorkbench.registerRoutes(
+                RIKiezkasseProcess.content_type, "mein.berlin.de")(adhResourceAreaProvider);
+        }])
+        .directive("adhMeinberlinDeHeader", ["adhConfig", "adhTopLevelState", AdhMeinberlinDe.headerDirective]);
+};

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/template.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/template.html
@@ -1,0 +1,23 @@
+<div class="l-rows-wrapper">
+    <div class="l-rows">
+        <div class="l-row">
+            <div class="l-cell">
+                <div class="l-cell-inner">
+                    <adh-meinberlin-de-header></adh-meinberlin-de-header>
+                </div>
+            </div>
+        </div>
+        <div class="l-row">
+            <div class="l-cell">
+                <div class="l-cell-inner">
+                    <adh-space data-key="content">
+                        <adh-process-view></adh-process-view>
+                    </adh-space>
+                    <adh-space data-key="error">
+                        <adh-routing-error></adh-routing-error>
+                    </adh-space>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Module.ts
@@ -4,6 +4,7 @@ import * as AdhMeinberlinAlexanderplatzModule from "./Alexanderplatz/Module";
 import * as AdhMeinberlinBuergerhaushaltModule from "./Buergerhaushalt/Module";
 import * as AdhMeinberlinPhaseModule from "./Phase/Module";
 import * as AdhMeinberlinStadtforumModule from "./Stadtforum/Module";
+import * as AdhMeinberlinDe from "./MeinberlinDe/Module";
 
 
 export var moduleName = "adhMeinberlin";
@@ -15,6 +16,7 @@ export var register = (angular) => {
     AdhMeinberlinBuergerhaushaltModule.register(angular);
     AdhMeinberlinPhaseModule.register(angular);
     AdhMeinberlinStadtforumModule.register(angular);
+    AdhMeinberlinDe.register(angular);
 
     angular
         .module(moduleName, [
@@ -22,6 +24,7 @@ export var register = (angular) => {
             AdhMeinberlinBplanModule.moduleName,
             AdhMeinberlinKiezkasseModule.moduleName,
             AdhMeinberlinBuergerhaushaltModule.moduleName,
-            AdhMeinberlinStadtforumModule.moduleName
+            AdhMeinberlinStadtforumModule.moduleName,
+            AdhMeinberlinDe.moduleName
         ]);
 };


### PR DESCRIPTION
this adds a context that is different from the default context in two aspects:

-   there are no user routes
-   the header consists only of the `customHeader` which renders the 'add proposal' button.

It is meant to be used on mein.berlin.de, where all other elements of the header (logo, help link, user indicator) are available in the embedding page.