### PR TITLE
Optimised embed for authentication only

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/__init__.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/__init__.py
@@ -1,5 +1,7 @@
 """Frontend view and simple pyramid app configurations."""
 import pkg_resources
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
 
 from pyramid.renderers import render
 from pyramid.config import Configurator
@@ -11,6 +13,12 @@ from pyramid.settings import asbool
 from pyramid.settings import aslist
 
 from adhocracy_core.rest.subscriber import add_cors_headers
+
+
+def url_origin(url):
+    """Return the origin part of an url (schema, host, port)."""
+    o = urlparse(url)
+    return urlunparse((o.scheme, o.netloc, '', '', '', ''))
 
 
 def config_view(request):

--- a/src/adhocracy_frontend/adhocracy_frontend/__init__.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/__init__.py
@@ -109,6 +109,17 @@ def require_config_view(request):
     return response
 
 
+def adhocracy_auth_view(request):
+    """Return embeddable code optimized for authentication."""
+    config = config_view(request)
+    result = render(
+        'adhocracy_frontend:build/js/AdhocracyAuth.html.mako', {
+            'canonical_origin': url_origin(config['canonical_url']),
+        }, request=request)
+    response = Response(result)
+    return response
+
+
 def root_view(request):
     """Return the embeddee HTML."""
     if not hasattr(request, 'cachebusted_url'):  # ease testing
@@ -181,6 +192,8 @@ def includeme(config):
     # AdhocracySDK shall not be cached the way other static files are cached
     config.add_route('adhocracy_sdk', 'AdhocracySDK.js')
     config.add_view(adhocracy_sdk_view, route_name='adhocracy_sdk')
+    config.add_route('adhocracy_auth', 'AdhocracyAuth.html')
+    config.add_view(adhocracy_auth_view, route_name='adhocracy_auth')
     config.add_static_view('static', 'adhocracy_frontend:build/',
                            cache_max_age=cache_max_age)
     config.add_subscriber(add_cors_headers, NewResponse)

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
@@ -1,0 +1,18 @@
+<script>
+var canonicalOrigin = "${canonical_origin}";
+
+var postMessage = function(data) {
+    window.parent.postMessage(JSON.stringify(data), canonicalOrigin);
+};
+
+var onMessage = function(name, cb) {
+    window.addEventListener("message", function(event) {
+        if (event.origin === canonicalOrigin) {
+            var message = JSON.parse(event.data);
+            if (message.name === name) {
+                cb(message);
+            }
+        }
+    });
+}
+</script>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
@@ -1,6 +1,19 @@
 <script>
 var canonicalOrigin = "${canonical_origin}";
 
+var http = function(url, cb) {
+    var req = new XMLHttpRequest();
+
+    req.onreadystatechange = function(e) {
+        if (req.readyState === 4 && req.status < 400) {
+            cb(e.target.response);
+        }
+    }
+
+    req.open('GET', url, true)
+    req.send(null);
+};
+
 var postMessage = function(data) {
     window.parent.postMessage(JSON.stringify(data), canonicalOrigin);
 };
@@ -15,4 +28,26 @@ var onMessage = function(name, cb) {
         }
     });
 }
+
+var sendLoginState = function() {
+    var sessionValue = localStorage.getItem("user-session");
+    if (sessionValue) {
+        var session = JSON.parse(sessionValue);
+        var path = session["user-path"];
+
+        http(path, function(response) {
+            var data = JSON.parse(response);
+            var userName = data.data["adhocracy_core.sheets.principal.IUserBasic"].name;
+
+            postMessage({
+                name: "userName",
+                data: userName
+            });
+        });
+    } else {
+        postMessage({name: "logout"});
+    }
+};
+
+sendLoginState();
 </script>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
@@ -49,5 +49,6 @@ var sendLoginState = function() {
     }
 };
 
+window.addEventListener("storage", sendLoginState);
 sendLoginState();
 </script>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
@@ -51,4 +51,8 @@ var sendLoginState = function() {
 
 window.addEventListener("storage", sendLoginState);
 sendLoginState();
+
+onMessage("logout", function() {
+    localStorage.removeItem("user-session");
+});
 </script>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/AdhocracyAuth.html.mako
@@ -1,58 +1,63 @@
 <script>
-var canonicalOrigin = "${canonical_origin}";
+(function() {
+    "use strict"
 
-var http = function(url, cb) {
-    var req = new XMLHttpRequest();
+    var canonicalOrigin = "${canonical_origin}";
 
-    req.onreadystatechange = function(e) {
-        if (req.readyState === 4 && req.status < 400) {
-            cb(e.target.response);
-        }
-    }
+    var http = function(url, cb) {
+        var req = new XMLHttpRequest();
 
-    req.open('GET', url, true)
-    req.send(null);
-};
-
-var postMessage = function(data) {
-    window.parent.postMessage(JSON.stringify(data), canonicalOrigin);
-};
-
-var onMessage = function(name, cb) {
-    window.addEventListener("message", function(event) {
-        if (event.origin === canonicalOrigin) {
-            var message = JSON.parse(event.data);
-            if (message.name === name) {
-                cb(message);
+        req.onreadystatechange = function(e) {
+            if (req.readyState === 4 && req.status < 400) {
+                cb(e.target.response);
             }
         }
-    });
-}
 
-var sendLoginState = function() {
-    var sessionValue = localStorage.getItem("user-session");
-    if (sessionValue) {
-        var session = JSON.parse(sessionValue);
-        var path = session["user-path"];
+        req.open('GET', url, true)
+        req.send(null);
+    };
 
-        http(path, function(response) {
-            var data = JSON.parse(response);
-            var userName = data.data["adhocracy_core.sheets.principal.IUserBasic"].name;
+    var postMessage = function(data) {
+        console.log(data);
+        window.parent.postMessage(JSON.stringify(data), canonicalOrigin);
+    };
 
-            postMessage({
-                name: "userName",
-                data: userName
-            });
+    var onMessage = function(name, cb) {
+        window.addEventListener("message", function(event) {
+            if (event.origin === canonicalOrigin) {
+                var message = JSON.parse(event.data);
+                if (message.name === name) {
+                    cb(message);
+                }
+            }
         });
-    } else {
-        postMessage({name: "logout"});
     }
-};
 
-window.addEventListener("storage", sendLoginState);
-sendLoginState();
+    var sendLoginState = function() {
+        var sessionValue = localStorage.getItem("user-session");
+        if (sessionValue) {
+            var session = JSON.parse(sessionValue);
+            var path = session["user-path"];
 
-onMessage("logout", function() {
-    localStorage.removeItem("user-session");
-});
+            http(path, function(response) {
+                var data = JSON.parse(response);
+                var userName = data.data["adhocracy_core.sheets.principal.IUserBasic"].name;
+
+                postMessage({
+                    name: "userName",
+                    data: userName
+                });
+            });
+        } else {
+            postMessage({name: "logout"});
+        }
+    };
+
+    window.addEventListener("storage", sendLoginState);
+    sendLoginState();
+
+    onMessage("logout", function() {
+        localStorage.removeItem("user-session");
+    });
+})();
 </script>

--- a/src/adhocracy_frontend/adhocracy_frontend/test_init_.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/test_init_.py
@@ -5,6 +5,20 @@ from pytest import fixture
 from pytest import mark
 
 
+class UrlOriginTest(unittest.TestCase):
+    def test_full_url(self):
+        from adhocracy_frontend import url_origin
+        url = 'https://example.com:123/some/path?query#hash'
+        expected = 'https://example.com:123'
+        assert url_origin(url) == expected
+
+    def test_no_port(self):
+        from adhocracy_frontend import url_origin
+        url = 'https://example.com/some/path?query#hash'
+        expected = 'https://example.com'
+        assert url_origin(url) == expected
+
+
 class ConfigViewTest(unittest.TestCase):
 
     def call_fut(self, request):


### PR DESCRIPTION
Sometimes we want to display a user indicator on the embedding page. Embedding a complete adhocracy seems like overkill. So I created a custom HTML snippet that is optimised for exactly this usecase.

We need to have access to two distinct data sources:

-  the session token stored in `localStorage`
-  the backend API (access is limited by cross origin policy)

In order to access these two we need an iframe that is running in the adhocracy origin. We can then communicate with this iframe using the `postMessage` API. The code I wrote is similar to the `adhCrossWindowMessaging` service and offers the following messages:

-  on load, it will automatically send the user name (e.g. `{name: "userName", data: "god"}`)
-  when a user logs in, it will also send the user name
-  when a user logs out, it will send the message `{name: "logout"}`
-  when it receives the message `{name: "logout"}` it will log out.

For security reasons, the snippet will refuse to communicate with any website outside of the origin of `canonical_url`.