### PR TITLE
Improve check-and-compile buildout steps

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -22,7 +22,7 @@ parts +=
 
 [tslint_json]
 recipe = collective.recipe.template
-input = inline:
+inline =
     {
       "ban": [],
       "rules": {
@@ -140,7 +140,7 @@ scripts = node npm
 
 [npm_config]
 recipe = collective.recipe.template
-input = inline:
+inline =
     {
         "name": "adhocracy-frontend",
         "version": "0.0.1",
@@ -308,7 +308,7 @@ update-command = ${javascript:command}
 
 [gruntfile]
 recipe = collective.recipe.template
-input = inline:
+inline =
     module.exports = function(grunt) {
         grunt.initConfig({
             ngtemplates: {
@@ -425,7 +425,7 @@ stop-on-error = yes
 
 [hologram]
 recipe = collective.recipe.template
-input = inline:
+inline =
     # Hologram will run from same directory where this config file resides
     # All paths should be relative to there
     # The directory containing the source files to parse recursively

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -172,6 +172,7 @@ mode = 700
 recipe = plone.recipe.command
 command = ${buildout:bin-directory}/npm install
 update-command = ${:command}
+stop-on-error = yes
 
 [npm_bins]
 # npm doesn't seem to allow to specify the bin directory, so we link stuff manually.
@@ -180,12 +181,14 @@ command =
     cd ${buildout:bin-directory}
     ln -sf ${buildout:directory}/node_modules/.bin/* .
 update-command = ${:command}
+stop-on-error = yes
 
 [protractor]
 recipe = plone.recipe.command
 command =
     ${buildout:bin-directory}/webdriver-manager update
 update-command = ${:command}
+stop-on-error = yes
 
 [bower]
 recipe = bowerrecipe
@@ -226,6 +229,7 @@ downloads = .
 recipe = plone.recipe.command
 command = cd ${adhocracy:frontend.static_dir}/js/ && ./AdhocracySpec.sh > AdhocracySpec.ts
 update-command = ${:command}
+stop-on-error = yes
 
 [merge_static_directories]
 recipe = collective.recipe.template
@@ -271,6 +275,7 @@ recipe = plone.recipe.command
 command =
     ${merge_static_directories:output}
 update-command = ${do_merge_static_directories:command}
+stop-on-error = yes
 
 [meta_api]
 # We save meta_api as a static file in order to use it in the resources part
@@ -280,6 +285,7 @@ command =
     ${buildout:bin-directory}/prequest ${noserver.ini:output} /meta_api > ${:output}
 update-command = ${:command}
 output = ${adhocracy:frontend.static_dir}/meta_api.json
+stop-on-error = yes
 
 [resources]
 recipe = plone.recipe.command
@@ -291,6 +297,7 @@ command =
     ${buildout:bin-directory}/node ${:jsdir}/mkResources.js ${meta_api:output} ${:jsdir}
 update-command = ${:command}
 jsdir = ${adhocracy:frontend.static_dir}/js
+stop-on-error = yes
 
 [javascript]
 recipe = plone.recipe.command
@@ -390,6 +397,7 @@ command =
     . ${source_env:output}
     ${buildout:bin-directory}/grunt
 update-command = ${grunt:command}
+stop-on-error = yes
 
 [rubygems]
 recipe = rubygemsrecipe
@@ -405,6 +413,7 @@ recipe = plone.recipe.command
 command =
     ln -sfn ${buildout:directory}/src/${adhocracy:frontend_package_name} ${buildout:directory}/src/current
     ln -sfn ${buildout:directory}/src/${adhocracy:frontend_package_name}/${adhocracy:frontend_package_name} ${buildout:directory}/src/current/current
+stop-on-error = yes
 
 [stylesheets]
 recipe = plone.recipe.command
@@ -412,6 +421,7 @@ command =
     ${buildout:bin-directory}/compass compile --force -c ${buildout:directory}/etc/compass.rb
     ${buildout:bin-directory}/compass compile --force -c ${buildout:directory}/etc/compass.min.rb
 update-command = ${stylesheets:command}
+stop-on-error = yes
 
 [hologram]
 recipe = collective.recipe.template
@@ -442,3 +452,4 @@ recipe = plone.recipe.command
 command =
     ${buildout:bin-directory}/hologram ${hologram:output}
 update-command = ${styleguide:command}
+stop-on-error = yes

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -234,19 +234,35 @@ recipe = collective.recipe.template
 # core packages.
 static_directories =
     ${adhocracy:frontend.core.static_dir}
-input = inline:
-    #!/bin/bash
-    if type brew > /dev/null 2>&1; then
-        # REFACT consider to replace coreutil-isms with posix calls
-        (brew list | grep --quiet coreutils) || echo "!!! Mac needs to manually installed gnu coreutils via $ brew install coreutils"
-        PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
-    fi
+inline =
+    #!/usr/bin/env python
+    import os
+    import os.path
 
-    mkdir -p ${adhocracy:frontend.static_dir}
-    find ${adhocracy:frontend.static_dir} -type l -exec rm {} +
-    for dir in ${:static_directories} ; do
-        cp -ans `readlink -f $dir`/. ${adhocracy:frontend.static_dir}
-    done
+    target_dir = "${adhocracy:frontend.static_dir}"
+    source_dirs = "${:static_directories}".split()
+
+    for source_dir in source_dirs:
+        for source_root, dirnames, filenames in os.walk(source_dir):
+           target_root = os.path.join(target_dir, os.path.relpath(source_root, source_dir))
+
+           if not os.path.exists(target_root):
+               os.makedirs(target_root)
+           elif not os.path.isdir(target_root):
+               raise Exception("unexpcted file {}".format(target_root))
+
+           for filename in filenames:
+               link_name = os.path.join(target_root, filename)
+               link_source = os.path.relpath(os.path.join(source_root, filename), target_root)
+
+               if os.path.islink(link_name):
+                  if  os.readlink(link_name) != link_source:
+                      os.unlink(link_name)
+                      os.symlink(link_source, link_name)
+               elif not os.path.exists(link_name):
+                  os.symlink(link_source, link_name)
+               else:
+                  raise Exception("unexpected file {}".format(link_name))
 output = ${buildout:bin-directory}/merge_static_directories
 mode = 700
 


### PR DESCRIPTION
- ensure templates do proper indenting
- rewrite `merge_static_directories` in python to not use `cp -s` option
- enable checking of script results