### PR TITLE
Use on zeo database per project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ __pycache__
 /src/*/current
 etc/scss-lint.yml
 etc/tslint.json
+/etc/zeo.conf
 /etc/development.ini
 /etc/frontend_development.ini
 /etc/test.ini

--- a/etc/zeo.conf.in
+++ b/etc/zeo.conf.in
@@ -11,11 +11,11 @@
 
 <blobstorage main>
   <filestorage>
-    path $INSTANCE/var/Data.fs
+    path $INSTANCE/var/db/${adhocracy:backend_package_name}/Data.fs
     # keep old objects when running bin/zeopack
     pack-keep-old false
     # do garbage collection when running bin/zeopack (slow)
     pack-gc true
   </filestorage>
-  blob-dir $INSTANCE/var/blobs
+  blob-dir $INSTANCE/var/db/${adhocracy:backend_package_name}/blobs
 </blobstorage>

--- a/src/adhocracy_core/base.cfg
+++ b/src/adhocracy_core/base.cfg
@@ -9,6 +9,7 @@ parts +=
      dirs
      adhocracy
      development.ini
+     zeodirs
      zeo.conf
      test.ini
      test_with_ws.ini
@@ -29,12 +30,16 @@ recipe = z3c.recipe.mkdir
 paths = etc
         var
         var/log
-        var/db/${adhocracy:backend_package_name}/blobs
         var/uploads_tmp
         var/mail
         var/mail/cur
         var/mail/new
         var/mail/tmp
+
+[zeodirs]
+recipe = z3c.recipe.mkdir
+paths = var/db/${adhocracy:backend_package_name}/blobs
+mode = 700
 
 [adhocracy]
 recipe = zc.recipe.egg

--- a/src/adhocracy_core/base.cfg
+++ b/src/adhocracy_core/base.cfg
@@ -107,7 +107,7 @@ recipe = collective.recipe.genshi
 domain = adhocracy
 search_path = ./src/adhocracy_core/adhocracy_core
 locales_path = ./src/adhocracy_core/adhocracy_core/locale
-input = inline:
+inline =
     #!/bin/bash
     #configuration
     DOMAIN="${:domain}"

--- a/src/adhocracy_core/base.cfg
+++ b/src/adhocracy_core/base.cfg
@@ -9,6 +9,7 @@ parts +=
      dirs
      adhocracy
      development.ini
+     zeo.conf
      test.ini
      test_with_ws.ini
      noserver.ini
@@ -28,7 +29,7 @@ recipe = z3c.recipe.mkdir
 paths = etc
         var
         var/log
-        var/blobs
+        var/db/${adhocracy:backend_package_name}/blobs
         var/uploads_tmp
         var/mail
         var/mail/cur
@@ -45,6 +46,11 @@ ackend_package_name = adhocracy_sample
 recipe = collective.recipe.template
 input = ${buildout:directory}/etc/development.ini.in
 output = ${buildout:directory}/etc/development.ini
+
+[zeo.conf]
+recipe = collective.recipe.template
+input = ${buildout:directory}/etc/zeo.conf.in
+output = ${buildout:directory}/etc/zeo.conf
 
 [test.ini]
 recipe = collective.recipe.template


### PR DESCRIPTION
- removes the need to delete/moves databases after running buildout with a different config
- fixes permissions of blob dir