### PR TITLE
refactor: use only colander schema for data validation, SRP

### DIFF
--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -1,5 +1,5 @@
 """Interfaces for plugable dependencies, basic metadata structures."""
-from collections import Iterable
+from collections import Iterable, namedtuple
 from enum import Enum
 import collections
 
@@ -884,3 +884,6 @@ class IAdhocracyWorkflow(IWorkflow):  # pragma: no cover
 
     def get_next_states(context, request: IRequest) -> [str]:
         """Get states you can trigger a transition to."""
+
+
+error_entry = namedtuple('ErrorEntry', ['location', 'name', 'description'])

--- a/src/adhocracy_core/adhocracy_core/rest/batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/batchview.py
@@ -56,7 +56,7 @@ class BatchItemResponse:
 class BatchView(RESTView):
     """Process batch requests."""
 
-    validation_POST = (POSTBatchRequestSchema, [])
+    schema_POST = POSTBatchRequestSchema
 
     @view_config(name='batch',
                  request_method='POST',

--- a/src/adhocracy_core/adhocracy_core/rest/exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/exceptions.py
@@ -20,7 +20,6 @@ from adhocracy_core.utils import log_compatible_datetime
 from adhocracy_core.utils import named_object
 from adhocracy_core.sheets.metadata import view_blocked_by_metadata
 from adhocracy_core.sheets.principal import IPasswordAuthentication
-from adhocracy_core.rest.schemas import BlockExplanationResponseSchema
 
 
 logger = logging.getLogger(__name__)
@@ -233,6 +232,7 @@ def handle_error_400_url_decode_error(error, request):
              )
 def handle_error_410_exception(error, request):
     """Add json body with explanation to 410 errors."""
+    from adhocracy_core.rest.schemas import BlockExplanationResponseSchema
     context = request.context
     registry = request.registry
     reason = error.detail or ''

--- a/src/adhocracy_core/adhocracy_core/rest/exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/exceptions.py
@@ -17,7 +17,6 @@ from pyramid.request import Request
 from adhocracy_core.exceptions import AutoUpdateNoForkAllowedError
 from adhocracy_core.utils import exception_to_str
 from adhocracy_core.utils import log_compatible_datetime
-from adhocracy_core.utils import named_object
 from adhocracy_core.sheets.metadata import view_blocked_by_metadata
 from adhocracy_core.sheets.principal import IPasswordAuthentication
 
@@ -206,7 +205,7 @@ def handle_error_400_auto_update_no_fork_allowed(error, request):
     description = '- The auto update tried to create a fork for: {0} caused'\
                   ' by isheet: {1} field: {2} with old_reference: {3} and new'\
                   ' reference: {4}. Try another root_version.'.format(*args)
-    dummy_node = named_object('root_versions')
+    dummy_node = colander.SchemaNode(colander.List(), name='root_versions')
     error_colander = colander.Invalid(dummy_node, msg + description)
     return handle_error_400_colander_invalid(error_colander, request)
 

--- a/src/adhocracy_core/adhocracy_core/rest/exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/exceptions.py
@@ -1,30 +1,26 @@
 """HTTP Exception (500, 310, 404,..) processing."""
 import json
 import logging
-import colander
-from collections import namedtuple
 
+import colander
 from pyramid.exceptions import URLDecodeError
-from pyramid.security import NO_PERMISSION_REQUIRED
-from pyramid.view import view_config
-from pyramid.traversal import resource_path
-from pyramid.httpexceptions import HTTPGone
 from pyramid.httpexceptions import HTTPBadRequest
-from pyramid.httpexceptions import HTTPException
 from pyramid.httpexceptions import HTTPClientError
+from pyramid.httpexceptions import HTTPException
+from pyramid.httpexceptions import HTTPGone
 from pyramid.request import Request
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.traversal import resource_path
+from pyramid.view import view_config
 
 from adhocracy_core.exceptions import AutoUpdateNoForkAllowedError
-from adhocracy_core.utils import exception_to_str
-from adhocracy_core.utils import log_compatible_datetime
+from adhocracy_core.interfaces import error_entry
 from adhocracy_core.sheets.metadata import view_blocked_by_metadata
 from adhocracy_core.sheets.principal import IPasswordAuthentication
-
+from adhocracy_core.utils import exception_to_str
+from adhocracy_core.utils import log_compatible_datetime
 
 logger = logging.getLogger(__name__)
-
-
-error_entry = namedtuple('ErrorEntry', ['location', 'name', 'description'])
 
 
 class JSONHTTPClientError(HTTPClientError):

--- a/src/adhocracy_core/adhocracy_core/rest/schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/schemas.py
@@ -57,7 +57,6 @@ from adhocracy_core.sheets.principal import IUserExtended
 from adhocracy_core.catalog import ICatalogsService
 from adhocracy_core.catalog.index import ReferenceIndex
 from adhocracy_core.utils import now
-from adhocracy_core.utils import raise_colander_style_error
 from adhocracy_core.utils import unflatten_multipart_request
 
 resolver = DottedNameResolver()
@@ -562,11 +561,13 @@ def _is_reference_filter(name: str, registry: Registry) -> bool:
     try:
         isheet, field, node = resolve(name)
     except ValueError:
-        raise_colander_style_error(None, name, 'No such sheet or field')
+        dummy_node = colander.SchemaNode(colander.String(), name=name)
+        raise colander.Invalid(dummy_node, 'No such sheet or field')
     if isinstance(node, (Reference, References)):
         return True
     else:
-        raise_colander_style_error(None, name, 'Not a reference node')
+        dummy_node = colander.SchemaNode(colander.String(), name=name)
+        raise colander.Invalid(dummy_node, 'Not a reference node')
 
 
 def _is_arbitrary_filter(name: str, catalogs: ICatalogsService) -> bool:

--- a/src/adhocracy_core/adhocracy_core/rest/schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/schemas.py
@@ -403,9 +403,8 @@ def create_validate_login_password(request: Request,
         if user is None:
             return
         sheet = registry.content.get_sheet(user, IPasswordAuthentication)
-        try:
-            sheet.check_plaintext_password(password)
-        except ValueError:
+        valid = sheet.check_plaintext_password(password)
+        if not valid:
             error = Invalid(node)
             error.add(Invalid(node['password'], msg=error_msg_wrong_login))
             raise error

--- a/src/adhocracy_core/adhocracy_core/rest/schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/schemas.py
@@ -413,7 +413,7 @@ def create_validate_login_password(request: Request,
 
 
 def create_validate_account_active(request: Request,
-                                   child_node_name: str):
+                                   child_node_name: str) -> callable:
     """Return validator to check the user account is already active.
 
     :param `child_node_name`: The name of the child node to raise error.

--- a/src/adhocracy_core/adhocracy_core/rest/test_exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_exceptions.py
@@ -29,7 +29,7 @@ class TestJSONHTTPException:
         assert inst.status == '402 Bad Bad'
 
     def test_add_error_entries_to_json_body(self):
-        from .exceptions import error_entry
+        from adhocracy_core.interfaces import error_entry
         error_entries = [error_entry('header', 'a', 'b')]
         inst = self.make_one(error_entries)
         assert inst.json_body['errors'] == [{'location': 'header',
@@ -346,7 +346,7 @@ class TestHandleError400:
         return handle_error_400_bad_request(error, request)
 
     def test_return_json_error_with_error_listing(self, error, request_):
-        from .exceptions import error_entry
+        from adhocracy_core.interfaces import error_entry
         request_.errors = [error_entry('b', '', '')]
         inst = self.call_fut(error, request_)
         assert inst.content_type == 'application/json'

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1462,9 +1462,10 @@ class TestPasswordResetView:
         assert inst.options() == {'POST': {}}
 
 
-@fixture()
+@fixture
 def integration(config):
     config.include('adhocracy_core.rest.views')
+    return config
 
 
 @mark.usefixtures('integration')

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1174,102 +1174,6 @@ class TestMetaApiView:
                                              'states': {},
                                              'transitions': {}}}
 
-
-class TestValidateLoginEmail:
-
-    @fixture
-    def request_(self, request_):
-        request_.validated['email'] = 'user@example.org'
-        return request_
-
-    def call_fut(self, context, request_):
-        from adhocracy_core.rest.views import validate_login_email
-        return validate_login_email(context, request_)
-
-    def test_valid(self, request_, context, mock_user_locator):
-        user = testing.DummyResource()
-        mock_user_locator.get_user_by_email.return_value = user
-        self.call_fut(context, request_)
-        assert request_.validated['user'] == user
-
-    def test_valid_email_with_capital_letters(self, request_, context, mock_user_locator):
-        request_.validated['email'] = 'usER@example.org'
-        user = testing.DummyResource()
-        mock_user_locator.get_user_by_email.return_value = user
-        self.call_fut(context, request_)
-        mock_user_locator.get_user_by_email.assert_called_with('user@example.org')
-        assert request_.validated['user'] == user
-
-    def test_invalid(self, request_, context, mock_user_locator):
-        mock_user_locator.get_user_by_email.return_value = None
-        self.call_fut(context, request_)
-        assert 'user' not in request_.validated
-        assert 'User doesn\'t exist' in request_.errors[0].description
-
-
-class TestValidateLoginNameUnitTest:
-
-    @fixture
-    def request_(self, request_):
-        request_.validated['name'] = 'user'
-        return request_
-
-    def call_fut(self, context, request_):
-        from adhocracy_core.rest.views import validate_login_name
-        return validate_login_name(context, request_)
-
-    def test_invalid(self, request_, context, mock_user_locator):
-        mock_user_locator.get_user_by_login.return_value = None
-        self.call_fut(context, request_)
-        assert 'User doesn\'t exist' in request_.errors[0].description
-
-    def test_valid(self, request_, context, mock_user_locator):
-        user = testing.DummyResource()
-        mock_user_locator.get_user_by_login.return_value = user
-        self.call_fut(context, request_)
-        assert request_.validated['user'] == user
-
-
-class TestValidateLoginPasswordUnitTest:
-
-    @fixture
-    def request_(self, request_):
-        from adhocracy_core.sheets.principal import IPasswordAuthentication
-        user = testing.DummyResource(__provides__=IPasswordAuthentication)
-        request_.validated['user'] = user
-        request_.validated['password'] = 'lalala'
-        return request_
-
-    def call_fut(self, context, request_):
-        from adhocracy_core.rest.views import validate_login_password
-        return validate_login_password(context, request_)
-
-    def test_valid(self, request_, context, mock_password_sheet):
-        sheet = mock_password_sheet
-        sheet.check_plaintext_password.return_value = True
-        self.call_fut(context, request_)
-        assert request_.errors == []
-
-    def test_invalid(self, request_, context, mock_password_sheet):
-        sheet = mock_password_sheet
-        sheet.check_plaintext_password.return_value = False
-        self.call_fut(context, request_)
-        assert 'password is wrong' in request_.errors[0].description
-
-    def test_invalid_with_ValueError(self, request_, context, mock_password_sheet):
-        sheet = mock_password_sheet
-        sheet.check_plaintext_password.side_effect = ValueError
-        self.call_fut(context, request_)
-        assert 'password is wrong' in request_.errors[0].description
-
-    def test_user_is_None(self, request_, context):
-        request_.validated['user'] = None
-        self.call_fut(context, request_)
-        assert request_.errors == []
-
-
-
-
 class TestLoginUserName:
 
     @fixture
@@ -1325,7 +1229,6 @@ class TestLoginEmailView:
     def test_options(self, request, context):
         inst = self.make_one(context, request)
         assert inst.options() == {}
-
 
 
 class TestActivateAccountView:

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -284,42 +284,6 @@ class TestValidateRequest:
         assert request_.validated == {}
 
 
-class TestValidatePOSTRootVersions:
-
-    def make_one(self, context, request_):
-        from adhocracy_core.rest.views import validate_post_root_versions
-        validate_post_root_versions(context, request_)
-
-    def test_valid_no_value(self, request_, context):
-        self.make_one(context, request_)
-        assert request_.errors == []
-
-    def test_valid_empty_value(self, request_, context):
-        self.make_one(context, request_)
-        request_.validated = {'root_versions': []}
-        assert request_.errors == []
-
-    def test_valid_with_value(self, request_, context):
-        from adhocracy_core.interfaces import IItemVersion
-        from adhocracy_core.interfaces import ISheet
-        root = testing.DummyResource(__provides__=(IItemVersion, ISheet))
-        request_.validated = {'root_versions': [root]}
-
-        self.make_one(context, request_)
-
-        assert request_.errors == []
-        assert request_.validated == {'root_versions': [root]}
-
-    def test_non_valid_value_has_wrong_iface(self, request_, context):
-        from adhocracy_core.interfaces import ISheet
-        root = testing.DummyResource(__provides__=(IResourceX, ISheet))
-        request_.validated = {'root_versions': [root]}
-
-        self.make_one(context, request_)
-
-        assert request_.errors != []
-        assert request_.validated == {'root_versions': []}
-
 
 class TestRespondIfBlocked:
 
@@ -736,13 +700,12 @@ class TestItemRESTView:
         return ItemRESTView(context, request_)
 
     def test_create(self, request_, context):
-        from adhocracy_core.rest.views import validate_post_root_versions
         from adhocracy_core.rest.views import SimpleRESTView
         from adhocracy_core.rest.schemas import POSTItemRequestSchema
         inst = self.make_one(context, request_)
         assert issubclass(inst.__class__, SimpleRESTView)
         assert inst.validation_POST == (POSTItemRequestSchema,
-                                        [validate_post_root_versions])
+                                        [])
         assert 'options' in dir(inst)
         assert 'get' in dir(inst)
         assert 'put' in dir(inst)

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -1016,9 +1016,7 @@ class LoginUsernameView(RESTView):
     """Log in a user via their name."""
 
     validation_POST = (POSTLoginUsernameRequestSchema,
-                       [validate_login_name,
-                        validate_login_password,
-                        validate_account_active])
+                       [])
 
     @view_config(request_method='OPTIONS')
     def options(self) -> dict:
@@ -1053,9 +1051,7 @@ class LoginEmailView(RESTView):
     """Log in a user via their email address."""
 
     validation_POST = (POSTLoginEmailRequestSchema,
-                       [validate_login_email,
-                        validate_login_password,
-                        validate_account_active])
+                       [])
 
     @view_config(request_method='OPTIONS')
     def options(self) -> dict:

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -98,22 +98,6 @@ def respond_if_blocked(context, request):
         raise HTTPGone(detail=block_reason)
 
 
-def validate_post_root_versions(context, request: Request):
-    """Check and transform the 'root_version' paths to resources."""
-    # TODO: make this a colander validator and move to schema.py
-    root_versions = request.validated.get('root_versions', [])
-    valid_root_versions = []
-    for root in root_versions:
-        if not IItemVersion.providedBy(root):
-            error = 'This resource is not a valid ' \
-                    'root version: {}'.format(request.resource_url(root))
-            request.errors.append(error_entry('body', 'root_versions', error))
-            continue
-        valid_root_versions.append(root)
-
-    request.validated['root_versions'] = valid_root_versions
-
-
 def validate_request_data(context: ILocation, request: Request,
                           schema=MappingSchema(), extra_validators=[]):
     """Validate request data.
@@ -601,7 +585,7 @@ class PoolRESTView(SimpleRESTView):
 class ItemRESTView(PoolRESTView):
     """View for Items and ItemVersions, overwrites GET and  POST handling."""
 
-    validation_POST = (POSTItemRequestSchema, [validate_post_root_versions])
+    validation_POST = (POSTItemRequestSchema, [])
 
     @view_config(request_method='GET',
                  permission='view')

--- a/src/adhocracy_core/adhocracy_core/sheets/rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/rate.py
@@ -3,6 +3,7 @@ from pyramid.traversal import find_interface
 from pyramid.registry import Registry
 from substanced.util import find_service
 from zope.interface import implementer
+from colander import Invalid
 import colander
 
 from adhocracy_core.interfaces import ISheet
@@ -119,10 +120,10 @@ def create_validate_subject(request) -> callable:
     def validator(node, value):
         user = get_user(request)
         if user is None or user != value['subject']:
-            err = colander.Invalid(node,
-                                   msg='')  # msg='' workaround colander bug
-            err['subject'] = 'Must be the currently logged-in user'
-            raise err
+            error = Invalid(node, msg='')
+            error.add(Invalid(node['subject'],
+                              msg='Must be the currently logged-in user'))
+            raise error
     return validator
 
 
@@ -151,9 +152,10 @@ def create_validate_is_unique(context, registry: Registry) -> callable:
                                                         'elements')
         for rate in same_rates:
             if rate not in old_versions:
-                err = colander.Invalid(node, msg='')
-                err['object'] = 'Another rate by the same user already exists'
-                raise err
+                error = Invalid(node, msg='')
+                msg = 'Another rate by the same user already exists'
+                error.add(Invalid(node['object'], msg=msg))
+                raise error
     return validator
 
 
@@ -167,9 +169,10 @@ def create_validate_rate_value(registry: Registry) -> callable:
     def validator(node, value):
         rate_validator = registry.getAdapter(value['object'], IRateValidator)
         if not rate_validator.validate(value['rate']):
-            err = colander.Invalid(node, msg='')
-            err['rate'] = rate_validator.helpful_error_message()
-            raise err
+            error = Invalid(node, msg='')
+            msg = rate_validator.helpful_error_message()
+            error.add(Invalid(node['rate'], msg=msg))
+            raise error
     return validator
 
 

--- a/src/adhocracy_core/adhocracy_core/utils/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/utils/__init__.py
@@ -165,10 +165,6 @@ def to_dotted_name(context) -> str:
         return get_dotted_name(context)
 
 
-named_object = namedtuple('NamedObject', ['name'])
-"""An object that has a name (and nothing else)."""
-
-
 def remove_keys_from_dict(dictionary: dict, keys_to_remove=()) -> dict:
     """Remove keys from `dictionary`.
 

--- a/src/adhocracy_core/adhocracy_core/utils/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/utils/__init__.py
@@ -1,5 +1,4 @@
 """Helper functions shared between modules."""
-from collections import namedtuple
 from collections.abc import Iterable
 from collections.abc import Sequence
 from datetime import datetime
@@ -21,10 +20,8 @@ from substanced.util import acquire
 from substanced.util import find_catalog
 from substanced.util import get_dotted_name
 from zope.interface import directlyProvidedBy
-from zope.interface import Interface
 from zope.interface import providedBy
 from zope.interface.interfaces import IInterface
-import colander
 
 from adhocracy_core.interfaces import ChangelogMetadata
 from adhocracy_core.interfaces import IResource
@@ -170,26 +167,6 @@ def to_dotted_name(context) -> str:
 
 named_object = namedtuple('NamedObject', ['name'])
 """An object that has a name (and nothing else)."""
-
-
-def raise_colander_style_error(sheet: Interface, field_name: str,
-                               description: str):
-    """Raise a Colander Invalid error without requiring a node object.
-
-    :param sheet: the error will be located within this sheet; set to `None`
-        to create a error outside of the "data" element, e.g. in a query string
-    :param field_name: the error will be located within this field in the sheet
-    :param description: the description of the error
-    :raises colander.Invalid: constructed from the given parameters
-
-    NOTE: You should always prefer to use the colander schemas to validate
-    request data.
-    """
-    if sheet is not None:
-        name = 'data.{}.{}'.format(sheet.__identifier__, field_name)
-    else:
-        name = field_name
-    raise colander.Invalid(named_object(name), description)
 
 
 def remove_keys_from_dict(dictionary: dict, keys_to_remove=()) -> dict:

--- a/src/adhocracy_core/adhocracy_core/utils/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/utils/test_init.py
@@ -287,28 +287,6 @@ def test_get_reason_blocked_is_hidden_is_hidden(context):
     assert get_reason_if_blocked(context) == 'both'
 
 
-class TestRaiseColanderStyleError:
-
-    def call_fut(self, *args):
-        from . import raise_colander_style_error
-        return raise_colander_style_error(*args)
-
-    def test_raise_colander_error(self):
-        from colander import Invalid
-        from adhocracy_core.interfaces import ISheet
-        with raises(Invalid) as err:
-            self.call_fut(ISheet, 'field_name', 'description')
-        assert err.value.asdict() == \
-             {'data.adhocracy_core.interfaces.ISheet.field_name': 'description'}
-
-    def test_raise_colander_error_with_isheet_is_none(self):
-        from colander import Invalid
-        with raises(Invalid) as err:
-            self.call_fut(None, 'field_name', 'description')
-        assert err.value.asdict() == \
-             {'field_name': 'description'}
-
-
 class TestGetVisibilityChange:
 
     @fixture


### PR DESCRIPTION
Internal Changes:

      - RestAPI view classes have no extra_validators hook anymore
        All validation has to happen in schemas defined in the class attributes schema_GET/POST/...