### PR TITLE
Improve caching performance

### DIFF
--- a/src/adhocracy_core/adhocracy_core/caching/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/caching/__init__.py
@@ -282,7 +282,7 @@ def purge_varnish_after_commit_hook(success: bool, registry: Registry,
         url = varnish_url + request.script_name + path
         for event in events:
             headers = {'X-Purge-Host': request.host}
-            headers['X-Purge-Regex'] = '/?\??.*$'
+            headers['X-Purge-Regex'] = '/?\??[^/]*$'
             try:
                 resp = requests.request('PURGE', url, headers=headers)
                 if resp.status_code != 200:


### PR DESCRIPTION
Do not match children resources with the x-purge-regex when sending a
PURGE request on a resource.

This should improve caching performance but I cannot test now because of #2173 