### PR TITLE
Fix merge static dir script

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -257,16 +257,10 @@ inline =
 
            for filename in filenames:
                link_name = os.path.join(target_root, filename)
+               if os.path.exists(link_name):
+                   continue
                link_source = os.path.relpath(os.path.join(source_root, filename), target_root)
-
-               if os.path.islink(link_name):
-                  if  os.readlink(link_name) != link_source:
-                      os.unlink(link_name)
-                      os.symlink(link_source, link_name)
-               elif not os.path.exists(link_name):
-                  os.symlink(link_source, link_name)
-               else:
-                  raise Exception("unexpected file {}".format(link_name))
+               os.symlink(link_source, link_name)
 output = ${buildout:bin-directory}/ad_merge_static_directories
 mode = 700
 

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -248,19 +248,19 @@ inline =
 
     for source_dir in source_dirs:
         for source_root, dirnames, filenames in os.walk(source_dir):
-           target_root = os.path.join(target_dir, os.path.relpath(source_root, source_dir))
+            target_root = os.path.join(target_dir, os.path.relpath(source_root, source_dir))
 
-           if not os.path.exists(target_root):
-               os.makedirs(target_root)
-           elif not os.path.isdir(target_root):
-               raise Exception("unexpcted file {}".format(target_root))
+            if not os.path.exists(target_root):
+                os.makedirs(target_root)
+            elif not os.path.isdir(target_root):
+                raise Exception("unexpcted file {}".format(target_root))
 
-           for filename in filenames:
-               link_name = os.path.join(target_root, filename)
-               if os.path.exists(link_name):
-                   continue
-               link_source = os.path.relpath(os.path.join(source_root, filename), target_root)
-               os.symlink(link_source, link_name)
+            for filename in filenames:
+                link_name = os.path.join(target_root, filename)
+                if os.path.exists(link_name):
+                    continue
+                link_source = os.path.relpath(os.path.join(source_root, filename), target_root)
+                os.symlink(link_source, link_name)
 output = ${buildout:bin-directory}/ad_merge_static_directories
 mode = 700
 

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -246,6 +246,7 @@ inline =
     target_dir = "${adhocracy:frontend.static_dir}"
     source_dirs = "${:static_directories}".split()
 
+    # remove old links
     for source_dir in source_dirs:
         for source_root, dirnames, filenames in os.walk(source_dir):
             target_root = os.path.join(target_dir, os.path.relpath(source_root, source_dir))
@@ -254,6 +255,15 @@ inline =
                 os.makedirs(target_root)
             elif not os.path.isdir(target_root):
                 raise Exception("unexpcted file {}".format(target_root))
+
+            for filename in filenames:
+                link_name = os.path.join(target_root, filename)
+                if os.path.islink(link_name):
+                    os.unlink(link_name)
+
+    for source_dir in source_dirs:
+        for source_root, dirnames, filenames in os.walk(source_dir):
+            target_root = os.path.join(target_dir, os.path.relpath(source_root, source_dir))
 
             for filename in filenames:
                 link_name = os.path.join(target_root, filename)


### PR DESCRIPTION
This fix the build being broken. It fixes the `bin/ad_merge_static_directories` script by not overriding symlinks which were already created. Since the project specific frontend package files are symlinked first, it works to achieve our goal of having the project frontend package taking precedence over the core frontend package.  

@slomo you need to tell me what you wanted to achieve with the call to the `unlink` follow by `link` function. 