### PR TITLE
Revert "Correct value of the bplan embed sheet"

### DIFF
--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/sheets/embed.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/sheets/embed.py
@@ -11,7 +11,7 @@ def embed_code_config_bplan_adapter(context: IResource,
                                     request: IRequest) -> {}:
     """Return config to render `adhocracy_core:templates/embed_code.html`."""
     mapping = embed_code_config_adapter(context, request)
-    mapping.update({'widget': 'mein-berlin-bplan-proposal-embed',
+    mapping.update({'widget': 'mein-berlin-bplaene-proposal-embed',
                     'autoresize': 'false',
                     'autourl': 'false',
                     'nocenter': 'true',

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/sheets/test_embed.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/sheets/test_embed.py
@@ -16,7 +16,7 @@ class TestEmbedCodeConfigBplanAdapter:
         assert result == {'sdk_url': 'http://localhost:6551/AdhocracySDK.js',
                           'frontend_url': 'http://localhost:6551',
                           'path': 'http://example.com/',
-                          'widget': 'mein-berlin-bplan-proposal-embed',
+                          'widget': 'mein-berlin-bplaene-proposal-embed',
                           'autoresize': 'false',
                           'locale': 'en',
                           'autourl': 'false',

--- a/src/adhocracy_meinberlin/docs/bplan.rst
+++ b/src/adhocracy_meinberlin/docs/bplan.rst
@@ -173,7 +173,7 @@ required fields.
     </script>
     <div class="adhocracy_marker"
          data-path="http://localhost/orga/1-23/"
-         data-widget="mein-berlin-bplan-proposal-embed"
+         data-widget="mein-berlin-bplaene-proposal-embed"
          data-autoresize="false"
          data-locale="en"
          data-autourl="false"


### PR DESCRIPTION
Reverts liqd/adhocracy3#2178 because it used the invalid embed context `mein-berlin-bplan-proposal-embed`. The right one is `meinberlin-bplan-proposal-embed` (in accordance with 1618)