### PR TITLE
Fix merge static directories

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -269,7 +269,7 @@ inline =
                 link_name = os.path.join(target_root, filename)
                 if os.path.exists(link_name):
                     continue
-                link_source = os.path.relpath(os.path.join(source_root, filename), target_root)
+                link_source = os.path.realpath(os.path.join(source_root, filename))
                 os.symlink(link_source, link_name)
 output = ${buildout:bin-directory}/ad_merge_static_directories
 mode = 700


### PR DESCRIPTION
Using absolute paths, as links with relative paths are not included in wheels.