### PR TITLE
Fix calculation of commentCountTotal in mercator2016 proposal

### DIFF
--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -640,7 +640,7 @@ var get = (
                     practical: subs.practicalrelevance.data[SIPracticalRelevance.nick].practicalrelevance
                 },
                 commentCounts: commentCounts,
-                commentCountTotal: _.sum(<any>commentCounts)
+                commentCountTotal: _.sum(_.values(commentCounts))
             };
         });
     });


### PR DESCRIPTION
*Fixes #2189*

`_.sum` does no longer work on objects (see #2137). This caused `commentCountTotal` to always be 0. This is the only place where `_.sum` is used in our code.

#2189 claimed that `commentCountTotal` was displayed correctly in the detail view, but I was not able to reproduce that.