### PR TITLE
mercator 2016 badges

### DIFF
--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2/resources.json
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2/resources.json
@@ -9,5 +9,25 @@
             {"name": "advocate-europe2"},
             "adhocracy_core.sheets.title.ITitle":
             {"title": "Sample mercator2 process"}
+           }},
+  {"path": "/organisation/advocate-europe2/badges",
+   "creator": "/principals/users/0000000",
+   "content_type": "adhocracy_core.resources.badge.IBadge",
+   "data": {"adhocracy_core.sheets.name.IName":
+              {"name": "winning"},
+              "adhocracy_core.sheets.title.ITitle":
+              {"title" : "Winning"},
+              "adhocracy_core.sheets.description.IDescription" :
+              {"description" : "This is the badge for winning proposals"}
+           }},
+  {"path": "/organisation/advocate-europe2/badges",
+   "creator": "/principals/users/0000000",
+   "content_type": "adhocracy_core.resources.badge.IBadge",
+   "data": {"adhocracy_core.sheets.name.IName":
+              {"name": "community"},
+              "adhocracy_core.sheets.title.ITitle":
+              {"title" : "Community"},
+              "adhocracy_core.sheets.description.IDescription" :
+              {"description" : "This is the badge for proposal which won the community award"}
            }}
 ]

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
@@ -1,4 +1,11 @@
-<div class="section-jump" id="section-jump-top">
+<div
+    class="section-jump"
+    id="section-jump-top"
+    data-ng-class="{
+        'has-rosette': data.winner.name,
+        'm-winner': data.winner.name === 'winning',
+        'm-community-award': data.winner.name === 'community'
+    }">
     <h2 class="print-only section-jump-cover-header" data-aria-hidden="true">{{ data.title }}</h2>
 
     <div class="section-jump-cover">

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
@@ -54,6 +54,12 @@
         <div class="section-jump-body">
             <nav class="section-jump-navigation jump-navigation m-narrow m-unnumbered" data-adh-sticky="">
                 <ol>
+                    <li data-ng-if="data.winner.name"><a
+                        href="#jury-decision"
+                        title="Jury Decision"
+                        data-du-smooth-scroll=""
+                        data-du-scrollspy=""
+                        ><i class="icon-star"></i></a></li>
                     <li><a
                         href="#mercator-proposal-brief"
                         data-du-smooth-scroll=""

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Detail.html
@@ -25,6 +25,12 @@
             <li class="meta-list-item meta-list-item-rate">
                 <adh-like data-refers-to="{{path}}" data-disabled="processState != 'participate'"></adh-like>
             </li>
+            <li data-ng-if="data.winner.name === 'winning'" class="meta-list-item meta-list-item-badge">
+                <span class="badge m-winner">{{ "TR__MERCATOR_BADGE_WINNERS" | translate }}</span>
+            </li>
+            <li data-ng-if="data.winner.name === 'community'" class="meta-list-item meta-list-item-badge">
+                <span class="badge m-community-award">{{ "TR__MERCATOR_BADGE_COMMUNITY_AWARD" | translate }}</span>
+            </li>
         </ul>
 
         <h1 class="section-jump-cover-header screen-only">{{ data.title }}

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -855,7 +855,8 @@ export var listItem = (
                     },
                     introduction: data.introduction,
                     commentCountTotal: data.commentCountTotal,
-                    supporterCount: data.supporterCount
+                    supporterCount: data.supporterCount,
+                    winnerBadgeAssignment: data.winner
                 };
 
                 scope.$on("$destroy", adhTopLevelState.bind("processState", scope.data, "currentPhase"));

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -856,7 +856,7 @@ export var listItem = (
                     introduction: data.introduction,
                     commentCountTotal: data.commentCountTotal,
                     supporterCount: data.supporterCount,
-                    winnerBadgeAssignment: data.winner
+                    winnerBadgeAssignment: data.winner.name ? data.winner : null
                 };
 
                 scope.$on("$destroy", adhTopLevelState.bind("processState", scope.data, "currentPhase"));


### PR DESCRIPTION
Badges for merctor 2016 are not completely implemented yet. This pull request provides the missing blocks to support the "winner" and "community award" badges that also existed in 2015. The new "shortlist" badge will be added separately.

@2e2a this assumes that the badges described in `src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2/resources.json` exist.