### PR TITLE
Remove cancle buttons of login/register forms in pcompass

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/CreatePasswordReset.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/CreatePasswordReset.html
@@ -43,5 +43,5 @@
         }"></p>
     </div>
 
-    <a class="login-cancel" href="" data-ng-click="cancel()">{{ "TR__CANCEL" | translate}}</a>
+    <a data-ng-if="enableCancel" class="login-cancel" href="" data-ng-click="cancel()">{{ "TR__CANCEL" | translate}}</a>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Login.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Login.html
@@ -57,5 +57,5 @@
         </div>
     </form>
 
-    <a class="login-cancel" href="" ng-click="cancel()">{{ "TR__CANCEL" | translate}}</a>
+    <a data-ng-if="enableCancel" class="login-cancel" href="" ng-click="cancel()">{{ "TR__CANCEL" | translate}}</a>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
@@ -127,7 +127,7 @@
         }"></p>
     </div>
 
-    <a class="login-cancel" href="" data-ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
+    <a data-ng-if="enableCancel" class="login-cancel" href="" data-ng-click="cancel()">{{ "TR__CANCEL" | translate }}</a>
     <div class="login-info">
         {{ "TR__REGISTRATION_SUPPORT" | translate }} <br />
         <a data-ng-href="mailto:{{supportEmail}}?subject=Trouble%20with%20registration">{{ supportEmail }}</a>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -1,4 +1,6 @@
 /// <reference path="../../../lib2/types/angular.d.ts"/>
+/// <reference path="../../../lib2/types/lodash.d.ts"/>
+import * as _ from "lodash";
 
 import * as AdhBadge from "../Badge/Badge";
 import * as AdhConfig from "../Config/Config";
@@ -122,6 +124,7 @@ export interface IScopeRegister extends angular.IScope {
     success : boolean;
 
     register : () => angular.IPromise<void>;
+    enableCancel : boolean;
     cancel : () => void;
     showError;
     logOut : () => void;
@@ -198,8 +201,6 @@ export var loginDirective = (
             scope.supportEmail = adhConfig.support_email;
             scope.showError = adhShowError;
 
-            scope.enableCancel = adhEmbed.getContext() !== "login";
-
             adhPermissions.bindScope(scope, "/principals/users");
 
             scope.credentials = {
@@ -211,6 +212,8 @@ export var loginDirective = (
                 scope.credentials.nameOrEmail = "";
                 scope.credentials.password = "";
             };
+
+            scope.enableCancel = ! _.includes(["login", "logout", "register"], adhEmbed.getContext());
 
             scope.cancel = () => {
                  adhTopLevelState.goToCameFrom("/");
@@ -340,6 +343,7 @@ export var registerDirective = (
     adhCredentials : AdhCredentials.Service,
     adhUser : AdhUser.Service,
     adhTopLevelState : AdhTopLevelState.Service,
+    adhEmbed : AdhEmbed.Service,
     adhShowError
 ) => {
     return {
@@ -398,6 +402,8 @@ export var registerDirective = (
                 passwordRepeat: "",
                 captchaGuess: ""
             };
+
+            scope.enableCancel = ! _.includes(["login", "logout", "register"], adhEmbed.getContext());
 
             scope.cancel = scope.goBack = () => {
                 adhTopLevelState.goToCameFrom("/");
@@ -473,6 +479,7 @@ export var createPasswordResetDirective = (
     adhHttp : AdhHttp.Service<any>,
     adhUser : AdhUser.Service,
     adhTopLevelState : AdhTopLevelState.Service,
+    adhEmbed : AdhEmbed.Service,
     adhShowError
 ) => {
     return {
@@ -491,6 +498,8 @@ export var createPasswordResetDirective = (
             scope.input = {
                 email: ""
             };
+
+            scope.enableCancel = ! _.includes(["login", "logout", "register"], adhEmbed.getContext());
 
             scope.goBack = scope.cancel = () => {
                  adhTopLevelState.goToCameFrom("/");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -7,6 +7,7 @@ import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhResourceArea from "../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
+import * as AdhEmbed from "../Embed/Embed";
 import * as AdhUtil from "../Util/Util";
 
 import * as AdhCredentials from "./Credentials";
@@ -87,6 +88,7 @@ export interface IScopeLogin extends angular.IScope {
     supportEmail : string;
 
     resetCredentials : () => void;
+    enableCancel : boolean;
     cancel : () => void;
     logIn : () => angular.IPromise<void>;
     showError;
@@ -183,6 +185,7 @@ export var loginDirective = (
     adhConfig : AdhConfig.IService,
     adhUser : AdhUser.Service,
     adhTopLevelState : AdhTopLevelState.Service,
+    adhEmbed : AdhEmbed.Service,
     adhPermissions : AdhPermissions.Service,
     adhShowError
 ) => {
@@ -194,6 +197,8 @@ export var loginDirective = (
             scope.errors = [];
             scope.supportEmail = adhConfig.support_email;
             scope.showError = adhShowError;
+
+            scope.enableCancel = adhEmbed.getContext() !== "login";
 
             adhPermissions.bindScope(scope, "/principals/users");
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../lib2/types/angular.d.ts"/>
 /// <reference path="../../../lib2/types/lodash.d.ts"/>
+
 import * as _ from "lodash";
 
 import * as AdhBadge from "../Badge/Badge";

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -213,7 +213,7 @@ export var loginDirective = (
                 scope.credentials.password = "";
             };
 
-            scope.enableCancel = ! _.includes(["login", "logout", "register"], adhEmbed.getContext());
+            scope.enableCancel = ! _.includes(["login", "register"], adhEmbed.getContext());
 
             scope.cancel = () => {
                  adhTopLevelState.goToCameFrom("/");
@@ -403,7 +403,7 @@ export var registerDirective = (
                 captchaGuess: ""
             };
 
-            scope.enableCancel = ! _.includes(["login", "logout", "register"], adhEmbed.getContext());
+            scope.enableCancel = ! _.includes(["login", "register"], adhEmbed.getContext());
 
             scope.cancel = scope.goBack = () => {
                 adhTopLevelState.goToCameFrom("/");
@@ -499,7 +499,7 @@ export var createPasswordResetDirective = (
                 email: ""
             };
 
-            scope.enableCancel = ! _.includes(["login", "logout", "register"], adhEmbed.getContext());
+            scope.enableCancel = ! _.includes(["login", "register"], adhEmbed.getContext());
 
             scope.goBack = scope.cancel = () => {
                  adhTopLevelState.goToCameFrom("/");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -10,6 +10,7 @@ import * as AdhMovingColumnsModule from "../MovingColumns/Module";
 import * as AdhPermissionsModule from "../Permissions/Module";
 import * as AdhResourceAreaModule from "../ResourceArea/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
+import * as AdhEmbed from "../Embed/Module";
 
 import * as AdhCredentialsModule from "./CredentialsModule";
 import * as AdhUserModule from "./Module";
@@ -36,7 +37,8 @@ export var register = (angular) => {
             AdhTopLevelStateModule.moduleName,
             AdhResourceAreaModule.moduleName,
             AdhUserModule.moduleName,
-            AdhImageModule.moduleName
+            AdhImageModule.moduleName,
+            AdhEmbed.moduleName
         ])
         .config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
             adhTopLevelStateProvider

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../../lib2/types/lodash.d.ts"/>
+
 import * as _ from "lodash";
 
 import * as AdhAngularHelpersModule from "../AngularHelpers/Module";
@@ -100,7 +102,7 @@ export var register = (angular) => {
             "adhShowError",
             AdhUserViews.loginDirective])
         .directive("adhPasswordReset", [
-            "adhConfig", "adhHttp", "adhUser", "adhTopLevelState", "adhShowError", AdhUserViews.passwordResetDirective])
+            "adhConfig", "adhHttp", "adhUser", "adhTopLevelState", "adhEmbed", "adhShowError", AdhUserViews.passwordResetDirective])
         .directive("adhCreatePasswordReset", [
             "adhConfig",
             "adhCredentials",
@@ -110,7 +112,15 @@ export var register = (angular) => {
             "adhShowError",
             AdhUserViews.createPasswordResetDirective])
         .directive("adhRegister", [
-            "$sce", "$http", "adhConfig", "adhCredentials", "adhUser", "adhTopLevelState", "adhShowError", AdhUserViews.registerDirective])
+            "$sce",
+            "$http",
+            "adhConfig",
+            "adhCredentials",
+            "adhUser",
+            "adhTopLevelState",
+            "adhEmbed",
+            "adhShowError",
+            AdhUserViews.registerDirective])
         .directive("adhUserIndicator", [
             "adhConfig", "adhResourceArea", "adhTopLevelState", "adhPermissions", "$location", AdhUserViews.indicatorDirective])
         .directive("adhUserMeta", ["adhConfig", "adhResourceArea", "adhGetBadges", AdhUserViews.metaDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -104,13 +104,14 @@ export var register = (angular) => {
             "adhShowError",
             AdhUserViews.loginDirective])
         .directive("adhPasswordReset", [
-            "adhConfig", "adhHttp", "adhUser", "adhTopLevelState", "adhEmbed", "adhShowError", AdhUserViews.passwordResetDirective])
+            "adhConfig", "adhHttp", "adhUser", "adhTopLevelState", "adhShowError", AdhUserViews.passwordResetDirective])
         .directive("adhCreatePasswordReset", [
             "adhConfig",
             "adhCredentials",
             "adhHttp",
             "adhUser",
             "adhTopLevelState",
+            "adhEmbed",
             "adhShowError",
             AdhUserViews.createPasswordResetDirective])
         .directive("adhRegister", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -91,7 +91,14 @@ export var register = (angular) => {
             "adhUser",
             "adhGetBadges",
             AdhUserViews.userProfileDirective])
-        .directive("adhLogin", ["adhConfig", "adhUser", "adhTopLevelState", "adhPermissions", "adhShowError", AdhUserViews.loginDirective])
+        .directive("adhLogin", [
+            "adhConfig",
+            "adhUser",
+            "adhTopLevelState",
+            "adhEmbed",
+            "adhPermissions",
+            "adhShowError",
+            AdhUserViews.loginDirective])
         .directive("adhPasswordReset", [
             "adhConfig", "adhHttp", "adhUser", "adhTopLevelState", "adhShowError", AdhUserViews.passwordResetDirective])
         .directive("adhCreatePasswordReset", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -4,13 +4,13 @@ import * as _ from "lodash";
 
 import * as AdhAngularHelpersModule from "../AngularHelpers/Module";
 import * as AdhBadgeModule from "../Badge/Module";
+import * as AdhEmbedModule from "../Embed/Module";
 import * as AdhHttpModule from "../Http/Module";
 import * as AdhLocaleModule from "../Locale/Module";
 import * as AdhMovingColumnsModule from "../MovingColumns/Module";
 import * as AdhPermissionsModule from "../Permissions/Module";
 import * as AdhResourceAreaModule from "../ResourceArea/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
-import * as AdhEmbed from "../Embed/Module";
 
 import * as AdhCredentialsModule from "./CredentialsModule";
 import * as AdhUserModule from "./Module";
@@ -30,6 +30,7 @@ export var register = (angular) => {
             AdhAngularHelpersModule.moduleName,
             AdhBadgeModule.moduleName,
             AdhCredentialsModule.moduleName,
+            AdhEmbedModule.moduleName,
             AdhLocaleModule.moduleName,
             AdhMovingColumnsModule.moduleName,
             AdhPermissionsModule.moduleName,
@@ -37,8 +38,7 @@ export var register = (angular) => {
             AdhTopLevelStateModule.moduleName,
             AdhResourceAreaModule.moduleName,
             AdhUserModule.moduleName,
-            AdhImageModule.moduleName,
-            AdhEmbed.moduleName
+            AdhImageModule.moduleName
         ])
         .config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
             adhTopLevelStateProvider

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsSpec.ts
@@ -19,6 +19,7 @@ export var register = () => {
             var adhConfigMock;
             var adhUserMock;
             var adhTopLevelStateMock;
+            var adhEmbedMock;
 
             beforeEach(() => {
                 adhConfigMock = {
@@ -31,8 +32,9 @@ export var register = () => {
                 adhUserMock = jasmine.createSpyObj("adhUserMock", ["logIn"]);
                 adhUserMock.logIn.and.returnValue(q.when(undefined));
                 adhTopLevelStateMock = jasmine.createSpyObj("adhTopLevelStateMock", ["goToCameFrom"]);
+                adhEmbedMock = jasmine.createSpyObj("adhEmbedMock", ["getContext"]);
                 directive = AdhUserViews.loginDirective(
-                    adhConfigMock, adhUserMock, adhTopLevelStateMock, adhPermissionsMock, "adhShowError");
+                    adhConfigMock, adhUserMock, adhTopLevelStateMock, adhEmbedMock, adhPermissionsMock, "adhShowError");
             });
 
             describe("link", () => {


### PR DESCRIPTION
Since the login is embedded by it self those buttons have no functionality in pcompass.