### PR TITLE
Fix purge regex for caching

### DIFF
--- a/src/adhocracy_core/adhocracy_core/caching/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/caching/__init__.py
@@ -282,7 +282,7 @@ def purge_varnish_after_commit_hook(success: bool, registry: Registry,
         url = varnish_url + request.script_name + path
         for event in events:
             headers = {'X-Purge-Host': request.host}
-            headers['X-Purge-Regex'] = '/?\??[^/]*$'
+            headers['X-Purge-Regex'] = '/?\??[^/]*'
             try:
                 resp = requests.request('PURGE', url, headers=headers)
                 if resp.status_code != 200:

--- a/src/adhocracy_core/adhocracy_core/caching/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/caching/test_init.py
@@ -466,7 +466,7 @@ class TestPurgeVarnishAfterCommitHook:
         purge_varnish_after_commit_hook(True, registry_for_varnish, request_)
         mock_requests.request.assert_called_once_with(
             'PURGE', 'http://localhost/', headers={'X-Purge-Host': 'host',
-                                                   'X-Purge-Regex': '/?\\??[^/]*$'})
+                                                   'X-Purge-Regex': '/?\\??[^/]*'})
 
     def test_change_descendants_in_changelog(
             self, monkeypatch, registry_for_varnish, changelog_meta, context,
@@ -478,7 +478,7 @@ class TestPurgeVarnishAfterCommitHook:
                                            changed_descendants=True)
         purge_varnish_after_commit_hook(True, registry_for_varnish, request_)
         assert mock_requests.request.call_args[1]['headers']['X-Purge-Regex']\
-            == '/?\??[^/]*$'
+            == '/?\??[^/]*'
 
     def test_non_empty_changelog_but_unchanged_resource(
             self, monkeypatch, registry_for_varnish, changelog_meta, context,


### PR DESCRIPTION
For consistency, since the regex is matched with '^' in the Varnish
configuration, '$' should be put there and not come from the backend.