### PR TITLE
fix alex embed

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/MeinberlinDe/Module.ts
@@ -23,7 +23,7 @@ import RIKiezkasseProcess from "../../../Resources_/adhocracy_meinberlin/resourc
 import * as AdhMeinberlinDe from "./MeinberlinDe";
 
 
-export var moduleName = "adhMeinberlinAlexanderplatzContext";
+export var moduleName = "adhMeinberlinDe";
 
 export var register = (angular) => {
     angular


### PR DESCRIPTION
this fixes #2227.

The problem was that both the `MeinberlinDe` module and the `AlexanderplatzContext` module had the same `moduleName`.