### PR TITLE
rm phantomjs

### DIFF
--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -21,7 +21,6 @@ flake8 = 2.4.1
 flake8-docstrings = 0.2.1.post1
 flake8-quotes = 0.0.1
 gp.recipe.node = 0.10.28.0
-gp.recipe.phantomjs = 1.9.7.2
 hypatia = 0.3
 logilab-common = 0.63.2
 mccabe = 0.3.1

--- a/src/adhocracy_frontend/adhocracy_frontend/static/test.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/test.html
@@ -38,14 +38,6 @@
 
 <body>
     <script type="text/javascript">
-        // phantom.js is missing bind(), so here is a simplified polyfill
-        Function.prototype.bind = Function.prototype.bind || function(thisp) {
-            var fn = this;
-            return function() {
-                return fn.apply(thisp, arguments);
-            };
-        };
-
         require(['AdhocracySpec'], function(spec) {
             jasmine.getEnv().execute()
         });

--- a/src/adhocracy_frontend/base.cfg
+++ b/src/adhocracy_frontend/base.cfg
@@ -6,7 +6,6 @@ parts +=
      adhocracy
      frontend_development.ini
      frontend_test.ini
-     phantomjs
      source_env
      supervisor
 eggs =
@@ -38,9 +37,6 @@ output = ${buildout:directory}/etc/frontend_development.ini
 recipe = collective.recipe.template
 input = ${buildout:directory}/etc/frontend_test.ini.in
 output = ${buildout:directory}/etc/frontend_test.ini
-
-[phantomjs]
-recipe = gp.recipe.phantomjs
 
 [source_env]
 recipe = collective.recipe.template


### PR DESCRIPTION
*Fixes #2226* I could not reproduce the issues reported by @pallix.

This removes phantomjs from our build scripts. It was used for browser tests some time ago, but we stopped doing this when switching to protractor, which [explicitly recommends against using it](https://github.com/angular/protractor/blob/master/docs/browser-setup.md#setting-up-phantomjs).

**Note** that you have to remove `parts/` and `.installed.cfg` to trigger a full reinstall.