### PR TITLE
fix stadtforum embedding on old mein.berlin.de

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -242,7 +242,10 @@ export class Service implements AdhTopLevelState.IAreaInput {
     public getProcess(resourceUrl : string, fail = true) : angular.IPromise<ResourcesBase.Resource> {
         var paths = [];
 
-        var path = resourceUrl.substr(this.adhConfig.rest_url.length);
+        if (resourceUrl.substr(0, 4) === "http") {
+            var path = resourceUrl.substr(this.adhConfig.rest_url.length);
+        }
+
         while (path !== AdhUtil.parentPath(path)) {
             paths.push(path);
             path = AdhUtil.parentPath(path);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceArea/ResourceArea.ts
@@ -242,6 +242,8 @@ export class Service implements AdhTopLevelState.IAreaInput {
     public getProcess(resourceUrl : string, fail = true) : angular.IPromise<ResourcesBase.Resource> {
         var paths = [];
 
+        // FIXME: This if-Statement was added for the special case that resourceUrl is a URL,
+        // not a relative path. It should be erased when the archived Stadtforum processes go offline.
         if (resourceUrl.substr(0, 4) === "http") {
             var path = resourceUrl.substr(this.adhConfig.rest_url.length);
         }

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_stadtforum/resources.json
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_stadtforum/resources.json
@@ -9,15 +9,5 @@
             {"name": "stadtforum"},
             "adhocracy_core.sheets.title.ITitle":
             {"title": "Sample Stadtforum participation process"}
-           }},
-  {"path": "/organisation/stadtforum",
-   "content_type": "adhocracy_core.resources.proposal.IProposal",
-   "data": {"adhocracy_core.sheets.name.IName":
-            {"name": "proposal_0000000"}
-           }},
-  {"path": "/organisation/stadtforum/proposal_0000000/",
-   "content_type": "adhocracy_core.resources.proposal.IProposalVersion",
-   "data": {"adhocracy_core.sheets.name.IName":
-            {"name": "VERSION_0000000"}
            }}
 ]

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_stadtforum/resources.json
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_stadtforum/resources.json
@@ -9,5 +9,15 @@
             {"name": "stadtforum"},
             "adhocracy_core.sheets.title.ITitle":
             {"title": "Sample Stadtforum participation process"}
+           }},
+  {"path": "/organisation/stadtforum",
+   "content_type": "adhocracy_core.resources.proposal.IProposal",
+   "data": {"adhocracy_core.sheets.name.IName":
+            {"name": "proposal_0000000"}
+           }},
+  {"path": "/organisation/stadtforum/proposal_0000000/",
+   "content_type": "adhocracy_core.resources.proposal.IProposalVersion",
+   "data": {"adhocracy_core.sheets.name.IName":
+            {"name": "VERSION_0000000"}
            }}
 ]


### PR DESCRIPTION
this should fix #2231.

I couldn't test it, unfortunately, because I could never reproduce the error in the issue locally.

But I think I found the problem:

In `ResourceArea.ts`, the function `getProcess` assumed that its input string `resourceUrl` was a complete URL, not a relative path, and then chopped it accordingly. 