### PR TITLE
Temporary fix for private processes

### DIFF
--- a/src/adhocracy_core/adhocracy_core/workflows/debate_private.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/debate_private.yaml
@@ -9,7 +9,7 @@ states:
     acm:
       principals:       [everyone,  participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,         D,         ~,           ~,          ~,      ~,         ~]
+        - [view,         D,         A,           A,         A,       A,         ~]
   evaluate:
     acm:
       principals:       [everyone,  participant, moderator, creator, initiator, admin]

--- a/src/adhocracy_core/adhocracy_core/workflows/debate_private.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/debate_private.yaml
@@ -4,12 +4,12 @@ states:
     acm:
       principals:       [everyone,  participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,         D,         A,           A,         A,       A,         ~]
+        - [view,         D,         A,           A,         A,       A,         A]
   participate:
     acm:
       principals:       [everyone,  participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,         D,         A,           A,         A,       A,         ~]
+        - [view,         D,         A,           A,         A,       A,         A]
   evaluate:
     acm:
       principals:       [everyone,  participant, moderator, creator, initiator, admin]

--- a/src/adhocracy_core/adhocracy_core/workflows/debate_private.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/debate_private.yaml
@@ -14,14 +14,14 @@ states:
     acm:
       principals:       [everyone,  participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,         D,         ~,           ~,          ~,      ~,         ~]
+        - [view,         D,         A,           A,         A,       A,         A]
   result:
     acm:
       principals:       [everyone,  participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,         D,         ~,           ~,          ~,      ~,         ~]
+        - [view,         D,         A,           A,         A,       A,         A]
   closed:
     acm:
       principals:       [everyone,  participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,         D,         ~,           ~,          ~,      ~,         ~]
+        - [view,         D,         A,           A,         A,        A,        A]

--- a/src/adhocracy_core/adhocracy_core/workflows/standard_private.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/standard_private.yaml
@@ -9,7 +9,7 @@ states:
     acm:
       principals:      [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,        D,        A,           A,         A,        A,        ~]
+        - [view,        D,        A,           A,         A,        A,        A]
   evaluate:
     acm:
       principals:      [everyone, participant, moderator, creator, initiator, admin]

--- a/src/adhocracy_core/adhocracy_core/workflows/standard_private.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/standard_private.yaml
@@ -14,14 +14,14 @@ states:
     acm:
       principals:      [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,        D,        ~,           ~,         ~,        ~,        ~]
+        - [view,        D,        A,           A,         A,        A,        A]
   result:
     acm:
       principals:      [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,        D,        ~,           ~,         ~,        ~,        ~]
+        - [view,        D,        A,           A,         A,        A,        A]
   closed:
     acm:
       principals:      [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,        D,        ~,           ~,         ~,        ~,        ~]
+        - [view,        D,        A,           A,         A,        A,        A]

--- a/src/adhocracy_core/adhocracy_core/workflows/standard_private.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/standard_private.yaml
@@ -9,7 +9,7 @@ states:
     acm:
       principals:      [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,        D,        ~,           ~,         ~,        ~,        ~]
+        - [view,        D,        A,           A,         A,        A,        ~]
   evaluate:
     acm:
       principals:      [everyone, participant, moderator, creator, initiator, admin]


### PR DESCRIPTION
Fixes only 'participate' state. 

All participants have both the 'participant' and 'everyone' roles, so
setting 'Deny' for 'view' permission for 'everyone' result in a 'Deny',
if participant does not have explicity 'Allow' in the private workflow.
Setting explicitely 'Allow' do not allow us to us inheritance with the ~
symbol.

@joka what do you think about the problem?