### PR TITLE
add basic admin interface (SDI)

### DIFF
--- a/etc/coveragerc
+++ b/etc/coveragerc
@@ -14,6 +14,7 @@ omit =
     src/adhocracy_core/adhocracy_core/__init__.py
     src/adhocracy_core/adhocracy_core/scripts/import_resources.py
     src/adhocracy_core/adhocracy_core/scripts/import_local_roles.py
+    src/adhocracy_core/adhocracy_core/sdi/*
     src/adhocracy/adhocracy/scaffolds/__init__
     src/adhocracy_sample/adhocracy_sample/__init__.py
     src/adhocracy_frontend/adhocracy_frontend/__init__.py

--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -1,5 +1,6 @@
 """Configure, add dependency packages/modules, start application."""
 from pyramid.config import Configurator
+from pyramid.interfaces import IAuthenticationPolicy
 from pyramid_zodbconn import get_connection
 from substanced.db import RootAdded
 from logging import getLogger
@@ -7,7 +8,6 @@ from logging import getLogger
 import transaction
 
 from adhocracy_core.authentication import TokenHeaderAuthenticationPolicy
-from adhocracy_core.authorization import RoleACLAuthorizationPolicy
 from adhocracy_core.resources.root import IRootPool
 from adhocracy_core.resources.principal import groups_and_roles_finder
 from adhocracy_core.auditing import set_auditlog
@@ -91,14 +91,8 @@ def includeme(config):
     settings = config.registry.settings
     config.include('pyramid_zodbconn')
     config.include('pyramid_mako')
-    authz_policy = RoleACLAuthorizationPolicy()
-    config.set_authorization_policy(authz_policy)
-    authn_secret = settings.get('substanced.secret')
-    authn_timeout = 60 * 60 * 24 * 30
-    authn_policy = TokenHeaderAuthenticationPolicy(
-        authn_secret,
-        groupfinder=groups_and_roles_finder,
-        timeout=authn_timeout)
+    config.include('.authorization')
+    authn_policy = _create_authn_policy(settings)
     config.set_authentication_policy(authn_policy)
     config.include('.renderers')
     config.include('.authentication')
@@ -120,6 +114,16 @@ def includeme(config):
     if settings.get('adhocracy.add_test_users', False):
         from adhocracy_core.testing import add_create_test_users_subscriber
         add_create_test_users_subscriber(config)
+
+
+def _create_authn_policy(settings: dict) -> IAuthenticationPolicy:
+    secret = settings.get('substanced.secret')
+    groupfinder = groups_and_roles_finder
+    timeout = 60 * 60 * 24 * 30
+    token_policy = TokenHeaderAuthenticationPolicy(secret,
+                                                   groupfinder=groupfinder,
+                                                   timeout=timeout)
+    return token_policy
 
 
 def main(global_config, **settings):

--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -36,6 +36,7 @@ def _set_app_root_if_missing(request):
         return
     registry = request.registry
     app_root = registry.content.create(IRootPool.__identifier__,
+                                       request=request,
                                        registry=request.registry)
     zodb_root['app_root'] = app_root
     transaction.savepoint()  # give app_root a _p_jar

--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -91,7 +91,6 @@ def includeme(config):
     settings = config.registry.settings
     config.include('pyramid_zodbconn')
     config.include('pyramid_mako')
-    config.hook_zca()  # global adapter lookup (used by adhocracy_core.utils)
     authz_policy = RoleACLAuthorizationPolicy()
     config.set_authorization_policy(authz_policy)
     authn_secret = settings.get('substanced.secret')

--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -135,14 +135,17 @@ def _create_authentication_policy(settings, config: Configurator)\
                                                    groupfinder=groupfinder,
                                                    timeout=timeout)
     multi_policy.add_policy(None, token_policy)
+    manage_prefix = settings.get('substanced.manage_prefix', '/manage')
     session_factory = SignedCookieSessionFactory(secret,
                                                  httponly=True,
+                                                 path=manage_prefix,
                                                  timeout=timeout)
     config.set_session_factory(session_factory)
     session_policy = AuthTktAuthenticationPolicy(secret,
                                                  hashalg='sha512',
                                                  http_only=True,
                                                  callback=groupfinder,
+                                                 path=manage_prefix,
                                                  timeout=timeout)
     # TODO add secure cookie flag if https
     multi_policy.add_policy(SDI_ROUTE_NAME, session_policy)

--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -93,6 +93,7 @@ def includeme(config):
     settings = config.registry.settings
     config.include('pyramid_zodbconn')
     config.include('pyramid_mako')
+    config.include('pyramid_chameleon')
     config.include('.authorization')
     authn_policy = _create_authn_policy(settings)
     config.set_authentication_policy(authn_policy)

--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -10,6 +10,7 @@ import transaction
 from adhocracy_core.authentication import TokenHeaderAuthenticationPolicy
 from adhocracy_core.resources.root import IRootPool
 from adhocracy_core.resources.principal import groups_and_roles_finder
+from adhocracy_core.resources.principal import get_user
 from adhocracy_core.auditing import set_auditlog
 from adhocracy_core.auditing import get_auditlog
 
@@ -95,6 +96,7 @@ def includeme(config):
     config.include('.authorization')
     authn_policy = _create_authn_policy(settings)
     config.set_authentication_policy(authn_policy)
+    config.add_request_method(get_user, name='user', reify=True)
     config.include('.renderers')
     config.include('.authentication')
     config.include('.authorization')

--- a/src/adhocracy_core/adhocracy_core/auditing/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/auditing/__init__.py
@@ -8,7 +8,6 @@ from pyramid.response import Response
 from BTrees.OOBTree import OOBTree
 from datetime import datetime
 from logging import getLogger
-from adhocracy_core.utils import get_user
 from adhocracy_core.sheets.principal import IUserBasic
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import ChangelogMetadata
@@ -98,10 +97,8 @@ def audit_resources_changes_callback(request: Request,
 
 
 def _get_user_info(request: Request) -> (str, str):
-    if not hasattr(request, 'authenticated_userid'):
-        return ('', '')  # ease scripting without user and testing
-    user = get_user(request)
-    if user is None:
+    user = request.user
+    if user is None:  # ease scripting without user and testing
         return ('', '')
     else:
         user_name = request.registry.content.get_sheet_field(user,

--- a/src/adhocracy_core/adhocracy_core/authentication/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/test_init.py
@@ -422,6 +422,12 @@ class TestMultiRouteAuthenticationPolicy:
         inst.policies = {}
         assert inst._get_matching_policy(request_) is None
 
+    def test_get_matching_policy_return_none_if_wrong_policy(
+        self, request_, inst, policy):
+        request_.matched_route = None
+        inst.policies = {'other_policy': policy}
+        assert inst._get_matching_policy(request_) is None
+
     def test_get_matching_policy_return_policy_if_none_matches(
         self, request_, inst, policy):
         request_.matched_route = None

--- a/src/adhocracy_core/adhocracy_core/authentication/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/test_init.py
@@ -1,8 +1,9 @@
-import unittest
 from unittest.mock import Mock
+import unittest
 
 from pyramid import testing
-import pytest
+from pytest import raises
+from pytest import fixture
 
 
 class TokenManagerUnitTest(unittest.TestCase):
@@ -375,8 +376,109 @@ def test_validate_user_headers_raise_if_authentication_failed(context,
     view = Mock()
     request_.headers['X-User-Token'] = 2
     request_.authenticated_userid = None
-    with pytest.raises(HTTPBadRequest):
+    with raises(HTTPBadRequest):
         validate_user_headers(view)(context, request_)
+
+
+class TestMultiRouteAuthenticationPolicy:
+
+    @fixture
+    def inst(self):
+        from . import MultiRouteAuthenticationPolicy
+        return MultiRouteAuthenticationPolicy()
+
+    @fixture
+    def policy(self, mocker):
+        from pyramid.interfaces import IAuthenticationPolicy
+        return mocker.Mock(spec=IAuthenticationPolicy)()
+
+    @fixture
+    def other_policy(self, mocker):
+        from pyramid.interfaces import IAuthenticationPolicy
+        return mocker.Mock(spec=IAuthenticationPolicy)()
+
+    @fixture
+    def route(self, mocker):
+        from pyramid.interfaces import IRoute
+        return mocker.Mock(spec=IRoute,
+                           name='route_name')()
+
+    def test_is_authentication_policy(self, inst):
+        from pyramid.interfaces import IAuthenticationPolicy
+        from zope.interface.verify import verifyObject
+        assert IAuthenticationPolicy.providedBy(inst)
+        assert verifyObject(IAuthenticationPolicy, inst)
+
+    def test_is_subclass_of_callback_policy(self, inst):
+        from pyramid.authentication import CallbackAuthenticationPolicy
+        assert isinstance(inst, CallbackAuthenticationPolicy)
+
+    def test_add_policy(self, inst, policy):
+        inst.add_policy('route_name', policy)
+        assert inst.policies['route_name'] is policy
+
+    def test_get_matching_policy_return_none_if_no_policy(self, request_, inst):
+        request_.matched_route = None
+        inst.policies = {}
+        assert inst._get_matching_policy(request_) is None
+
+    def test_get_matching_policy_return_policy_if_none_matches(
+        self, request_, inst, policy):
+        request_.matched_route = None
+        inst.policies = {None: policy}
+        assert inst._get_matching_policy(request_) is policy
+
+    def test_get_matching_policy_return_policy_if_route_name_matches(
+        self, request_, inst, policy, other_policy, route):
+        request_.matched_route = route
+        inst.policies = {route.name: policy,
+                         'other_route': other_policy}
+        assert inst._get_matching_policy(request_) is policy
+
+    def test_unauthenticated_userid_return_none_if_no_policy_policy_machted(
+        self, request_, inst, mocker):
+        inst._get_matching_policy = mocker.Mock(return_value=None)
+        assert inst.unauthenticated_userid(request_) is None
+
+    def test_unauthenticated_userid_return_userid_of_matched_policy(
+        self, inst, request_, policy, mocker):
+        inst._get_matching_policy = mocker.Mock(return_value=policy)
+        policy.unauthenticated_userid.return_value = 'userid'
+        assert inst.unauthenticated_userid(request_) == 'userid'
+
+    def test_effective_principals_return_everyone_if_no_policy_policy_machted(
+        self, request_, inst, mocker):
+        from pyramid.security import Everyone
+        inst._get_matching_policy = mocker.Mock(return_value=None)
+        assert inst.effective_principals(request_) == [Everyone]
+
+    def test_effective_principals_return_principals_of_matched_policy(
+        self, inst, request_, policy, mocker):
+        inst._get_matching_policy = mocker.Mock(return_value=policy)
+        policy.effective_principals.return_value = ['Group1']
+        assert inst.effective_principals(request_) == ['Group1']
+
+    def test_remember_return_empty_list_if_no_policies(self, inst, request_):
+        assert inst.remember(request_, 'principal') == []
+
+    def test_remember_return_headers_of_all_policies(
+        self, inst, request_, policy, other_policy):
+        inst.policies['route1'] = policy
+        policy.remember.return_value = [('1', '1')]
+        inst.policies['route2'] = other_policy
+        other_policy.remember.return_value = [('2', '2')]
+        assert inst.remember(request_, 'principal') == [('1','1'), ('2', '2')]
+
+    def test_forget_return_empty_list_if_no_policies(self, inst, request_):
+        assert inst.forget(request_) == []
+
+    def test_forget_return_headers_of_all_policies(
+        self, inst, request_, policy, other_policy):
+        inst.policies['route1'] = policy
+        policy.forget.return_value = [('1', '1')]
+        inst.policies['route2'] = other_policy
+        other_policy.forget.return_value = [('2', '2')]
+        assert inst.forget(request_) == [('1','1'), ('2', '2')]
 
 
 class IncludemeIntegrationTest(unittest.TestCase):

--- a/src/adhocracy_core/adhocracy_core/authorization/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/__init__.py
@@ -209,7 +209,9 @@ def create_fake_god_request(registry):
 
 
 def includeme(config):
-    """Register adapter to extend the root acm."""
+    """Register adapter to extend the root acm and add authorization policy."""
     config.registry.registerAdapter(acm_extension_adapter,
                                     (Interface,),
                                     IRootACMExtension)
+    authz_policy = RoleACLAuthorizationPolicy()
+    config.set_authorization_policy(authz_policy)

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -19,6 +19,10 @@ from substanced.interfaces import ReferenceClass
 from substanced.interfaces import IUserLocator
 from substanced.interfaces import IService
 from substanced.interfaces import IWorkflow
+from substanced.sdi import MANAGE_ROUTE_NAME
+
+
+SDI_ROUTE_NAME = MANAGE_ROUTE_NAME
 
 
 def namedtuple(typename, field_names, verbose=False, rename=False):

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -370,6 +370,20 @@ class UserLocatorAdapter(object):
         return sorted(list(roleids))
 
 
+def get_user(request: Request) -> IUser:
+    """Get authenticated user, meant to use as request method 'user'."""
+    userid = request.authenticated_userid
+    if userid is None:
+        return None
+    adapter = request.registry.queryMultiAdapter((request.context, request),
+                                                 IRolesUserLocator)
+    if adapter is None:
+        return None
+    else:
+        user = adapter.get_user_by_userid(userid)
+        return user
+
+
 def groups_and_roles_finder(userid: str, request: Request) -> list:
     """A Pyramid authentication policy groupfinder callback."""
     with statsd_timer('authentication.groups', rate=.1):

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -1,5 +1,6 @@
 """Principal types (user/group) and helpers to search/get user information."""
 from logging import getLogger
+from pytz import timezone
 
 from pyramid.registry import Registry
 from pyramid.traversal import find_resource
@@ -118,6 +119,10 @@ class User(Pool):
         self.group_ids = []
         """Readonly :term:`group_id`s for this user."""
         self.hidden = True
+
+    @property
+    def timezone(self):  # be compatible to substanced
+        return timezone(self.tzname)
 
     def activate(self, active: bool=True):
         """

--- a/src/adhocracy_core/adhocracy_core/resources/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/subscriber.py
@@ -49,7 +49,6 @@ from adhocracy_core.utils import find_graph
 from adhocracy_core.utils import get_changelog_metadata
 from adhocracy_core.utils import get_iresource
 from adhocracy_core.utils import get_modification_date
-from adhocracy_core.utils import get_user
 from adhocracy_core.utils import get_visibility_change
 from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.sheets.metadata import IMetadata
@@ -70,7 +69,7 @@ def update_modification_date_modified_by(event):
     appstruct = {}
     appstruct['modification_date'] = get_modification_date(event.registry)
     if event.request is not None:
-        appstruct['modified_by'] = get_user(event.request)
+        appstruct['modified_by'] = event.request.user
     sheet.set(appstruct,
               send_event=False,
               omit_readonly=False,

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -590,3 +590,24 @@ class TestDeletePasswordResets:
         mock_is_older.return_value = False
         self.call_fut(request_, 7)
         assert 'reset' in resets
+
+
+class TestGetUser:
+
+    def call_fut(self, *args):
+        from .principal import get_user
+        return get_user(*args)
+
+    def test_return_none_if_no_authenticated_user(self, request_):
+        request_.authenticated_userid = None
+        assert self.call_fut(request_) is None
+
+    def test_return_none_if_user_no_locator(self, request_):
+        request_.authenticated_userid = 'userid'
+        assert self.call_fut(request_) is None
+
+    def test_return_user_resource(self, request_, mock_user_locator):
+        user = testing.DummyResource()
+        request_.authenticated_userid = 'userid'
+        mock_user_locator.get_user_by_userid.return_value = user
+        assert self.call_fut(request_) == user

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -124,6 +124,7 @@ class TestUser:
 
     @mark.usefixtures('integration')
     def test_create(self, meta, registry, principals):
+        from pytz import timezone
         from zope.interface.verify import verifyObject
         from adhocracy_core import sheets
         appstructs = {
@@ -144,6 +145,7 @@ class TestUser:
         assert user.password.startswith('$2')
         assert user.tzname == 'UTC'
         assert user.roles == []
+        assert user.timezone == timezone(user.tzname)
 
 
 class TestGroups:

--- a/src/adhocracy_core/adhocracy_core/resources/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_subscriber.py
@@ -416,16 +416,14 @@ class TestUpdateModificationDate:
         from adhocracy_core.sheets.metadata import IMetadata
         now = datetime.now()
         monkeypatch.setattr(subscriber, 'get_modification_date', lambda x: now)
-        user = object()
-        monkeypatch.setattr(subscriber, 'get_user', lambda x: user)
         register_sheet(context, mock_sheet, registry, isheet=IMetadata)
-        request = testing.DummyResource()
+        request = testing.DummyResource(user=object())
         event = testing.DummyResource(object=context,
                                       registry=registry,
                                       request=request)
         self.call_fut(event)
         assert mock_sheet.set.call_args[0][0] == {'modification_date': now,
-                                                  'modified_by': user}
+                                                  'modified_by': request.user}
         assert mock_sheet.set.call_args[1] == {'send_event': False,
                                                'omit_readonly': False}
 

--- a/src/adhocracy_core/adhocracy_core/rest/exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/exceptions.py
@@ -14,6 +14,7 @@ from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.traversal import resource_path
 from pyramid.view import view_config
 
+from adhocracy_core.authentication import UserTokenHeader
 from adhocracy_core.exceptions import AutoUpdateNoForkAllowedError
 from adhocracy_core.interfaces import error_entry
 from adhocracy_core.schema import References
@@ -179,8 +180,8 @@ def _get_filtered_request_headers(request) -> []:
     """Filter secret parts of the request headers."""
     headers = {}
     for key, value in request.headers.items():
-        if 'X-User-Token' in key:
-            headers['X-User-Token'] = '<hidden>'
+        if key in [UserTokenHeader, 'Cookie']:
+            headers[key] = '<hidden>'
         else:
             headers[key] = value
     return headers

--- a/src/adhocracy_core/adhocracy_core/rest/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/subscriber.py
@@ -4,10 +4,12 @@ from pyramid.events import NewResponse
 
 def add_cors_headers(event):
     """Add CORS headers to response."""
+    origin = event.request.headers.get('Origin', '*')
     event.response.headers.update({
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers':
-        'Origin, Content-Type, Accept, X-User-Path, X-User-Token',
+        'Access-Control-Allow-Origin': origin,
+        'Access-Control-Allow-Headers': 'Origin, Content-Type, Accept, '
+                                        'X-User-Path, X-User-Token',
+        'Access-Control-Allow-Credentials': 'true',
         'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS',
     })
 

--- a/src/adhocracy_core/adhocracy_core/rest/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/subscriber.py
@@ -9,7 +9,7 @@ def add_cors_headers(event):
     if _is_api_request(event.request):
         _set_cors_header(event.request, event.response)
     else:
-        return
+        _set_frame_options_header(event.response)
 
 
 def _set_cors_header(request: IRequest, response: IResponse):
@@ -21,6 +21,10 @@ def _set_cors_header(request: IRequest, response: IResponse):
         'Access-Control-Allow-Credentials': 'true',
         'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS',
     })
+
+
+def _set_frame_options_header(response: IResponse):
+    response.headers.update({'X-Frame-Options': 'DENY'})
 
 
 def _is_api_request(request: IRequest) -> bool:

--- a/src/adhocracy_core/adhocracy_core/rest/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/subscriber.py
@@ -1,9 +1,12 @@
 """Subscriber to modify the http response object."""
+from pyramid.interfaces import IRequest
 from pyramid.events import NewResponse
 
 
 def add_cors_headers(event):
-    """Add CORS headers to response."""
+    """Add CORS headers to response for api requests."""
+    if not _is_api_request(event.request):
+        return
     origin = event.request.headers.get('Origin', '*')
     event.response.headers.update({
         'Access-Control-Allow-Origin': origin,
@@ -12,6 +15,12 @@ def add_cors_headers(event):
         'Access-Control-Allow-Credentials': 'true',
         'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS',
     })
+
+
+def _is_api_request(request: IRequest) -> bool:
+    # assuming api requests have no route
+    route_name = getattr(request.matched_route, 'name', None)
+    return route_name is None
 
 
 def includeme(config):

--- a/src/adhocracy_core/adhocracy_core/rest/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/subscriber.py
@@ -1,14 +1,20 @@
 """Subscriber to modify the http response object."""
 from pyramid.interfaces import IRequest
+from pyramid.interfaces import IResponse
 from pyramid.events import NewResponse
 
 
 def add_cors_headers(event):
     """Add CORS headers to response for api requests."""
-    if not _is_api_request(event.request):
+    if _is_api_request(event.request):
+        _set_cors_header(event.request, event.response)
+    else:
         return
-    origin = event.request.headers.get('Origin', '*')
-    event.response.headers.update({
+
+
+def _set_cors_header(request: IRequest, response: IResponse):
+    origin = request.headers.get('Origin', '*')
+    response.headers.update({
         'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Headers': 'Origin, Content-Type, Accept, '
                                         'X-User-Path, X-User-Token',

--- a/src/adhocracy_core/adhocracy_core/rest/test_exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_exceptions.py
@@ -106,6 +106,11 @@ class TestJSONHTTPException:
         self.make_one([], request_)
         assert "{'X-User-Token': '<hidden>'}" in str(log)
 
+    def test_log_but_hide_cookies_in_headers(self, request_, log):
+        request_.headers['Cookie'] = 'auth=secret'
+        self.make_one([], request_)
+        assert "{'Cookie': '<hidden>'}" in str(log)
+
 
 @mark.usefixtures('log')
 class TestHandleErrorX0XException:

--- a/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
@@ -3,19 +3,28 @@ from pytest import fixture
 from pytest import mark
 
 
-def test_add_cors_headers(context):
+def test_add_cors_headers(request_):
     from .subscriber import add_cors_headers
-    headers = {}
-    response = testing.DummyResource(headers=headers)
-    event = testing.DummyResource(response=response)
-
+    response = testing.DummyResource(headers={})
+    event = testing.DummyResource(response=response,
+                                  request=request_)
     add_cors_headers(event)
-
-    assert headers == \
+    assert response.headers == \
         {'Access-Control-Allow-Origin': '*',
-         'Access-Control-Allow-Headers':
-         'Origin, Content-Type, Accept, X-User-Path, X-User-Token',
+         'Access-Control-Allow-Headers': 'Origin, Content-Type, Accept,'
+                                         ' X-User-Path, X-User-Token',
+         'Access-Control-Allow-Credentials': 'true',
          'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS'}
+
+
+def test_add_cors_headers_use_request_origin_as_allow_origin(request_):
+    from .subscriber import add_cors_headers
+    response = testing.DummyResource(headers={})
+    request_.headers = {'Origin': 'http://x.org'}
+    event = testing.DummyResource(response=response,
+                                  request=request_)
+    add_cors_headers(event)
+    assert response.headers['Access-Control-Allow-Origin'] == 'http://x.org'
 
 
 @fixture()

--- a/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
@@ -9,7 +9,8 @@ def mock_route(mocker):
     return mocker.Mock(spec=IRoute)
 
 
-def test_add_cors_headers_ignore_if_no_api_request(request_, mock_route):
+def test_add_cors_headers_set_x_frame_options_if_no_api_request(request_,
+                                                                mock_route):
     from .subscriber import add_cors_headers
     mock_route.name = 'route_name'
     request_.matched_route = mock_route
@@ -17,7 +18,7 @@ def test_add_cors_headers_ignore_if_no_api_request(request_, mock_route):
     event = testing.DummyResource(response=response,
                                   request=request_)
     add_cors_headers(event)
-    assert response.headers == {}
+    assert response.headers == {'X-Frame-Options': 'DENY'}
 
 
 def test_add_cors_headers(request_):

--- a/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
@@ -3,6 +3,23 @@ from pytest import fixture
 from pytest import mark
 
 
+@fixture
+def mock_route(mocker):
+    from pyramid.interfaces import IRoute
+    return mocker.Mock(spec=IRoute)
+
+
+def test_add_cors_headers_ignore_if_no_api_request(request_, mock_route):
+    from .subscriber import add_cors_headers
+    mock_route.name = 'route_name'
+    request_.matched_route = mock_route
+    response = testing.DummyResource(headers={})
+    event = testing.DummyResource(response=response,
+                                  request=request_)
+    add_cors_headers(event)
+    assert response.headers == {}
+
+
 def test_add_cors_headers(request_):
     from .subscriber import add_cors_headers
     response = testing.DummyResource(headers={})

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -898,7 +898,7 @@ class TestLoginUserName:
 
     def test_post_without_token_authentication_policy(self, request, context):
         inst = self.make_one(context, request)
-        with pytest.raises(KeyError):
+        with pytest.raises(IndexError):
             inst.post()
 
     def test_post_with_token_authentication_policy(self, request, context, mock_authpolicy):
@@ -926,7 +926,7 @@ class TestLoginEmailView:
 
     def test_post_without_token_authentication_policy(self, request, context):
         inst = self.make_one(context, request)
-        with pytest.raises(KeyError):
+        with pytest.raises(IndexError):
             inst.post()
 
     def test_post_with_token_authentication_policy(self, request, context, mock_authpolicy):

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -898,7 +898,7 @@ class TestLoginUserName:
 
     def test_post_without_token_authentication_policy(self, request, context):
         inst = self.make_one(context, request)
-        with pytest.raises(IndexError):
+        with pytest.raises(KeyError):
             inst.post()
 
     def test_post_with_token_authentication_policy(self, request, context, mock_authpolicy):
@@ -907,6 +907,26 @@ class TestLoginUserName:
         assert inst.post() == {'status': 'success',
                                'user_path': 'http://example.com/',
                                'user_token': 'token'}
+
+    def test_post_with_cookie_authentication_policy(
+        self, request, context, mock_authpolicy):
+        mock_authpolicy.remember.return_value = [('Set-Cookie', 'value;'),
+                                                 ('X-User-Token', 'token')]
+        inst = self.make_one(context, request)
+        inst.post()
+        assert ('X-User-Token', 'token') not in request.response.headers.items()
+        assert ('Set-Cookie', 'value;') in request.response.headers.items()
+
+    def test_post_with_cookie_authentication_policy_and_https(
+        self, request, context, mock_authpolicy):
+        request.scheme = 'https'
+        mock_authpolicy.remember.return_value = [('Set-Cookie', 'value;'),
+                                                 ('X-User-Token', 'token')]
+        inst = self.make_one(context, request)
+        inst = self.make_one(context, request)
+        inst.post()
+        assert ('Set-Cookie', 'value;Secure;') in request.response.headers.items()
+
 
     def test_options(self, request, context):
         inst = self.make_one(context, request)
@@ -926,7 +946,7 @@ class TestLoginEmailView:
 
     def test_post_without_token_authentication_policy(self, request, context):
         inst = self.make_one(context, request)
-        with pytest.raises(IndexError):
+        with pytest.raises(KeyError):
             inst.post()
 
     def test_post_with_token_authentication_policy(self, request, context, mock_authpolicy):

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -58,7 +58,6 @@ from adhocracy_core.sheets.pool import IPool as IPoolSheet
 from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.sheets.tags import ITags
 from adhocracy_core.utils import extract_events_from_changelog_metadata
-from adhocracy_core.utils import get_user
 from adhocracy_core.utils import is_batchmode
 from adhocracy_core.utils import to_dotted_name
 from adhocracy_core.utils import is_created_in_current_transaction
@@ -309,7 +308,7 @@ class PoolRESTView(SimpleRESTView):
         validated = self.request.validated
         kwargs = dict(parent=self.context,
                       appstructs=validated.get('data', {}),
-                      creator=get_user(self.request),
+                      creator=self.request.user,
                       root_versions=validated.get('root_versions', []),
                       request=self.request,
                       is_batchmode=is_batchmode(self.request),
@@ -812,7 +811,7 @@ class ReportAbuseView:
         messenger = self.request.registry.messenger
         messenger.send_abuse_complaint(url=self.request.validated['url'],
                                        remark=self.request.validated['remark'],
-                                       user=get_user(self.request))
+                                       user=self.request.user)
         return ''
 
 
@@ -849,10 +848,11 @@ class MessageUserView:
         """Send a message to another user."""
         messenger = self.request.registry.messenger
         data = self.request.validated
+        user = self.request.user
         messenger.send_message_to_user(recipient=data['recipient'],
                                        title=data['title'],
                                        text=data['text'],
-                                       from_user=get_user(self.request))
+                                       from_user=user)
         return ''
 
 

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -14,6 +14,7 @@ from zope.interface.interfaces import IInterface
 from zope.interface import Interface
 import colander
 
+from adhocracy_core.authentication import UserTokenHeader
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import IItem
 from adhocracy_core.interfaces import IItemVersion
@@ -724,15 +725,29 @@ class LoginUsernameView:
 
 
 def _login_user(request: IRequest) -> dict:
-    """Log-in a user and return a response indicating success."""
+    """Set cookies and return a data for token header authentication."""
     user = request.validated['user']
     userid = resource_path(user)
-    authentication_headers = dict(remember(request, userid))
-    url = request.resource_url(user)
-    token = authentication_headers['X-User-Token']
+    headers = remember(request, userid)
+    _set_sdi_auth_cookies(headers, request)
+    cstruct = _get_api_auth_data(headers, request, user)
+    return cstruct
+
+
+def _set_sdi_auth_cookies(headers: [tuple], request: IRequest):
+    cookie_headers = [(x, y) for x, y in headers if x == 'Set-Cookie']
+    request.response.headers.extend(cookie_headers)
+
+
+def _get_api_auth_data(headers: [tuple], request: IRequest, user: IResource)\
+        -> dict:
+    token_header = [(x, y) for x, y in headers if x == UserTokenHeader][0]
+    user_url = request.resource_url(user)
+    # TODO: use colander schema to create cstruct
     return {'status': 'success',
-            'user_path': url,
-            'user_token': token}
+            'user_path': user_url,
+            'user_token': token_header[1],
+            }
 
 
 @view_defaults(

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -735,18 +735,28 @@ def _login_user(request: IRequest) -> dict:
 
 
 def _set_sdi_auth_cookies(headers: [tuple], request: IRequest):
-    cookie_headers = [(x, y) for x, y in headers if x == 'Set-Cookie']
+    cookie_headers = []
+    force_secure = request.scheme.startswith('https')
+    for name, value in headers:
+        if name != 'Set-Cookie':
+            continue
+        header = (name, value)
+        has_secure_flag = 'Secure;' in value
+        if force_secure and not has_secure_flag:  # pragma: no branch
+            header = (name, value + 'Secure;')
+        cookie_headers.append(header)
     request.response.headers.extend(cookie_headers)
 
 
 def _get_api_auth_data(headers: [tuple], request: IRequest, user: IResource)\
         -> dict:
-    token_header = [(x, y) for x, y in headers if x == UserTokenHeader][0]
+    token_headers = dict([(x, y) for x, y in headers if x == UserTokenHeader])
+    token = token_headers[UserTokenHeader]
     user_url = request.resource_url(user)
     # TODO: use colander schema to create cstruct
     return {'status': 'success',
             'user_path': user_url,
-            'user_token': token_header[1],
+            'user_token': token,
             }
 
 

--- a/src/adhocracy_core/adhocracy_core/sdi/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/__init__.py
@@ -1,4 +1,4 @@
-"""Admin interface based on substanced, url prefix is 'manage'."""
+"""Admin interface based on substanced (sdi), url prefix is '/manage'."""
 from pyramid.config import Configurator
 from substanced.content import _ContentTypePredicate
 from substanced.sdi import MANAGE_ROUTE_NAME

--- a/src/adhocracy_core/adhocracy_core/sdi/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/__init__.py
@@ -1,0 +1,44 @@
+"""Admin interface based on substanced, url prefix is 'manage'."""
+from pyramid.config import Configurator
+from substanced.content import _ContentTypePredicate
+from substanced.sdi import MANAGE_ROUTE_NAME
+from substanced.sdi import sdiapi
+from substanced.sdi import add_mgmt_view
+
+
+def includeme(config):
+    """Register sdi admin interface."""
+    settings = config.registry.settings
+    config.add_directive('add_mgmt_view', add_mgmt_view, action_wrap=False)
+    _add_sdi_assets(config)
+    _add_manage_route(settings, config)
+    _add_sdi_request_extensions(config)
+    config.add_view_predicate('content_type', _ContentTypePredicate)
+    config.override_asset(to_override='substanced.sdi:templates/',
+                          override_with='substanced.sdi.views:templates/')
+    config.include('substanced.folder')
+    config.scan('substanced.db.views')
+    config.scan('.views.manage')
+    config.scan('.views.login')
+    config.scan('.views.contents')
+    config.scan('.views.services')
+
+
+def _add_sdi_assets(config: Configurator):
+    year = 86400 * 365
+    config.add_static_view('deformstatic', 'deform:static', cache_max_age=year)
+    config.add_static_view('sdistatic',
+                           'substanced.sdi:static',
+                           cache_max_age=year)
+
+
+def _add_manage_route(settings: dict, config: Configurator):
+    manage_prefix = settings.get('substanced.manage_prefix', '/manage')
+    manage_pattern = manage_prefix + '*traverse'
+    config.add_route(MANAGE_ROUTE_NAME, manage_pattern)
+
+
+def _add_sdi_request_extensions(config: Configurator):
+    config.add_request_method(sdiapi, reify=True)
+    config.add_permission('sdi.edit-properties')  # used by sheet machinery
+    config.set_request_property(lambda r: r.user.locale, name='_LOCALE_')

--- a/src/adhocracy_core/adhocracy_core/sdi/views/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/__init__.py
@@ -1,1 +1,1 @@
-"""Views for the sdi admint interface."""
+"""Views for the admin interface."""

--- a/src/adhocracy_core/adhocracy_core/sdi/views/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/__init__.py
@@ -1,0 +1,1 @@
+"""Views for the sdi admint interface."""

--- a/src/adhocracy_core/adhocracy_core/sdi/views/contents.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/contents.py
@@ -1,0 +1,22 @@
+"""Contents tab."""
+from substanced.folder.views import FolderContents
+from substanced.folder.views import folder_contents_views
+
+
+@folder_contents_views()
+class AdhocracyFolderContents(FolderContents):
+    """Default contents tab."""
+
+    def sdi_addable_content(self):
+        registry = self.request.registry
+        introspector = registry.introspector
+        cts = []
+        meta_addable = self.request.registry.content\
+            .get_resources_meta_addable(self.context, self.request)
+        content_types_addable = [m.iresource.__identifier__ for m
+                                 in meta_addable]
+        for data in introspector.get_category('substance d content types'):
+            intr = data['introspectable']
+            if intr['content_type'] in content_types_addable:
+                cts.append(data)
+        return cts

--- a/src/adhocracy_core/adhocracy_core/sdi/views/login.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/login.py
@@ -1,0 +1,17 @@
+"""Logout page."""
+from pyramid.httpexceptions import HTTPFound
+from pyramid.security import forget
+from pyramid.security import NO_PERMISSION_REQUIRED
+
+from substanced.sdi import mgmt_view
+
+
+@mgmt_view(name='logout',
+           tab_condition=False,
+           permission=NO_PERMISSION_REQUIRED
+           )
+def logout(request):
+    """Logout user (remove authentication cookies)."""
+    headers = forget(request)
+    location = request.sdiapi.mgmt_path(request.context)
+    return HTTPFound(location=location, headers=headers)

--- a/src/adhocracy_core/adhocracy_core/sdi/views/login.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/login.py
@@ -12,6 +12,7 @@ from substanced.event import LoggedIn
 from substanced.sdi import mgmt_view
 
 from adhocracy_core.interfaces import IRolesUserLocator
+from adhocracy_core.rest.views import get_set_cookie_headers
 
 
 @mgmt_view(name='login',
@@ -55,10 +56,11 @@ def login(context, request):
             if user is not None:
                 request.session.pop('sdi.came_from', None)
                 headers = remember(request, resource_path(user))
+                cookie_headers = get_set_cookie_headers(headers, request)
                 msg = LoggedIn(login, user, context, request)
                 request.registry.notify(msg)
                 return HTTPFound(location=came_from,
-                                 headers=headers)
+                                 headers=cookie_headers)
             request.sdiapi.flash('Failed login', 'danger')
 
     # Pass this through FBO views (e.g., forbidden) which use its macros.

--- a/src/adhocracy_core/adhocracy_core/sdi/views/login.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/login.py
@@ -1,9 +1,75 @@
 """Logout page."""
+from pyramid.authentication import Authenticated
 from pyramid.httpexceptions import HTTPFound
-from pyramid.security import forget
+from pyramid.httpexceptions import HTTPForbidden
+from pyramid.renderers import get_renderer
 from pyramid.security import NO_PERMISSION_REQUIRED
-
+from pyramid.security import remember
+from pyramid.security import forget
+from pyramid.session import check_csrf_token
+from pyramid.traversal import resource_path
+from substanced.event import LoggedIn
 from substanced.sdi import mgmt_view
+
+from adhocracy_core.interfaces import IRolesUserLocator
+
+
+@mgmt_view(name='login',
+           renderer='substanced.sdi.views:templates/login.pt',
+           tab_condition=False,
+           permission=NO_PERMISSION_REQUIRED
+           )
+@mgmt_view(renderer='substanced.sdi.views:templates/login.pt',
+           context=HTTPForbidden,
+           permission=NO_PERMISSION_REQUIRED,
+           tab_condition=False
+           )
+@mgmt_view(renderer='substanced.sdi.views:templates/forbidden.pt',
+           context=HTTPForbidden,
+           permission=NO_PERMISSION_REQUIRED,
+           effective_principals=Authenticated,
+           tab_condition=False
+           )
+def login(context, request):
+    """Login form."""
+    login_url = request.sdiapi.mgmt_path(request.context, 'login')
+    referrer = request.url
+    if '/auditstream-sse' in referrer:
+        return HTTPForbidden()
+    if login_url in referrer:
+        referrer = request.sdiapi.mgmt_path(request.virtual_root)
+    came_from = request.session.setdefault('sdi.came_from', referrer)
+    login = ''
+    password = ''
+    if 'form.submitted' in request.params:
+        try:
+            check_csrf_token(request)
+        except:
+            request.sdiapi.flash('Failed login (CSRF)', 'danger')
+        else:
+            login = request.params['login']
+            password = request.params['password']
+            adapter = request.registry.queryMultiAdapter((context, request),
+                                                         IRolesUserLocator)
+            user = adapter.get_user_by_login(login)
+            if user is not None:
+                request.session.pop('sdi.came_from', None)
+                headers = remember(request, resource_path(user))
+                msg = LoggedIn(login, user, context, request)
+                request.registry.notify(msg)
+                return HTTPFound(location=came_from,
+                                 headers=headers)
+            request.sdiapi.flash('Failed login', 'danger')
+
+    # Pass this through FBO views (e.g., forbidden) which use its macros.
+    template = get_renderer('substanced.sdi.views:templates/login.pt')\
+        .implementation()
+    return dict(url=request.sdiapi.mgmt_path(request.virtual_root, '@@login'),
+                came_from=came_from,
+                login=login,
+                password=password,
+                login_template=template,
+                )
 
 
 @mgmt_view(name='logout',

--- a/src/adhocracy_core/adhocracy_core/sdi/views/manage.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/manage.py
@@ -1,0 +1,31 @@
+"""Base views."""
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.httpexceptions import HTTPFound
+from pyramid.httpexceptions import HTTPForbidden
+
+from substanced.sdi import mgmt_view
+from substanced.sdi import sdi_mgmt_views
+
+
+class ManagementViews(object):
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    @mgmt_view(tab_condition=False,
+               permission=NO_PERMISSION_REQUIRED,
+               )
+    @mgmt_view(name='manage_main',
+               tab_condition=False,
+               permission=NO_PERMISSION_REQUIRED,
+               )
+    def manage_main(self):
+        view_data = sdi_mgmt_views(self.context, self.request)
+        if not view_data:
+            raise HTTPForbidden()
+        else:
+            view_name = '@@%s' % (view_data[0]['view_name'],)
+            location = self.request.sdiapi.mgmt_path(self.request.context,
+                                                     view_name)
+            return HTTPFound(location=location)

--- a/src/adhocracy_core/adhocracy_core/sdi/views/manage.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/manage.py
@@ -23,7 +23,10 @@ class ManagementViews(object):
     def manage_main(self):
         view_data = sdi_mgmt_views(self.context, self.request)
         if not view_data:
-            raise HTTPForbidden()
+            self.request.session['came_from'] = self.request.url
+            location = self.request.sdiapi.mgmt_path(self.request.virtual_root,
+                                                     '@@login')
+            raise HTTPForbidden(location=location)
         else:
             view_name = '@@%s' % (view_data[0]['view_name'],)
             location = self.request.sdiapi.mgmt_path(self.request.context,

--- a/src/adhocracy_core/adhocracy_core/sdi/views/services.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/services.py
@@ -1,0 +1,14 @@
+"""Services tab."""
+from substanced.folder.views import FolderServices
+from substanced.folder.views import folder_contents_views
+from substanced.folder.views import RIGHT
+from substanced.sdi import _
+
+
+@folder_contents_views(name='services',
+                       tab_title=_('Services'),
+                       tab_near=RIGHT,
+                       view_permission='sdi.view-services',
+                       )
+class AdhocracyFolderServices(FolderServices):
+    """Services tab."""

--- a/src/adhocracy_core/adhocracy_core/sdi/views/templates/rename.pt
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/templates/rename.pt
@@ -1,0 +1,58 @@
+<div metal:use-macro="request.sdiapi.main_template" i18n:domain="substanced">
+
+  <div metal:fill-slot="main">
+    <form action="@@${request.view_name}" method="POST">
+      <fieldset>
+        <input type="hidden"
+               name="csrf_token" 
+               value="${request.session.get_csrf_token()}"/>
+
+        <div class="panel panel-default">
+          <div class="panel-heading" i18n:translate="">Rename Items</div>
+          <div class="panel-body">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th i18n:translate="">Old Name</th>
+                  <th i18n:translate="">New Name</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr tal:repeat="item torename">
+                  <td width="30%">${item.__name__}</td>
+                  <td width="70%">
+                    <input type="hidden"
+                           name="item-rename"
+                           value="${item.__name__}" />
+                    <input type="text"
+                           name="${item.__name__}"
+                           value="${item.__name__}" />
+                  </td>
+                </tr>
+              </tbody>
+
+            </table>
+
+            <div class="form-actions">
+              <button id="rename"
+                      name="form.rename_finish"
+                      type="submit"
+                      class="btn btn-primary"
+                      value="rename_finish">
+              <tal:block i18n:translate="">Rename all</tal:block>
+              </button>
+              <button id="duplicate"
+                      name="form.rename_finish"
+                      type="submit"
+                      class="btn"
+                      value="cancel">
+              <tal:block i18n:translate="">Cancel</tal:block>
+              </button>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </form>
+  </div>
+
+</div>

--- a/src/adhocracy_core/adhocracy_core/sheets/rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/rate.py
@@ -21,7 +21,6 @@ from adhocracy_core.schema import Integer
 from adhocracy_core.schema import Reference as ReferenceSchema
 from adhocracy_core.schema import PostPool
 from adhocracy_core.sheets import sheet_meta
-from adhocracy_core.utils import get_user
 
 
 class IRate(IPredicateSheet, ISheetReferenceAutoUpdateMarker):
@@ -120,7 +119,7 @@ class RateSchema(MappingSchema):
 def create_validate_subject(request) -> callable:
     """Create validator to ensure value['subject'] is current user."""
     def validator(node, value):
-        user = get_user(request)
+        user = request.user
         if user is None or user != value['subject']:
             error = Invalid(node, msg='')
             error.add(Invalid(node['subject'],

--- a/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
@@ -141,22 +141,15 @@ class TestCreateValidateSubject:
         from .rate import create_validate_subject
         return create_validate_subject(*args)
 
-    @fixture
-    def mock_get_user(self, mocker):
-        from . import rate
-        mock_get_user = mocker.patch.object(rate, 'get_user')
-        return mock_get_user
-
-    def test_ignore_if_subject_is_loggedin_user(self, node, request_, mock_get_user):
+    def test_ignore_if_subject_is_loggedin_user(self, node, request_):
         user = testing.DummyResource()
-        mock_get_user.return_value = user
+        request_.user = user
         validator = self.call_fut(request_)
         assert validator(node, {'subject': user}) is None
 
-    def test_ignore_if_subject_is_not_loggedin_user(self, node, request_,
-                                                    mock_get_user):
+    def test_ignore_if_subject_is_not_loggedin_user(self, node, request_):
         user = testing.DummyResource()
-        mock_get_user.return_value = None
+        request_.user = None
         validator = self.call_fut(request_)
         with raises(colander.Invalid):
             node['subject'] = Mock()

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -246,6 +246,7 @@ def request_():
     request.registry.settings = {}
     request.user = None
     request.scheme = 'http'
+    request.matched_route = None
     return request
 
 

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -244,6 +244,7 @@ def request_():
     """
     request = DummyRequest()
     request.registry.settings = {}
+    request.user = None
     return request
 
 

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -245,6 +245,7 @@ def request_():
     request = DummyRequest()
     request.registry.settings = {}
     request.user = None
+    request.scheme = 'http'
     return request
 
 

--- a/src/adhocracy_core/adhocracy_core/utils/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/utils/__init__.py
@@ -13,7 +13,6 @@ from pyramid.compat import is_nonstr_iter
 from pyramid.location import lineage
 from pyramid.request import Request
 from pyramid.registry import Registry
-from pyramid.traversal import find_resource
 from pyramid.traversal import resource_path
 from substanced.util import acquire
 from substanced.util import find_catalog
@@ -116,19 +115,6 @@ def exception_to_str(err: Exception):
         return '{}: {}'.format(name, desc)
     else:
         return name
-
-
-def get_user(request: Request) -> object:
-    """Return resource object of the authenticated user.
-
-    This requires that :func:`pyramid.request.Request.authenticated_userid`
-    returns a resource path.
-    """
-    user_path = request.authenticated_userid
-    try:
-        return find_resource(request.root, str(user_path))
-    except KeyError:
-        return None
 
 
 def normalize_to_tuple(context) -> tuple:

--- a/src/adhocracy_core/adhocracy_core/utils/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/utils/test_init.py
@@ -111,37 +111,6 @@ def test_exception_to_str_runtime_error():
     assert err_string == 'RuntimeError'
 
 
-class GetUserUnitTest(unittest.TestCase):
-
-    def make_one(self, request):
-        from adhocracy_core.utils import get_user
-        return get_user(request)
-
-    def setUp(self):
-        user = testing.DummyResource()
-        context = testing.DummyResource()
-        context['user'] = user
-        self.context = context
-
-        class DummyRequest(testing.DummyRequest):
-            @property
-            def authenticated_userid(self):
-                return self._dummy_userid
-        self.request = DummyRequest(root=context,
-                                    _dummy_userid=None)
-
-    def test_with_user_id_is_None(self):
-        assert self.make_one(self.request) is None
-
-    def test_with_user_id_is_not_resource_path(self):
-        assert self.make_one(self.request) is None
-
-    def test_with_user_id(self):
-        user = self.context['user']
-        self.request._dummy_userid = '/user'
-        assert self.make_one(self.request) == user
-
-
 class TestNormalizeToTuple:
 
     def call_fut(self, value):

--- a/src/adhocracy_core/docs/sdi.rst
+++ b/src/adhocracy_core/docs/sdi.rst
@@ -1,0 +1,45 @@
+# doctest: +ELLIPSIS
+# doctest: +NORMALIZE_WHITESPACE
+
+Technical Admin interface (sdi).
+================================
+
+A generic admin interface is provided based on :mod:`substanced.sdi`.
+
+First you have to start adhocracy
+
+    >>> from webtest import TestApp
+    >>> log = getfixture('log')
+    >>> app_router = getfixture('app_router')
+    >>> testapp = TestApp(app_router)
+    >>> rest_url = 'http://localhost'
+    >>> xhr_headers = {'X-REQUESTED-WITH': 'XMLHttpRequest'}
+
+If you got the sdi without login you get an error::
+
+    >>> resp = testapp.get(rest_url + '/manage', headers=xhr_headers, expect_errors=True)
+    >>> resp.status_code
+    403
+
+If you login as god user with the frontend application::
+
+    >>> data = {'name': 'god',
+    ...         'password': 'password'}
+    >>> resp = testapp.post_json('/login_username', data, headers=xhr_headers)
+
+you are redirected to the sdi contents listing::
+
+    >>> resp = testapp.get(rest_url + '/manage')
+    >>> resp.status_code
+    302
+    >>> resp.location
+    '.../manage/@@contents'
+
+    >>> html = testapp.get(resp.location).text
+    >>> '/adhocracy' in html
+    True
+
+All following post requests are guarded with csrf tokens::
+
+    >>> 'csrfToken' in html
+    True

--- a/src/adhocracy_core/docs/sdi.rst
+++ b/src/adhocracy_core/docs/sdi.rst
@@ -1,8 +1,8 @@
 # doctest: +ELLIPSIS
 # doctest: +NORMALIZE_WHITESPACE
 
-Technical Admin interface (sdi).
-================================
+Admin interface (sdi)
+=====================
 
 A generic admin interface is provided based on :mod:`substanced.sdi`.
 

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -57,7 +57,7 @@ z3c.recipe.mkdir = 0.6
 zc.buildout = 2.4.4
 zc.recipe.egg = 2.0.3
 zdaemon = 4.0.1
-zodbpickle = 0.6.0 
+zodbpickle = 0.6.0
 
 # Required by:
 # ZODB==4.1.0

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Module.ts
@@ -20,6 +20,7 @@ export var register = (angular, config, metaApi) => {
         ])
         .config(["$httpProvider", ($httpProvider) => {
             $httpProvider.interceptors.push(["adhHttpBusy", (adhHttpBusy : AdhHttp.Busy) => adhHttpBusy.createInterceptor()]);
+            $httpProvider.defaults.withCredentials = true;  // allow cookie uthentication for SSO with admin interface
         }])
         .service("adhHttpBusy", ["$q", AdhHttp.Busy])
         .directive("adhHttpBusy", ["adhConfig", "adhHttpBusy", AdhHttp.busyDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Module.ts
@@ -20,7 +20,6 @@ export var register = (angular, config, metaApi) => {
         ])
         .config(["$httpProvider", ($httpProvider) => {
             $httpProvider.interceptors.push(["adhHttpBusy", (adhHttpBusy : AdhHttp.Busy) => adhHttpBusy.createInterceptor()]);
-            $httpProvider.defaults.withCredentials = true;  // allow cookie authentication for SingleSignOn with admin interface
         }])
         .service("adhHttpBusy", ["$q", AdhHttp.Busy])
         .directive("adhHttpBusy", ["adhConfig", "adhHttpBusy", AdhHttp.busyDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Module.ts
@@ -20,7 +20,7 @@ export var register = (angular, config, metaApi) => {
         ])
         .config(["$httpProvider", ($httpProvider) => {
             $httpProvider.interceptors.push(["adhHttpBusy", (adhHttpBusy : AdhHttp.Busy) => adhHttpBusy.createInterceptor()]);
-            $httpProvider.defaults.withCredentials = true;  // allow cookie uthentication for SSO with admin interface
+            $httpProvider.defaults.withCredentials = true;  // allow cookie authentication for SingleSignOn with admin interface
         }])
         .service("adhHttpBusy", ["$q", AdhHttp.Busy])
         .directive("adhHttpBusy", ["adhConfig", "adhHttpBusy", AdhHttp.busyDirective])


### PR DESCRIPTION
#Backend Extensions:
--------------------------

- /manage shows basic SDI (contents and services tab) when loged in as god

Backend internal Changes:  
----------------------------------

- add request property 'user' ,  rm utils.get_user,

Backend API Changes:   Token Header and Cookie based authententication 
-----------------------------------------------------------------------------------------------

We cannot use the existing Token header authentication for the sdi, because its based on  ServerSide Rendering. Possible solution are:

1. addional server to run the sdi:

      ++ easy
      -- even more complicated deployment
      -- no SSO frontend and sdi

2. Cookie based authentication for frontend and sdi

     ++ better security possible , see https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Local_Storage and http://www.stormpath.com/blog/where-to-store-your-jwts-cookies-vs-html5-web-storage/
http://blog.ionic.io/angularjs-authentication/
     ++ SSO frontend and sdi
     -- difficult CORS setup
     -- frontend changes needed

3. Token Header and Cookie based authentication

    ++ easy
    ++ SSO frontend and sdi
    -- less security (more ways to attack) 

4. No SSO, TokenHeader for the REST API and cookie authentication for the SDI

CHANGED: Instead of 3. I choosed 4. in this pull request.  
SSO will be another pull request depending on  #2318 

TODO:

 - [x] cookies are marked as secure when login was over HTTPS (deployment allows only HTTPS access)
 - [x] cookies are http-only
 - [x] cookies are same-site (lets hope other browser will support it)
 - [x] SDI provides an additional login
 - [x] SDI login sets the cookies on `/manage` path
 - [X] CORS headers are absent from `/manage`
 - [x] SDI prevents click-jacking by using `X-FRAME-OPTIONS`
 - [x] no changes to the frontend are made
 - [x] create low-prio SSO pull-request (may need even some other changes first)

