### PR TITLE
handle aborted requests in http/error.ts

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Error.ts
@@ -31,6 +31,13 @@ var extractErrorItems = (code : number, error : IBackendError) : IBackendErrorIt
             description: (<any>error).reason,
             code: code
         }];
+    } else if (!error) {
+        return [{
+            location: "client",
+            name: "abort",
+            description: "the request was aborted before it could reach the server",
+            code: code
+        }];
     } else {
         _.forEach(error.errors, (item) => {
             item.code = code;
@@ -63,8 +70,12 @@ export var logBackendBatchError = (
 
     console.log(response);
 
-    var lastResponse = _.last(response.data.responses);
-    throw extractErrorItems(lastResponse.code, lastResponse.body);
+    if (response.data) {
+        var lastResponse = _.last(response.data.responses);
+        throw extractErrorItems(lastResponse.code, lastResponse.body);
+    } else {
+        throw extractErrorItems(response.status, null);
+    }
 };
 
 


### PR DESCRIPTION
AJAX requests can be aborted, either explicitly (by calling `request.abort()`), by a firewall or browser extension, or because the user navigated away. In this case the request data is `null` and status is 0 (even though I also saw -1 in the wild). [spec](https://www.w3.org/TR/XMLHttpRequest/#the-status-attribute).

Our error handling code expected `data` to have a specific form, so it broke when a request was aborted and data was consequently `null`. I fixed that.

This is somehow related to #2263 because I think it is caused by aborted requests. This does not fix that issue, though.