### PR TITLE
activate pramid_execlog to log stacktrace of internal python errors

### DIFF
--- a/etc/development.ini.in
+++ b/etc/development.ini.in
@@ -13,6 +13,7 @@ pyramid.debug_routematch = false
 pyramid.debug_templates = true
 pyramid.default_locale_name = en
 pyramid.includes =
+    pyramid_exclog
     pyramid_zodbconn
     pyramid_tm
     pyramid_mailer

--- a/etc/test.ini.in
+++ b/etc/test.ini.in
@@ -7,6 +7,7 @@
 use = egg:${adhocracy:backend_package_name}
 pyramid.prevent_http_cache = true
 pyramid.includes =
+    pyramid_exclog
     pyramid_tm
     pyramid_mailer
 zodbconn.uri = memory://


### PR DESCRIPTION
We don't log the full stack trace of python errors, only the short
descripton. With pyramid_execlog all stack traces are logged. This is
usefull for debugging and should be activated on production server if not done otherwise (@slomo)

Mind the stackttrace contains sensitive personal data like
authentication token or cookies.