### PR TITLE
update buildout recipe dependencies

### DIFF
--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -7,10 +7,10 @@ Pygments = 2.0.2
 WebOb = 1.5.1
 WebTest = 2.0.18
 astroid = 1.3.4
-bowerrecipe = 0.1.1
+bowerrecipe = 0.2
 collective.recipe.omelette = 0.16
-collective.recipe.supervisor = 0.19
-collective.recipe.template = 1.11
+collective.recipe.supervisor = 0.20
+collective.recipe.template = 1.13
 contexttimer = 0.3.1
 python-coveralls = 2.5.0
 sh = 1.11
@@ -20,7 +20,7 @@ docutils = 0.12
 flake8 = 2.4.1
 flake8-docstrings = 0.2.1.post1
 flake8-quotes = 0.0.1
-gp.recipe.node = 0.10.28.0
+gp.recipe.node = 0.12.7.1
 hypatia = 0.3
 logilab-common = 0.63.2
 mccabe = 0.3.1
@@ -55,7 +55,7 @@ waitress = 0.8.9
 z3c.checkversions = 0.5
 z3c.recipe.mkdir = 0.6
 zc.buildout = 2.4.4
-zc.recipe.egg = 2.0.1
+zc.recipe.egg = 2.0.3
 zdaemon = 4.0.1
 zodbpickle = 0.6.0 
 
@@ -197,7 +197,6 @@ repoze.lru = 0.6
 
 # Required by:
 # flake8-quotes==0.0.1
-# gp.recipe.phantomjs==1.9.7.2
 # hexagonit.recipe.download==1.7
 # mr.developer==1.31
 # pyramid==1.5.2


### PR DESCRIPTION
bowerrecipe:

	* update bower packages with every buildout run
          (should fix build problems with missing bower dependencies)

collective.recipe.template
gp.recipe.node
zc.rceipe.egg:

        * minor updates