### PR TITLE
Replace CrossWindow factory with a provider

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -154,7 +154,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
     AdhBadgeModule.register(angular);
     AdhCommentModule.register(angular);
     AdhConfigModule.register(angular, config);
-    AdhCrossWindowMessagingModule.register(angular, config.trusted_domains !== []);
+    AdhCrossWindowMessagingModule.register(angular);
     AdhDateTimeModule.register(angular);
     AdhDoneModule.register(angular);
     AdhEmbedModule.register(angular);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../../lib2/types/angular.d.ts"/>
+
 /* tslint:disable:variable-name */
 
 /**
@@ -42,7 +44,7 @@ export interface IService {
 }
 
 
-export class Provider {
+export class Provider implements angular.IServiceProvider {
     public config : IService;
 
     public $get() : IService {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
@@ -33,6 +33,8 @@
  * 10 in particular, but others may be affected.)
  */
 
+/// <reference path="../../../lib2/types/angular.d.ts"/>
+
 import * as _ from "lodash";
 
 import * as AdhConfig from "../Config/Config";
@@ -69,7 +71,7 @@ export interface IService {
     dummy? : boolean;
 }
 
-export class Provider {
+export class Provider implements angular.IServiceProvider {
     public $get;
     private callbacks : ICallback[] = [];
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessaging.ts
@@ -58,34 +58,78 @@ export interface IPostMessageService {
     (data : string, origin : string) : void;
 }
 
+export interface IProvider {
+    registerMessageHandler : (name : string, callback : (data : IMessageData) => void) => void;
+}
+
 export interface IService {
     registerMessageHandler : (name : string, callback : (data : IMessageData) => void) => void;
     postResize : (height : number) => void;
     dummy? : boolean;
 }
 
+export class Provider implements IProvider {
+    public $get;
+    private callbacks : { name : string, callback : (data : IMessageData) => void }[] = [];
+
+    constructor() {
+        var _self = this;
+        this.$get = [
+            "adhConfig",
+            "$location",
+            "$window",
+            "$rootScope",
+            "adhCredentials",
+            "adhUser", (
+                adhConfig : AdhConfig.IService,
+                $location : angular.ILocationService,
+                $window : Window,
+                $rootScope,
+                adhCredentials : AdhCredentials.Service,
+                adhUser : AdhUser.Service) : IService => {
+                    if (adhConfig.embedded) {
+                        var postMessageToParent = $window.parent.postMessage.bind($window.parent);
+                        return new Service(
+                            postMessageToParent, $location,
+                            $window,
+                            $rootScope,
+                            adhConfig.trusted_domains,
+                            adhCredentials,
+                            adhUser,
+                            _self.callbacks);
+                    } else {
+                        return new Dummy();
+                    }
+                }];
+    }
+
+    public registerMessageHandler(name, callback) {
+        this.callbacks.push({ name : name, callback : callback });
+    }
+}
 
 export class Service implements IService {
 
     private embedderOrigin : string = "*";
 
-    /**
-     * Injection of the User service is only required if login information shall be
-     * passed to the embedding website. In that case trustedDomains must be set.
-     */
     constructor(
         private _postMessage : IPostMessageService,
         private $location : angular.ILocationService,
         private $window : Window,
         private $rootScope,
         private trustedDomains : string[],
-        private adhCredentials? : AdhCredentials.Service,
-        private adhUser? : AdhUser.Service
+        private adhCredentials : AdhCredentials.Service,
+        private adhUser : AdhUser.Service,
+        providedMessageHandlers : { name : string, callback : (data : IMessageData) => void }[] = []
     ) {
         var _self : Service = this;
 
         _self.registerMessageHandler("setup", _self.setup.bind(_self));
         _self.manageResize();
+
+        for (var messageHandler of providedMessageHandlers) {
+            _self.registerMessageHandler(messageHandler.name, messageHandler.callback);
+        }
 
         _self.postMessage("requestSetup", {});
     }
@@ -215,21 +259,3 @@ export class Dummy implements IService {
         return;
     }
 }
-
-
-export var factory = (
-    adhConfig : AdhConfig.IService,
-    $location : angular.ILocationService,
-    $window : Window,
-    $rootScope,
-    adhCredentials? : AdhCredentials.Service,
-    adhUser? : AdhUser.Service
-) : IService => {
-    if (adhConfig.embedded) {
-        var postMessageToParent = $window.parent.postMessage.bind($window.parent);
-        return new Service(postMessageToParent, $location, $window, $rootScope, adhConfig.trusted_domains, adhCredentials, adhUser);
-    } else {
-        return new Dummy();
-    }
-};
-

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessagingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessagingSpec.ts
@@ -199,7 +199,7 @@ export var register = () => {
                 service.postMessage(name, data);
                 expect(windowMock.parent.postMessage).toHaveBeenCalled();
             });
-            it("allows to register message handlers a configuration phase", () => {
+            it("allows to register message handlers in configuration phase", () => {
 
                 var callbackMock = jasmine.createSpy("callbackMock");
                 provider.registerMessageHandler("test", callbackMock);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessagingSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/CrossWindowMessagingSpec.ts
@@ -163,7 +163,9 @@ export var register = () => {
             });
         });
 
-        describe("factory", () => {
+        describe("provider", () => {
+            var provider;
+            var factory;
             var service;
             var config : AdhConfig.IService;
 
@@ -177,23 +179,46 @@ export var register = () => {
                     trusted_domains: []
                 };
                 windowMock.parent = jasmine.createSpyObj("parentMock", ["postMessage"]);
+                provider = new AdhCrossWindowMessaging.Provider;
+                factory = provider.$get[6];
             });
 
             it("returns a service instance", () => {
-                service = AdhCrossWindowMessaging.factory(config, locationMock, windowMock, rootScopeMock);
+                service = factory(config, locationMock, windowMock, rootScopeMock);
                 expect(service).toBeDefined();
             });
             it("returns a dummy service when not embedded", () => {
                 config.embedded = false;
-                service = AdhCrossWindowMessaging.factory(config, locationMock, windowMock, rootScopeMock);
+                service = factory(config, locationMock, windowMock, rootScopeMock);
                 expect(service.dummy).toBeDefined();
             });
             it("returns a service instance that uses $window.parent.postMessage", () => {
                 var name = "test";
                 var data = {x: "y"};
-                service = AdhCrossWindowMessaging.factory(config, locationMock, windowMock, rootScopeMock);
+                service = factory(config, locationMock, windowMock, rootScopeMock);
                 service.postMessage(name, data);
                 expect(windowMock.parent.postMessage).toHaveBeenCalled();
+            });
+            it("allows to register message handlers a configuration phase", () => {
+
+                var callbackMock = jasmine.createSpy("callbackMock");
+                provider.registerMessageHandler("test", callbackMock);
+
+                var data = {x: "y"};
+                var message = {
+                    name: "test",
+                    data: data
+                };
+                var event = {
+                    origin: "*",
+                    data: JSON.stringify(message)
+                };
+
+                service = factory(config, locationMock, windowMock, rootScopeMock);
+
+                var args = windowMock.addEventListener.calls.mostRecent().args;
+                args[1](event);
+                expect(callbackMock).toHaveBeenCalledWith(data);
             });
         });
     });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/Module.ts
@@ -6,7 +6,7 @@ import * as AdhCrossWindowMessaging from "./CrossWindowMessaging";
 
 export var moduleName = "adhCrossWindowMessaging";
 
-export var register = (angular, trusted = false) => {
+export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhCredentialsModule.moduleName,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/CrossWindowMessaging/Module.ts
@@ -7,16 +7,10 @@ import * as AdhCrossWindowMessaging from "./CrossWindowMessaging";
 export var moduleName = "adhCrossWindowMessaging";
 
 export var register = (angular, trusted = false) => {
-    var mod = angular
+    angular
         .module(moduleName, [
             AdhCredentialsModule.moduleName,
             AdhUserModule.moduleName
-        ]);
-
-    if (trusted) {
-        mod.factory("adhCrossWindowMessaging", [
-            "adhConfig", "$location", "$window", "$rootScope", "adhCredentials", "adhUser", AdhCrossWindowMessaging.factory]);
-    } else {
-        mod.factory("adhCrossWindowMessaging", ["adhConfig", "$location", "$window", "$rootScope", AdhCrossWindowMessaging.factory]);
-    }
+        ])
+        .provider("adhCrossWindowMessaging", AdhCrossWindowMessaging.Provider);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../../lib2/types/angular.d.ts"/>
+
 import * as _ from "lodash";
 
 import * as AdhConfig from "../Config/Config";
@@ -13,7 +15,7 @@ var metaParams = [
     "noheader"
 ];
 
-export class Provider {
+export class Provider implements angular.IServiceProvider {
     protected directives : string[];
     protected contexts : string[];
     protected contextAliases : {[key : string]: string};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -17,6 +17,8 @@
  * change paths without a reload and in being more flexibel.
  */
 
+/// <reference path="../../../lib2/types/angular.d.ts"/>
+
 import * as _ from "lodash";
 
 import * as AdhConfig from "../Config/Config";
@@ -72,7 +74,7 @@ export interface IRoutingError {
 }
 
 
-export class Provider {
+export class Provider implements angular.IServiceProvider {
     public areas : {[key : string]: any};
     public default : any;
     public $get;

--- a/src/euth/euth/static/js/Adhocracy.ts
+++ b/src/euth/euth/static/js/Adhocracy.ts
@@ -167,7 +167,7 @@ export var init = (config: AdhConfig.IService, metaApi) => {
     AdhBadgeModule.register(angular);
     AdhCommentModule.register(angular);
     AdhConfigModule.register(angular, config);
-    AdhCrossWindowMessagingModule.register(angular, config.trusted_domains !== []);
+    AdhCrossWindowMessagingModule.register(angular);
     AdhDateTimeModule.register(angular);
     AdhDocumentModule.register(angular);
     AdhDoneModule.register(angular);

--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -182,7 +182,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
     AdhBadgeModule.register(angular);
     AdhCommentModule.register(angular);
     AdhConfigModule.register(angular, config);
-    AdhCrossWindowMessagingModule.register(angular, config.trusted_domains !== []);
+    AdhCrossWindowMessagingModule.register(angular);
     AdhDebateWorkbenchModule.register(angular);
     AdhDateTimeModule.register(angular);
     AdhDocumentModule.register(angular);

--- a/src/mercator/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/mercator/static/js/Adhocracy.ts
@@ -165,7 +165,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
     AdhBlogModule.register(angular);
     AdhCommentModule.register(angular);
     AdhConfigModule.register(angular, config);
-    AdhCrossWindowMessagingModule.register(angular, config.trusted_domains !== []);
+    AdhCrossWindowMessagingModule.register(angular);
     AdhDateTimeModule.register(angular);
     AdhDoneModule.register(angular);
     AdhEmbedModule.register(angular);

--- a/src/pcompass/pcompass/static/js/Adhocracy.ts
+++ b/src/pcompass/pcompass/static/js/Adhocracy.ts
@@ -164,7 +164,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
     AdhBadgeModule.register(angular);
     AdhCommentModule.register(angular);
     AdhConfigModule.register(angular, config);
-    AdhCrossWindowMessagingModule.register(angular, config.trusted_domains !== []);
+    AdhCrossWindowMessagingModule.register(angular);
     AdhDateTimeModule.register(angular);
     AdhDoneModule.register(angular);
     AdhEmbedModule.register(angular);

--- a/src/s1/s1/static/js/Adhocracy.ts
+++ b/src/s1/s1/static/js/Adhocracy.ts
@@ -168,7 +168,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
     AdhBadgeModule.register(angular);
     AdhCommentModule.register(angular);
     AdhConfigModule.register(angular, config);
-    AdhCrossWindowMessagingModule.register(angular, config.trusted_domains !== []);
+    AdhCrossWindowMessagingModule.register(angular);
     AdhDateTimeModule.register(angular);
     AdhDoneModule.register(angular);
     AdhEmbedModule.register(angular);

--- a/src/spd/spd/static/js/Adhocracy.ts
+++ b/src/spd/spd/static/js/Adhocracy.ts
@@ -177,7 +177,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
     AdhBadgeModule.register(angular);
     AdhCommentModule.register(angular);
     AdhConfigModule.register(angular, config);
-    AdhCrossWindowMessagingModule.register(angular, config.trusted_domains !== []);
+    AdhCrossWindowMessagingModule.register(angular);
     AdhDateTimeModule.register(angular);
     AdhDebateWorkbenchModule.register(angular);
     AdhDoneModule.register(angular);


### PR DESCRIPTION
 - remove injection filter if no trusted sites were present, because it
   was anyway broken
 - allow to register cross window message callbacks during configuration phase