### PR TITLE
add idea collection process typ for meinberlin

### DIFF
--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/__init__.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/__init__.py
@@ -9,5 +9,6 @@ def includeme(config):
     config.include('.alexanderplatz')
     config.include('.stadtforum')
     config.include('.collaborative_text')
+    config.include('.idea_collection')
     config.include('.root')
     config.include('.subscriber')

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/idea_collection.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/idea_collection.py
@@ -1,0 +1,28 @@
+"""Shared idea collection process."""
+from adhocracy_core.resources import add_resource_type_to_registry
+from adhocracy_core.resources import process
+from adhocracy_core.resources import proposal
+from adhocracy_core.sheets.geo import ILocationReference
+from adhocracy_core.sheets.image import IImageReference
+
+
+class IProcess(process.IProcess):
+    """Idea collection participation process."""
+
+
+process_meta = process.process_meta._replace(
+    iresource=IProcess,
+    element_types=(proposal.IGeoProposal,
+                   ),
+    is_implicit_addable=True,
+    extended_sheets=(
+        ILocationReference,
+        IImageReference,
+    ),
+    workflow_name = 'standard',
+)
+
+
+def includeme(config):
+    """Add resource type to content."""
+    add_resource_type_to_registry(process_meta, config)

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/test_idea_collection.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/resources/test_idea_collection.py
@@ -1,0 +1,35 @@
+from pytest import mark
+from pytest import fixture
+
+
+class TestProcess:
+
+    @fixture
+    def meta(self):
+        from .idea_collection import process_meta
+        return process_meta
+
+    def test_meta(self, meta):
+        from adhocracy_core import resources
+        from adhocracy_core import sheets
+        from adhocracy_core.resources.asset import add_assets_service
+        from .idea_collection import IProcess
+        assert meta.iresource is IProcess
+        assert IProcess.isOrExtends(resources.process.IProcess)
+        assert meta.is_implicit_addable is True
+        assert meta.permission_create == 'create_process'
+        assert meta.extended_sheets == (
+            sheets.geo.ILocationReference,
+            sheets.image.IImageReference,
+        )
+        assert add_assets_service in meta.after_creation
+        assert meta.permission_create == 'create_process'
+        assert meta.workflow_name == 'standard'
+        assert meta.element_types == (
+            resources.proposal.IGeoProposal,
+        )
+
+    @mark.usefixtures('integration')
+    def test_create(self, registry, meta):
+        res = registry.content.create(meta.iresource.__identifier__)
+        assert meta.iresource.providedBy(res)

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_idea_collection.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_idea_collection.py
@@ -13,7 +13,7 @@ def _post_document_item(app_user, path='') -> TestResponse:
 
 
 @mark.functional
-class TestCollaborativeText:
+class TestIdeaCollection:
 
     @fixture
     def process_url(self):

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_idea_collection.py
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_idea_collection.py
@@ -1,0 +1,49 @@
+from pytest import fixture
+from pytest import mark
+from webtest import TestResponse
+
+from adhocracy_core.testing import add_resources
+from adhocracy_core.testing import do_transition_to
+
+
+def _post_document_item(app_user, path='') -> TestResponse:
+    from adhocracy_core.resources.proposal import IGeoProposal
+    resp = app_user.post_resource(path, IGeoProposal, {})
+    return resp
+
+
+@mark.functional
+class TestCollaborativeText:
+
+    @fixture
+    def process_url(self):
+        return '/organisation/idea_collection'
+
+    def test_create_resources(self,
+                              datadir,
+                              process_url,
+                              app_admin):
+        json_file = str(datadir.join('resources.json'))
+        add_resources(app_admin.app_router, json_file)
+        resp = app_admin.get(process_url)
+        assert resp.status_code == 200
+
+    def test_set_participate_state(self, process_url, app_admin):
+        resp = app_admin.get(process_url)
+        assert resp.status_code == 200
+
+        resp = do_transition_to(app_admin,
+                                process_url,
+                                'announce')
+        assert resp.status_code == 200
+
+        resp = do_transition_to(app_admin,
+                                process_url,
+                                'participate')
+        assert resp.status_code == 200
+
+    def test_participate_initiator_creates_document(self,
+                                                    process_url,
+                                                    app_initiator):
+        resp = _post_document_item(app_initiator, path=process_url)
+        assert resp.status_code == 200

--- a/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_idea_collection/resources.json
+++ b/src/adhocracy_meinberlin/adhocracy_meinberlin/workflows/test_idea_collection/resources.json
@@ -1,0 +1,8 @@
+[{"path": "/organisation",
+  "content_type": "adhocracy_meinberlin.resources.idea_collection.IProcess",
+  "data": {"adhocracy_core.sheets.name.IName":
+           {"name": "idea_collection"},
+           "adhocracy_core.sheets.title.ITitle":
+           {"title": "Idea collection participation process"}
+          }}
+]


### PR DESCRIPTION
"Idea collection" is the third standard process for mein besides bplan and collaborative text work.
Refactoring the backend and database migration to make full use of standard processe is yet to be done and not part of this pull request. 
You can import a test intstance with adhocray_meinberlin.workflow.test_idea_collection.resources.json


API Extensions:

   - new Process type Idea collection with content: IGeoProposal and standard workflow.