### PR TITLE
cleanup workflow permissions 

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -6,7 +6,7 @@ permissions:
   - [edit,                           ~,         ~,             ~,            ~,         A,       ~,         A] # default permission to edit resourche sheets/fields
   - [edit_some,                      ~,         ~,             A,            A,         A,       A,         A] # General guard permission to edit non versionable resources (do put requests)
   - [delete,                         ~,         ~,             ~,            A,         A,       ~,         A] # mark resources as "deleted"
-  - [hide,                           ~,         ~,             ~,            A,         ~,       A,         A] # mark resources as "hidden" because there are legal problems.
+  - [hide,                           ~,         ~,             ~,            ~,         ~,       A,         A] # mark resources as "hidden" because there are legal problems.
   - [do_transition,                  ~,         ~,             ~,            ~,         ~,       A,         A] # default permission to do transition to next workflow state (phase)
   - [message_to_user,                ~,         ~,             A,            A,         ~,       A,         A] # send message to user
   - [report_abuse,                   A,         ~,             ~,            ~,         ~,       ~,         ~] # report abuse, resources that should be hidden

--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -6,7 +6,7 @@ permissions:
   - [edit,                           ~,         ~,             ~,            ~,         A,       ~,         A] # default permission to edit resourche sheets/fields
   - [edit_some,                      ~,         ~,             A,            A,         A,       A,         A] # General guard permission to edit non versionable resources (do put requests)
   - [delete,                         ~,         ~,             ~,            A,         A,       ~,         A] # mark resources as "deleted"
-  - [hide,                           ~,         ~,             ~,            ~,         ~,       A,         A] # mark resources as "hidden" because there are legal problems.
+  - [hide,                           ~,         ~,             ~,            ~,         ~,       ~,         A] # mark resources as "hidden" because there are legal problems.
   - [do_transition,                  ~,         ~,             ~,            ~,         ~,       A,         A] # default permission to do transition to next workflow state (phase)
   - [message_to_user,                ~,         ~,             A,            A,         ~,       A,         A] # send message to user
   - [report_abuse,                   A,         ~,             ~,            ~,         ~,       ~,         ~] # report abuse, resources that should be hidden

--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -11,7 +11,6 @@ permissions:
   - [message_to_user,                ~,         ~,             A,            A,         ~,       A,         A] # send message to user
   - [report_abuse,                   A,         ~,             ~,            ~,         ~,       ~,         ~] # report abuse, resources that should be hidden
   # create structure
-  - [create_pool,                    ~,         ~,             ~,            ~,         ~,       ~,         A] # create pool
   - [create_organisation,            ~,         ~,             ~,            ~,         ~,       ~,         A] # create organisation
   - [create_process,                 ~,         ~,             ~,            ~,         ~,       A,         A] # create process
   # create process content

--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -1,7 +1,7 @@
 principals:                         [everyone, authenticated, participant, moderator, creator, initiator, admin]
 permissions:
   # general
-  - [view,                           A,         A,             A,            A,         A,       A,         A] # default permission view resource sheets/field;  view a resource or show it in listings
+  - [view,                           A,         ~,             ~,            ~,         ~,       ~,         ~] # default permission view resource sheets/field;  view a resource or show it in listings
   - [create,                         ~,         A,             ~,            ~,         ~,       ~,         ~] # default permission to create resource sheets/fields; general guard to create resources (POST requests)
   - [edit,                           ~,         ~,             ~,            ~,         A,       ~,         A] # default permission to edit resourche sheets/fields
   - [edit_some,                      ~,         A,             ~,            ~,         ~,       ~,         ~] # General guard permission to edit non versionable resources (do put requests)

--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -23,7 +23,7 @@ permissions:
   - [edit_rate,                      ~,         ~,             ~,            ~,         ~,       ~,         ~] # create rate version (edit for rates)
   # badges
   - [create_badge,                   ~,         ~,             ~,            A,         ~,       A,         A] # create badge
-  - [create_badge_assignment,        ~,         ~,             ~,            A,         ~,       A,         A] # create badge assingment
+  - [create_badge_assignment,        ~,         ~,             ~,            ~,         ~,       ~,         A] # create badge assingment
   - [create_badge_group,             ~,         ~,             ~,            A,         ~,       A,         A] # create badge group
   - [assign_badge,                   ~,         ~,             ~,            A,         ~,       A,         A] # assign a specific badge with a badge assignment resource
   # user, groups, permissions

--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -2,13 +2,13 @@ principals:                         [everyone, authenticated, participant, moder
 permissions:
   # general
   - [view,                           A,         A,             A,            A,         A,       A,         A] # default permission view resource sheets/field;  view a resource or show it in listings
-  - [create,                         ~,         ~,             A,            A,         ~,       A,         A] # default permission to create resource sheets/fields; general guard to create resources (POST requests)
+  - [create,                         ~,         A,             ~,            ~,         ~,       ~,         ~] # default permission to create resource sheets/fields; general guard to create resources (POST requests)
   - [edit,                           ~,         ~,             ~,            ~,         A,       ~,         A] # default permission to edit resourche sheets/fields
-  - [edit_some,                      ~,         ~,             A,            A,         A,       A,         A] # General guard permission to edit non versionable resources (do put requests)
+  - [edit_some,                      ~,         A,             ~,            ~,         ~,       ~,         ~] # General guard permission to edit non versionable resources (do put requests)
   - [delete,                         ~,         ~,             ~,            A,         A,       ~,         A] # mark resources as "deleted"
   - [hide,                           ~,         ~,             ~,            ~,         ~,       ~,         A] # mark resources as "hidden" because there are legal problems.
   - [do_transition,                  ~,         ~,             ~,            ~,         ~,       A,         A] # default permission to do transition to next workflow state (phase)
-  - [message_to_user,                ~,         ~,             A,            A,         ~,       A,         A] # send message to user
+  - [message_to_user,                ~,         A,             ~,            ~,         ~,       ~,         ~] # send message to user
   - [report_abuse,                   A,         ~,             ~,            ~,         ~,       ~,         ~] # report abuse, resources that should be hidden
   # create structure
   - [create_organisation,            ~,         ~,             ~,            ~,         ~,       ~,         A] # create organisation

--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -14,7 +14,7 @@ permissions:
   - [create_organisation,            ~,         ~,             ~,            ~,         ~,       ~,         A] # create organisation
   - [create_process,                 ~,         ~,             ~,            ~,         ~,       A,         A] # create process
   # create process content
-  - [create_asset,                   ~,         ~,             A,            ~,         ~,       ~,         A] # create asset (image/file upload)
+  - [create_asset,                   ~,         ~,             ~,            ~,         ~,       ~,         A] # create asset (image/file upload)
   - [create_external,                ~,         ~,             A,            ~,         ~,       ~,         A] # create external (store external URL)
   - [create_proposal,                ~,         ~,             ~,            ~,         ~,       ~,         A] # create proposal
   - [create_document,                ~,         ~,             ~,            ~,         ~,       ~,         A] # create document

--- a/src/adhocracy_core/adhocracy_core/authorization/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/test_init.py
@@ -279,7 +279,7 @@ class TestSetACMSForAppRoot:
 def test_get_root_base_acl():
     from . import _get_root_base_acl
     acl = _get_root_base_acl()
-    assert acl[0] == ('Allow', 'role:admin', 'view')
+    assert acl[0] == ('Allow', 'role:admin', 'edit')
 
 
 def test_set_acl_set_resource_dirty():

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -14,6 +14,7 @@ from zope.interface import directlyProvides
 from zope.interface import noLongerProvides
 from zope.interface.interfaces import IInterface
 
+from adhocracy_core.resources.principal import allow_create_asset_authenticated
 from adhocracy_core.catalog import ICatalogsService
 from adhocracy_core.interfaces import IItem
 from adhocracy_core.interfaces import IItemVersion
@@ -673,6 +674,13 @@ def add_canbadge_sheet_to_users(root, registry):  # pragma: no cover
     migrate_new_sheet(root, IUser, ICanBadge)
 
 
+@log_migration
+def allow_create_asset_for_users(root, registry):  # pragma: no cover
+    """Allow all users to create_assets inside the users service."""
+    users = find_service(root, 'principals', 'users')
+    allow_create_asset_authenticated(users, registry, {})
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -707,3 +715,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(reset_comment_count)
     config.add_evolution_step(remove_is_service_attribute)
     config.add_evolution_step(add_canbadge_sheet_to_users)
+    config.add_evolution_step(allow_create_asset_for_users)

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -51,6 +51,7 @@ from adhocracy_core.sheets.title import ITitle
 from adhocracy_core.sheets.versions import IVersionable
 from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.utils import has_annotation_sheet_data
+from adhocracy_core.workflows import update_workflow_state_acls
 
 logger = logging.getLogger(__name__)
 
@@ -681,6 +682,13 @@ def allow_create_asset_for_users(root, registry):  # pragma: no cover
     allow_create_asset_authenticated(users, registry, {})
 
 
+@log_migration
+def update_workflow_state_acl_for_all_resources(root,
+                                                registry):  # pragma: no cover
+    """Update the local :term:`acl` with the current workflow state acl."""
+    update_workflow_state_acls(root, registry)
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -716,3 +724,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(remove_is_service_attribute)
     config.add_evolution_step(add_canbadge_sheet_to_users)
     config.add_evolution_step(allow_create_asset_for_users)
+    config.add_evolution_step(update_workflow_state_acl_for_all_resources)

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -885,5 +885,8 @@ class IAdhocracyWorkflow(IWorkflow):  # pragma: no cover
     def get_next_states(context, request: IRequest) -> [str]:
         """Get states you can trigger a transition to."""
 
+    def update_acl(context) -> list:
+        """Reset the local permission :term:`acl` for `context`."""
+
 
 error_entry = namedtuple('ErrorEntry', ['location', 'name', 'description'])

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -1,6 +1,8 @@
 """Principal types (user/group) and helpers to search/get user information."""
 from logging import getLogger
 
+from pyramid.authentication import Authenticated
+from pyramid.authorization import Allow
 from pyramid.registry import Registry
 from pyramid.traversal import find_resource
 from pyramid.traversal import get_current_registry
@@ -156,6 +158,17 @@ user_meta = pool_meta._replace(
 )
 
 
+def allow_create_asset_authenticated(context: IPool,
+                                     registry: Registry,
+                                     options: dict):
+    """Set local permission to create assets for authenticated.
+
+    This is needed to assure user can create their user image.
+    """
+    acl = [(Allow, Authenticated, 'create_asset')]
+    set_acl(context, acl, registry=registry)
+
+
 class IUsersService(IServicePool):
     """Service Pool for Users."""
 
@@ -168,6 +181,7 @@ users_meta = service_meta._replace(
     extended_sheets=(adhocracy_core.sheets.asset.IHasAssetPool,),
     after_creation=(add_badge_assignments_service,
                     add_assets_service,
+                    allow_create_asset_authenticated,
                     ),
 )
 

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -2,7 +2,9 @@
 from logging import getLogger
 
 from pyramid.authentication import Authenticated
+from pyramid.authentication import Everyone
 from pyramid.authorization import Allow
+from pyramid.authorization import Deny
 from pyramid.registry import Registry
 from pyramid.traversal import find_resource
 from pyramid.traversal import get_current_registry
@@ -225,7 +227,7 @@ groups_meta = service_meta._replace(
 def deny_view_permission(context: IResource, registry: Registry,
                          options: dict):
     """Remove view permission for everyone for `context`."""
-    acl = [('deny', 'system.Everyone', 'view')]
+    acl = [(Deny, Everyone, 'view')]
     set_acl(context, acl, registry=registry)
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -241,10 +241,12 @@ class TestPasswordResets:
 
     @mark.usefixtures('integration')
     def test_remove_view_permission(self, meta, registry):
+        from pyramid.authorization import Deny
+        from pyramid.authentication import Everyone
         from adhocracy_core.authorization import get_acl
         resource = registry.content.create(meta.iresource.__identifier__)
         acl = get_acl(resource)
-        assert acl == [('deny', 'system.Everyone', 'view')]
+        assert acl == [(Deny, Everyone, 'view')]
 
     @mark.usefixtures('integration')
     def test_hide(self, meta, registry):

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -84,11 +84,22 @@ class TestUsers:
         assert sheets.asset.IHasAssetPool in meta.extended_sheets
         assert badge.add_badge_assignments_service in meta.after_creation
         assert asset.add_assets_service in meta.after_creation
+        assert principal.allow_create_asset_authenticated in meta.after_creation
 
     @mark.usefixtures('integration')
     def test_create(self, meta, registry):
         resource = registry.content.create(meta.iresource.__identifier__)
         assert meta.iresource.providedBy(resource)
+
+
+def test_create_asset_permission(context, registry, mocker):
+    from . import principal
+    from .principal import allow_create_asset_authenticated
+    set_acl = mocker.spy(principal, 'set_acl')
+    allow_create_asset_authenticated(context, registry, {})
+    set_acl.assert_called_with(context,
+                               [('Allow', 'system.Authenticated', 'create_asset')],
+                               registry=registry)
 
 
 class TestUser:

--- a/src/adhocracy_core/adhocracy_core/workflows/sample.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/sample.yaml
@@ -14,6 +14,7 @@ states:
        - [create_comment,    A,           A,         ~,       ~]
        - [create_rate,      A,           ~,         ~,        ~]
        - [create_asset,      A,           ~,         ~,       ~]
+       - [create_badge_assignment,  ~,    A,         A,       ~]
        - [edit_rate,         ~,           ~,         A,       ~]
        - [create_relation,   A,           ~,         ~,       ~]
        - [edit_relation,     ~,           ~,         A,       ~]

--- a/src/adhocracy_core/adhocracy_core/workflows/sample.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/sample.yaml
@@ -13,6 +13,7 @@ states:
        - [create_document,   A,           ~,         ~,       ~]
        - [create_comment,    A,           A,         ~,       ~]
        - [create_rate,      A,           ~,         ~,        ~]
+       - [create_asset,      A,           ~,         ~,       ~]
        - [edit_rate,         ~,           ~,         A,       ~]
        - [create_relation,   A,           ~,         ~,       ~]
        - [edit_relation,     ~,           ~,         A,       ~]

--- a/src/adhocracy_core/adhocracy_core/workflows/sample.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/sample.yaml
@@ -12,10 +12,11 @@ states:
        - [create_proposal,   A,           ~,         ~,       ~]
        - [create_document,   A,           ~,         ~,       ~]
        - [create_comment,    A,           A,         ~,       ~]
-       - [create_rate,      A,           ~,         ~,       ~]
+       - [create_rate,      A,           ~,         ~,        ~]
        - [edit_rate,         ~,           ~,         A,       ~]
        - [create_relation,   A,           ~,         ~,       ~]
        - [edit_relation,     ~,           ~,         A,       ~]
+       - [hide,              ~,           A,         ~,       ~]
   frozen:
     title: Frozen
 transitions:

--- a/src/adhocracy_core/adhocracy_core/workflows/standard.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/standard.yaml
@@ -32,6 +32,7 @@ states:
         - [create_relation,          ~,         A,           ~,         ~,       ~,         ~]
         - [edit_relation,            ~,         ~,           ~,         A,       ~,         ~]
         - [create_badge_assignment,  ~,         ~,           ~,         A,       ~,         ~]
+        - [hide,                     ~,         ~,           A,         ~,       ~,         A]
   evaluate:
     title: Evaluate
     acm:
@@ -40,6 +41,7 @@ states:
         - [view,               ~,         ~,           ~,         ~,       ~,         ~]
         - [create_proposal,    ~,         ~,           ~,         ~,       ~,         ~]
         - [create_comment,     ~,         A,           A,         ~,       ~,         ~]
+        - [hide,               ~,         ~,           A,         ~,       ~,         A]
   result:
     title: Result
     acm:
@@ -48,6 +50,7 @@ states:
         - [view,               ~,         ~,           ~,         ~,       ~,         ~]
         - [create_proposal,    ~,         ~,           ~,         ~,       ~,         ~]
         - [create_comment,     ~,         ~,           A,         ~,       A,         ~]
+        - [hide,               ~,         ~,           A,         ~,       ~,         A]
   closed:
     title: Closed
     acm:

--- a/src/adhocracy_core/adhocracy_core/workflows/standard.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/standard.yaml
@@ -32,7 +32,7 @@ states:
         - [edit_rate,                ~,        ~,           ~,         A,       ~,         ~]
         - [create_relation,          ~,        A,           ~,         ~,       ~,         ~]
         - [edit_relation,            ~,        ~,           ~,         A,       ~,         ~]
-        - [create_badge_assignment,  ~,        ~,           ~,         A,       ~,         ~]
+        - [create_badge_assignment,  ~,        ~,           A,         A,       ~,         ~]
         - [hide,                     ~,        ~,           A,         ~,       ~,         ~]
   evaluate:
     title: Evaluate
@@ -43,6 +43,7 @@ states:
         - [create_proposal,          ~,        ~,           ~,         ~,       ~,         ~]
         - [create_asset,             ~,        ~,           ~,         ~,       ~,         ~]
         - [create_comment,           ~,        A,           A,         ~,       ~,         ~]
+        - [create_badge_assignment,  ~,        ~,           A,         ~,       ~,         ~]
         - [hide,                     ~,        ~,           A,         ~,       ~,         ~]
   result:
     title: Result
@@ -53,6 +54,7 @@ states:
         - [create_proposal,          ~,        ~,           ~,         ~,       ~,         ~]
         - [create_asset,             ~,        ~,           ~,         ~,       ~,         ~]
         - [create_comment,           ~,        ~,           A,         ~,       A,         ~]
+        - [create_badge_assignment,  ~,        ~,           A,         ~,       ~,         ~]
         - [hide,                     ~,        ~,           A,         ~,       ~,         ~]
   closed:
     title: Closed

--- a/src/adhocracy_core/adhocracy_core/workflows/standard.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/standard.yaml
@@ -7,59 +7,59 @@ states:
     title: Draft
     description: This phase is for internal review.
     acm:
-      principals:                 [everyone, participant, moderator, creator, initiator, admin]
+      principals:                   [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,                   D,         D,           A,         A,       A,         A]
-        - [create_document,        ~,         ~,           A,         ~,       ~,         ~]
-        - [edit,                   ~,         ~,           A,         ~,       A,         ~]
+        - [view,                     D,        D,           A,         A,       A,         A]
+        - [create_document,          ~,        ~,           A,         ~,       ~,         ~]
+        - [edit,                     ~,        ~,           A,         ~,       A,         ~]
       display_only_to_roles: [admin, initiator, moderator]
   announce:
     title: Announce
     acm:
-      principals:             [everyone, participant, moderator, creator, initiator, admin]
+      principals:                   [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,               ~,        ~,           ~,         ~,       ~,         ~]
+        - [view,                     ~,        ~,           ~,         ~,       ~,         ~]
   participate:
     title: Participate
     acm:
       principals:                   [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,                     ~,         A,           A,         A,       A,         ~]
-        - [create_proposal,          ~,         A,           ~,         ~,       ~,         ~]
-        - [create_asset,             ~,         A,           ~,         ~,       ~,         ~]
-        - [create_comment,           ~,         A,           A,         ~,       ~,         ~]
-        - [create_rate,              ~,         A,           ~,         ~,       ~,         ~]
-        - [edit_rate,                ~,         ~,           ~,         A,       ~,         ~]
-        - [create_relation,          ~,         A,           ~,         ~,       ~,         ~]
-        - [edit_relation,            ~,         ~,           ~,         A,       ~,         ~]
-        - [create_badge_assignment,  ~,         ~,           ~,         A,       ~,         ~]
-        - [hide,                     ~,         ~,           A,         ~,       ~,         A]
+        - [view,                     ~,        A,           A,         A,       A,         ~]
+        - [create_proposal,          ~,        A,           ~,         ~,       ~,         ~]
+        - [create_asset,             ~,        A,           ~,         ~,       ~,         ~]
+        - [create_comment,           ~,        A,           A,         ~,       ~,         ~]
+        - [create_rate,              ~,        A,           ~,         ~,       ~,         ~]
+        - [edit_rate,                ~,        ~,           ~,         A,       ~,         ~]
+        - [create_relation,          ~,        A,           ~,         ~,       ~,         ~]
+        - [edit_relation,            ~,        ~,           ~,         A,       ~,         ~]
+        - [create_badge_assignment,  ~,        ~,           ~,         A,       ~,         ~]
+        - [hide,                     ~,        ~,           A,         ~,       ~,         ~]
   evaluate:
     title: Evaluate
     acm:
-      principals:             [everyone, participant, moderator, creator, initiator, admin]
+      principals:                   [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,               ~,         ~,           ~,         ~,       ~,         ~]
-        - [create_proposal,    ~,         ~,           ~,         ~,       ~,         ~]
-        - [create_asset,       ~,         ~,           ~,         ~,       ~,         ~]
-        - [create_comment,     ~,         A,           A,         ~,       ~,         ~]
-        - [hide,               ~,         ~,           A,         ~,       ~,         A]
+        - [view,                     ~,        ~,           ~,         ~,       ~,         ~]
+        - [create_proposal,          ~,        ~,           ~,         ~,       ~,         ~]
+        - [create_asset,             ~,        ~,           ~,         ~,       ~,         ~]
+        - [create_comment,           ~,        A,           A,         ~,       ~,         ~]
+        - [hide,                     ~,        ~,           A,         ~,       ~,         ~]
   result:
     title: Result
     acm:
-      principals:             [everyone, participant, moderator, creator, initiator, admin]
+      principals:                   [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,               ~,         ~,           ~,         ~,       ~,         ~]
-        - [create_proposal,    ~,         ~,           ~,         ~,       ~,         ~]
-        - [create_asset,       ~,         ~,           ~,         ~,       ~,         ~]
-        - [create_comment,     ~,         ~,           A,         ~,       A,         ~]
-        - [hide,               ~,         ~,           A,         ~,       ~,         A]
+        - [view,                     ~,        ~,           ~,         ~,       ~,         ~]
+        - [create_proposal,          ~,        ~,           ~,         ~,       ~,         ~]
+        - [create_asset,             ~,        ~,           ~,         ~,       ~,         ~]
+        - [create_comment,           ~,        ~,           A,         ~,       A,         ~]
+        - [hide,                     ~,        ~,           A,         ~,       ~,         ~]
   closed:
     title: Closed
     acm:
-      principals:             [everyone, participant, moderator, creator, initiator, admin]
+      principals:                   [everyone, participant, moderator, creator, initiator, admin]
       permissions:
-        - [view,               ~,        ~,           ~,         ~,       ~,         ~]
+        - [view,                     ~,        ~,           ~,         ~,       ~,         ~]
 transitions:
   to_announce:
     from_state: draft

--- a/src/adhocracy_core/adhocracy_core/workflows/standard.yaml
+++ b/src/adhocracy_core/adhocracy_core/workflows/standard.yaml
@@ -26,6 +26,7 @@ states:
       permissions:
         - [view,                     ~,         A,           A,         A,       A,         ~]
         - [create_proposal,          ~,         A,           ~,         ~,       ~,         ~]
+        - [create_asset,             ~,         A,           ~,         ~,       ~,         ~]
         - [create_comment,           ~,         A,           A,         ~,       ~,         ~]
         - [create_rate,              ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,                ~,         ~,           ~,         A,       ~,         ~]
@@ -40,6 +41,7 @@ states:
       permissions:
         - [view,               ~,         ~,           ~,         ~,       ~,         ~]
         - [create_proposal,    ~,         ~,           ~,         ~,       ~,         ~]
+        - [create_asset,       ~,         ~,           ~,         ~,       ~,         ~]
         - [create_comment,     ~,         A,           A,         ~,       ~,         ~]
         - [hide,               ~,         ~,           A,         ~,       ~,         A]
   result:
@@ -49,6 +51,7 @@ states:
       permissions:
         - [view,               ~,         ~,           ~,         ~,       ~,         ~]
         - [create_proposal,    ~,         ~,           ~,         ~,       ~,         ~]
+        - [create_asset,       ~,         ~,           ~,         ~,       ~,         ~]
         - [create_comment,     ~,         ~,           A,         ~,       A,         ~]
         - [hide,               ~,         ~,           A,         ~,       ~,         A]
   closed:

--- a/src/adhocracy_core/adhocracy_core/workflows/test_standard.py
+++ b/src/adhocracy_core/adhocracy_core/workflows/test_standard.py
@@ -131,6 +131,21 @@ class TestStandardPublicWithPrivateProcessesConfig:
         resp = app_admin.get(process_url_public)
         assert resp.status_code == 200
 
+    def test_participate_authenticated_can_post_proposal(
+            self, process_url_public, app_authenticated):
+        from adhocracy_core.resources.proposal import IProposal
+        resp = app_authenticated.post_resource(process_url_public, IProposal,
+                                               {})
+        assert resp.status_code == 200
+
+    def test_participate_authenticated_can_post_badge_assignments(
+            self, process_url_public, app_authenticated):
+        from adhocracy_core.resources.badge import IBadgeAssignment
+        resp = app_authenticated.options(process_url_public +
+                                         '/proposal_0000000/badge_assignments')
+        assert resp.json['POST']['request_body'][0]['content_type'] == \
+            IBadgeAssignment.__identifier__
+
     def test_evaluate_authenticated_can_read_public_process(
             self, process_url_public, app_authenticated, app_admin):
         self.set_process_state(process_url_public, app_admin, 'evaluate')

--- a/src/adhocracy_core/docs/badges.rst
+++ b/src/adhocracy_core/docs/badges.rst
@@ -18,7 +18,7 @@ Some imports to work with rest api calls::
 Start adhocracy app and log in some users::
 
     >>> participant = getfixture('app_participant')
-    >>> initiator = getfixture('app_initiator')
+    >>> moderator = getfixture('app_moderator')
     >>> admin = getfixture('app_admin')
     >>> log = getfixture('log')
 
@@ -49,7 +49,7 @@ Badges can be created in `badges` pools. The IHasBadgesPool sheet of the process
 gives us the right pool:
 
 
-    >>> resp = initiator.get('/organisation/process').json
+    >>> resp = moderator.get('/organisation/process').json
     >>> badges_pool = resp['data']['adhocracy_core.sheets.badge.IHasBadgesPool']['badges_pool']
 
 Now we can create a Badge::
@@ -60,7 +60,7 @@ Now we can create a Badge::
     ...                  'adhocracy_core.sheets.description.IDescription': {'description': 'This is 1'},
     ...                  },
     ...         }
-    >>> resp = initiator.post(badges_pool, prop).json
+    >>> resp = moderator.post(badges_pool, prop).json
     >>> badge = resp['path']
 
 To add a badge to a badge group we first create the group::
@@ -69,7 +69,7 @@ To add a badge to a badge group we first create the group::
     ...         'data': {'adhocracy_core.sheets.name.IName': {'name': 'group1'},
     ...                  },
     ...         }
-    >>> resp = initiator.post(badges_pool, prop).json
+    >>> resp = moderator.post(badges_pool, prop).json
     >>> group = resp['path']
 
 then create the badge inside this group::
@@ -78,12 +78,12 @@ then create the badge inside this group::
     ...         'data': {'adhocracy_core.sheets.name.IName': {'name': 'badge1'},
     ...                  },
     ...         }
-    >>> resp = initiator.post(group, prop).json
+    >>> resp = moderator.post(group, prop).json
     >>> badge_with_group = resp['path']
 
 The badge groups hierarchy is also shown with the badge sheet::
 
-    >>> resp = initiator.get(badge_with_group).json
+    >>> resp = moderator.get(badge_with_group).json
     >>> resp['data']['adhocracy_core.sheets.badge.IBadge']
     {'groups': [.../group1/']}
 
@@ -96,18 +96,18 @@ and badge.
 
 First we need the pool to post badge assignments to::
 
-    >>> resp = initiator.get(proposal_version).json
+    >>> resp = moderator.get(proposal_version).json
     >>> post_pool = resp['data']['adhocracy_core.sheets.badge.IBadgeable']['post_pool']
 
 To get assignable badges we send an options request to this post pool::
 
-    >>> resp = initiator.options(post_pool).json
+    >>> resp = moderator.options(post_pool).json
     >>> resp['POST']['request_body'][0]['data']['adhocracy_core.sheets.badge.IBadgeAssignment']['badge']
     [.../process/badges/badge1/',.../process/badges/group1/badge1/']
 
 The user is typically the current logged in user::
 
-    >>> user = initiator.user_path
+    >>> user = moderator.user_path
 
 Now we can post the assignment to a proposal version::
 
@@ -117,7 +117,7 @@ Now we can post the assignment to a proposal version::
     ...                       'badge': badge,
     ...                       'object': proposal_version}
     ...          }}
-    >>> resp = initiator.post(post_pool, prop)
+    >>> resp = moderator.post(post_pool, prop)
     >>> resp.status_code
     200
 
@@ -129,7 +129,7 @@ or proposal item::
     ...                       'badge': badge,
     ...                       'object': proposal_item}
     ...          }}
-    >>> resp = initiator.post(post_pool, prop)
+    >>> resp = moderator.post(post_pool, prop)
     >>> resp.status_code
     200
 
@@ -147,7 +147,7 @@ It is not possible to assign twice the same badge::
     ...                       'badge': badge,
     ...                       'object': proposal_version}
     ...          }}
-    >>> resp = initiator.post(post_pool, prop).json
+    >>> resp = moderator.post(post_pool, prop).json
     >>> resp['errors'][0]['description']
     'Badge already assigned'
 
@@ -155,7 +155,7 @@ We can also use the filtering pool api to search for content with specific badge
 
     >>> prop = {'badge': 'badge1',
     ...         'depth': 'all'}
-    >>> resp = initiator.get('/organisation/process', params=prop).json
+    >>> resp = moderator.get('/organisation/process', params=prop).json
     >>> resp['data']['adhocracy_core.sheets.pool.IPool']['elements']
     ['...document_0000000/',...document_0000000/VERSION_0000000/']
 
@@ -163,7 +163,7 @@ In addition we can search for versions that have an item with a specific badge::
 
     >>> prop = {'item_badge': 'badge1',
     ...         'depth': 'all'}
-    >>> resp = initiator.get('/organisation/process', params=prop).json
+    >>> resp = moderator.get('/organisation/process', params=prop).json
     >>> resp['data']['adhocracy_core.sheets.pool.IPool']['elements']
     ['...0/']
 
@@ -175,7 +175,7 @@ PostPool and Assignable validation
 
 If we use the wrong post_pool we get an error::
 
-    >>> resp = initiator.get(proposal2_version).json
+    >>> resp = moderator.get(proposal2_version).json
     >>> wrong_post_pool = resp['data']['adhocracy_core.sheets.badge.IBadgeable']['post_pool']
 
     >>> prop = {'content_type': 'adhocracy_core.resources.badge.IBadgeAssignment',
@@ -184,7 +184,7 @@ If we use the wrong post_pool we get an error::
     ...                       'badge': badge,
     ...                       'object': proposal_version}
     ...          }}
-    >>> resp = initiator.post(wrong_post_pool, prop).json
+    >>> resp = moderator.post(wrong_post_pool, prop).json
     >>> resp
     {...'You can only add references inside ...0/badge_assignments...
 
@@ -199,7 +199,7 @@ User Badges
 Badges can be assigned to users the same way as process content.
 The principals pool gives us the badges pool::
 
-    >>> resp = initiator.get('/principals').json
+    >>> resp = moderator.get('/principals').json
     >>> badges_pool = resp['data']['adhocracy_core.sheets.badge.IHasBadgesPool']['badges_pool']
 
 There the admin can create badges::
@@ -213,8 +213,8 @@ There the admin can create badges::
 
 The user gives us the badge assignment post pool::
 
-    >>> user_with_badge = initiator.user_path
-    >>> resp = initiator.get(user_with_badge).json
+    >>> user_with_badge = moderator.user_path
+    >>> resp = moderator.get(user_with_badge).json
     >>> post_pool = resp['data']['adhocracy_core.sheets.badge.IBadgeable']['post_pool']
 
 

--- a/src/adhocracy_core/docs/deletion.rst
+++ b/src/adhocracy_core/docs/deletion.rst
@@ -204,7 +204,7 @@ Lets hide pool2::
     >>> data = {'content_type': 'adhocracy_core.resources.pool.IBasicPool',
     ...         'data': {'adhocracy_core.sheets.metadata.IMetadata':
     ...                      {'hidden': True}}}
-    >>> resp = moderator.put("/pool2", data).json
+    >>> resp = admin.put("/pool2", data).json
 
 Inspecting the 'updated_resources' listing in the response, we see that
 pool2 was removed::

--- a/src/adhocracy_core/docs/permissions.rst
+++ b/src/adhocracy_core/docs/permissions.rst
@@ -213,7 +213,7 @@ Can hide and delete process content
     ['deleted', 'hidden']
 
 Can hide and delete process structure
-    >>> resp = moderator.options('/organisation').json
+    >>> resp = moderator.options('/organisation/process').json
     >>> sorted(resp['PUT']['request_body']['data']
     ...                  ['adhocracy_core.sheets.metadata.IMetadata'])
     ['deleted', 'hidden']

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator.yaml
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator.yaml
@@ -9,12 +9,14 @@ states:
         - [create_comment,            ~,         A,           A,         ~,       A,         ~]
         - [create_rate,               ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,                 ~,         ~,           ~,         A,       ~,         ~]
+        - [hide,                      ~,         ~,           A,         ~,       ~,         A]
   evaluate:
     acm:
       principals:                    [everyone, participant, moderator, creator, initiator, admin]
       permissions:
         - [create_mercator_proposal,  ~,        ~,          ~,          ~,       A,         ~]
         - [edit_mercator_proposal,    ~,        ~,          ~,          ~,       A,         ~]
+        - [hide,                      ~,         ~,         A,          ~,       ~,         A]
   result:
     acm:
       principals:                    [everyone, participant, moderator, creator, initiator, admin]

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator.yaml
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator.yaml
@@ -5,6 +5,7 @@ states:
       principals:                    [everyone, participant, moderator, creator, initiator, admin]
       permissions:
         - [create_mercator_proposal,  ~,         A,           ~,         ~,       A,         ~]
+        - [create_asset,              ~,         A,           ~,         ~,       A,         ~]
         - [edit_mercator_proposal,    ~,         ~,           ~,         A,       ~,         ~]
         - [create_comment,            ~,         A,           A,         ~,       A,         ~]
         - [create_rate,               ~,         A,           ~,         ~,       ~,         ~]
@@ -15,6 +16,7 @@ states:
       principals:                    [everyone, participant, moderator, creator, initiator, admin]
       permissions:
         - [create_mercator_proposal,  ~,        ~,          ~,          ~,       A,         ~]
+        - [create_asset,              ~,        ~,          ~,          ~,       A,         ~]
         - [edit_mercator_proposal,    ~,        ~,          ~,          ~,       A,         ~]
         - [hide,                      ~,         ~,         A,          ~,       ~,         A]
   result:
@@ -22,6 +24,7 @@ states:
       principals:                    [everyone, participant, moderator, creator, initiator, admin]
       permissions:
         - [create_mercator_proposal,  ~,         ~,          ~,          ~,       A,         ~]
+        - [create_asset,              ~,         ~,          ~,          ~,       A,         ~]
         - [edit_mercator_proposal,    ~,         ~,          ~,          A,       A,         ~]
         - [create_document,           ~,         ~,          ~,          A,       A,         ~]
 

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator.yaml
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator.yaml
@@ -10,7 +10,7 @@ states:
         - [create_comment,            ~,         A,           A,         ~,       A,         ~]
         - [create_rate,               ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,                 ~,         ~,           ~,         A,       ~,         ~]
-        - [hide,                      ~,         ~,           A,         ~,       ~,         A]
+        - [hide,                      ~,         ~,           A,         ~,       ~,         ~]
   evaluate:
     acm:
       principals:                    [everyone, participant, moderator, creator, initiator, admin]
@@ -18,7 +18,7 @@ states:
         - [create_mercator_proposal,  ~,        ~,          ~,          ~,       A,         ~]
         - [create_asset,              ~,        ~,          ~,          ~,       A,         ~]
         - [edit_mercator_proposal,    ~,        ~,          ~,          ~,       A,         ~]
-        - [hide,                      ~,         ~,         A,          ~,       ~,         A]
+        - [hide,                      ~,         ~,         A,          ~,       ~,         ~]
   result:
     acm:
       principals:                    [everyone, participant, moderator, creator, initiator, admin]

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator2.yaml
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator2.yaml
@@ -5,6 +5,7 @@ states:
       principals:                       [everyone, participant, moderator, creator, initiator, admin]
       permissions:
         - [create_proposal,              ~,         A,           ~,         ~,       A,         ~]
+        - [create_asset,                  ~,        A,           ~,         ~,       A,         ~]
         - [create_comment,               ~,         A,           A,         ~,       A,         ~]
         - [create_rate,                  ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,                    ~,         ~,           ~,         A,       ~,         ~]

--- a/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator2.yaml
+++ b/src/adhocracy_mercator/adhocracy_mercator/workflows/mercator2.yaml
@@ -9,7 +9,7 @@ states:
         - [create_comment,               ~,         A,           A,         ~,       A,         ~]
         - [create_rate,                  ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,                    ~,         ~,           ~,         A,       ~,         ~]
-        - [create_badge_assignment,      ~,         A,           ~,         ~,       ~,         ~]
+        - [create_badge_assignment,      ~,         A,           A,         ~,       ~,         ~]
         - [view_mercator2_extra_funding, ~,         D,           A,         A,       ~,         ~]
         - [view_mercator2_winnerinfo,    ~,         D,           D,         ~,       ~,         ~]
         - [edit_mercator2_winnerinfo,    ~,         D,           D,         ~,       ~,         ~]
@@ -18,6 +18,7 @@ states:
       principals:                       [everyone, participant, moderator, creator, initiator, admin]
       permissions:
         - [edit,                         ~,        ~,           ~,       D,         ~,         ~]
+        - [create_badge_assignment,      ~,        ~,           A,      ~,       ~,         ~]
         - [view_mercator2_extra_funding, ~,        D,           A,      ~,          ~,         ~]
         - [view_mercator2_winnerinfo,    ~,        D,           A,      ~,          ~,         ~]
         - [edit_mercator2_winnerinfo,    ~,        D,           A,      ~,          ~,         ~]
@@ -26,6 +27,7 @@ states:
       principals:                       [everyone, participant, moderator, creator, initiator, admin]
       permissions:
         - [edit,                         ~,         ~,           ~,         A,       ~,         ~]
+        - [create_badge_assignment,      ~,         ~,           A,         ~,       ~,         ~]
         - [view_mercator2_extra_funding, ~,         D,           A,         ~,       ~,         ~]
         - [view_mercator2_winnerinfo,    ~,         A,           A,         ~,       ~,         ~]
         - [edit_mercator2_winnerinfo,    ~,         D,           A,         ~,       ~,         ~]

--- a/src/adhocracy_s1/adhocracy_s1/workflows/s1.yaml
+++ b/src/adhocracy_s1/adhocracy_s1/workflows/s1.yaml
@@ -9,6 +9,7 @@ states:
         - [create_comment,       ~,         A,           A,         ~,       A,         ~]
         - [create_rate,          ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,            ~,         ~,           ~,         A,       ~,         ~]
+        - [hide,                 ~,         ~,           ~,         A,       ~,         A]
   select:
     title: Evaluate
     acm:
@@ -18,6 +19,7 @@ states:
         - [create_rate,          ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,            ~,         ~,           ~,         A,       ~,         ~]
         - [create_comment,       ~,         A,           A,         ~,       A,         ~]
+        - [hide,                 ~,         ~,           ~,         A,       ~,         A]
   result:
     title: Result
     acm:
@@ -27,6 +29,7 @@ states:
         - [create_comment,       ~,         A,           A,         ~,       A,         ~]
         - [create_rate,          ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,            ~,         ~,           ~,         A,       ~,         ~]
+        - [hide,                 ~,         ~,           ~,         A,       ~,         A]
 transitions:
   to_select:
     from_state: propose

--- a/src/adhocracy_s1/adhocracy_s1/workflows/s1.yaml
+++ b/src/adhocracy_s1/adhocracy_s1/workflows/s1.yaml
@@ -9,7 +9,7 @@ states:
         - [create_comment,       ~,         A,           A,         ~,       A,         ~]
         - [create_rate,          ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,            ~,         ~,           ~,         A,       ~,         ~]
-        - [hide,                 ~,         ~,           ~,         A,       ~,         A]
+        - [hide,                 ~,         ~,           ~,         A,       ~,         ~]
   select:
     title: Evaluate
     acm:
@@ -19,7 +19,7 @@ states:
         - [create_rate,          ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,            ~,         ~,           ~,         A,       ~,         ~]
         - [create_comment,       ~,         A,           A,         ~,       A,         ~]
-        - [hide,                 ~,         ~,           ~,         A,       ~,         A]
+        - [hide,                 ~,         ~,           ~,         A,       ~,         ~]
   result:
     title: Result
     acm:
@@ -29,7 +29,7 @@ states:
         - [create_comment,       ~,         A,           A,         ~,       A,         ~]
         - [create_rate,          ~,         A,           ~,         ~,       ~,         ~]
         - [edit_rate,            ~,         ~,           ~,         A,       ~,         ~]
-        - [hide,                 ~,         ~,           ~,         A,       ~,         A]
+        - [hide,                 ~,         ~,           ~,         A,       ~,         ~]
 transitions:
   to_select:
     from_state: propose


### PR DESCRIPTION
Cleanups to make it easer getting an overview of all permissions for one workflow state

- mv  permission settings to workflow if possible, except for admin role 
- use system roles everybody/authenticated as a shortcut
- normalise lines/columns to eas copy and paste
- set local permission 'create_asset' for /principlas/users to allow moving this permission to the workflow

Backend internal changes:

- helper function `update_workflow_state_acls` to update all ACL set by workflows
- migration step to run `update_worfklow_state_acls`