### PR TITLE
Add badge groups to old assignment api

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -72,6 +72,7 @@ export var getBadgesFactory = (
     }
 };
 
+
 export var bindPath = (
     adhHttp : AdhHttp.Service<any>,
     adhPermissions : AdhPermissions.Service,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -16,9 +16,7 @@ import * as SIBadge from "../../Resources_/adhocracy_core/sheets/badge/IBadge";
 import * as SIBadgeable from "../../Resources_/adhocracy_core/sheets/badge/IBadgeable";
 import * as SIBadgeAssignment from "../../Resources_/adhocracy_core/sheets/badge/IBadgeAssignment";
 import * as SIDescription from "../../Resources_/adhocracy_core/sheets/description/IDescription";
-import * as SIHasBadgesPool from "../../Resources_/adhocracy_core/sheets/badge/IHasBadgesPool";
 import * as SIName from "../../Resources_/adhocracy_core/sheets/name/IName";
-import * as SIPool from "../../Resources_/adhocracy_core/sheets/pool/IPool";
 import * as SITitle from "../../Resources_/adhocracy_core/sheets/title/ITitle";
 
 var pkgLocation = "/Badge";
@@ -131,14 +129,6 @@ export var bindPath = (
         });
     });
 
-    adhHttp.get(scope.badgesPath, {elements: "paths"}).then((badges) => {
-        var badgelist : string[] = badges.data[SIPool.nick].elements;
-        $q.all(_.map(badgelist, (b) => adhHttp.get(b))).then((result) => {
-            // FIXME: here a check is currently missing that checks if we have group at hand
-            // scope.badges = _.map(result, getBadge);
-        });
-    });
-
     if (typeof pathKey !== "undefined") {
         scope.$watch(pathKey, (path : string) => {
             if (path) {
@@ -179,7 +169,6 @@ export var badgeAssignmentCreateDirective = (
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Assignment.html",
         scope: {
-            badgesPath: "@",
             badgeablePath: "@",
             poolPath: "@",
             showDescription: "=?",
@@ -226,7 +215,6 @@ export var badgeAssignmentEditDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Assignment.html",
         scope: {
             path: "@",
-            badgesPath: "@",
             poolPath: "@",
             showDescription: "=?",
             onSubmit: "=?",
@@ -290,21 +278,12 @@ export var badgeAssignmentDirective = (
             scope.badgeablePath = scope.path;
             scope.data = {};
 
-            var processUrl = adhTopLevelState.get("processUrl");
-            var promise1 = adhHttp.get(processUrl).then((resource) => {
-                scope.badgesPath = resource.data[SIHasBadgesPool.nick].badges_pool;
-            });
-
-            var promise2 = adhHttp.get(scope.path).then((proposal) => {
+            adhHttp.get(scope.path).then((proposal) => {
                 scope.poolPath = proposal.data[SIBadgeable.nick].post_pool;
 
                 return adhGetBadges(proposal).then((assignments : IBadge[]) => {
                     scope.assignments = assignments;
                 });
-            });
-
-            $q.all([promise1, promise2]).then(() => {
-                scope.ready = true;
             });
 
             scope.submit = () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Module.ts
@@ -26,8 +26,20 @@ export var register = (angular) => {
                 .registerDirective("badge-assignment-edit");
         }])
         .factory("adhGetBadges", ["adhHttp", "$q", AdhBadge.getBadgesFactory])
-        .directive("adhBadgeAssignmentCreate", ["adhConfig", "adhHttp", "$q", "adhCredentials", AdhBadge.badgeAssignmentCreateDirective])
-        .directive("adhBadgeAssignmentEdit", ["adhConfig", "adhHttp", "$q", "adhCredentials", AdhBadge.badgeAssignmentEditDirective])
+        .directive("adhBadgeAssignmentCreate", [
+            "adhConfig",
+            "adhHttp",
+            "adhPermissions",
+            "$q",
+            "adhCredentials",
+            AdhBadge.badgeAssignmentCreateDirective])
+        .directive("adhBadgeAssignmentEdit", [
+            "adhConfig",
+            "adhHttp",
+            "adhPermissions",
+            "$q",
+            "adhCredentials",
+            AdhBadge.badgeAssignmentEditDirective])
         .directive("adhBadgeAssignment", ["adhConfig", "adhHttp", "$q", "adhTopLevelState", "adhGetBadges",
             AdhBadge.badgeAssignmentDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Wrapper.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Wrapper.html
@@ -20,6 +20,7 @@
             data-ng-if="data.selected && data.selected !== 'new'"
             data-path="{{data.selected}}"
             data-badges-path="{{badgesPath}}"
+            data-pool-path="{{poolPath}}"
             data-show-description="showDescription"
             data-on-submit="submit"
             data-on-cancel="cancel"></adh-badge-assignment-edit>
@@ -28,6 +29,7 @@
             data-ng-if="data.selected === 'new'"
             data-badgeable-path="{{badgeablePath}}"
             data-badges-path="{{badgesPath}}"
+            data-pool-path="{{poolPath}}"
             data-show-description="showDescription"
             data-on-submit="submit"
             data-on-cancel="cancel"></adh-badge-assignment-create>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Wrapper.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Wrapper.html
@@ -14,21 +14,22 @@
             data-ng-class="{'is-selected': data.selected === 'new'}"
             class="badge m-new">{{ "TR__NEW_BADGE" | translate }}</a>
     </div>
-    <div data-ng-if="ready">
-      <adh-badge-assignment-edit
-         data-ng-if="data.selected && data.selected !== 'new'"
-         data-path="{{data.selected}}"
-         data-pool-path="{{poolPath}}"
-         data-show-description="showDescription"
-         data-on-submit="submit"
-         data-on-cancel="cancel"></adh-badge-assignment-edit>
 
-      <adh-badge-assignment-create
-         data-ng-if="data.selected === 'new'"
-         data-badgeable-path="{{badgeablePath}}"
-         data-pool-path="{{poolPath}}"
-         data-show-description="showDescription"
-         data-on-submit="submit"
-         data-on-cancel="cancel"></adh-badge-assignment-create>
+    <div data-ng-if="ready">
+        <adh-badge-assignment-edit
+            data-ng-if="data.selected && data.selected !== 'new'"
+            data-path="{{data.selected}}"
+            data-pool-path="{{poolPath}}"
+            data-show-description="showDescription"
+            data-on-submit="submit"
+            data-on-cancel="cancel"></adh-badge-assignment-edit>
+
+        <adh-badge-assignment-create
+            data-ng-if="data.selected === 'new'"
+            data-badgeable-path="{{badgeablePath}}"
+            data-pool-path="{{poolPath}}"
+            data-show-description="showDescription"
+            data-on-submit="submit"
+            data-on-cancel="cancel"></adh-badge-assignment-create>
     </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Wrapper.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Wrapper.html
@@ -14,20 +14,21 @@
             data-ng-class="{'is-selected': data.selected === 'new'}"
             class="badge m-new">{{ "TR__NEW_BADGE" | translate }}</a>
     </div>
+    <div data-ng-if="ready">
+      <adh-badge-assignment-edit
+         data-ng-if="data.selected && data.selected !== 'new'"
+         data-path="{{data.selected}}"
+         data-pool-path="{{poolPath}}"
+         data-show-description="showDescription"
+         data-on-submit="submit"
+         data-on-cancel="cancel"></adh-badge-assignment-edit>
 
-    <adh-badge-assignment-edit
-       data-ng-if="data.selected && data.selected !== 'new'"
-       data-path="{{data.selected}}"
-       data-pool-path="{{poolPath}}"
-       data-show-description="showDescription"
-       data-on-submit="submit"
-       data-on-cancel="cancel"></adh-badge-assignment-edit>
-
-    <adh-badge-assignment-create
-       data-ng-if="data.selected === 'new'"
-       data-badgeable-path="{{badgeablePath}}"
-       data-pool-path="{{poolPath}}"
-       data-show-description="showDescription"
-       data-on-submit="submit"
-       data-on-cancel="cancel"></adh-badge-assignment-create>
+      <adh-badge-assignment-create
+         data-ng-if="data.selected === 'new'"
+         data-badgeable-path="{{badgeablePath}}"
+         data-pool-path="{{poolPath}}"
+         data-show-description="showDescription"
+         data-on-submit="submit"
+         data-on-cancel="cancel"></adh-badge-assignment-create>
+    </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Wrapper.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Wrapper.html
@@ -15,23 +15,19 @@
             class="badge m-new">{{ "TR__NEW_BADGE" | translate }}</a>
     </div>
 
-    <div data-ng-if="ready">
-        <adh-badge-assignment-edit
-            data-ng-if="data.selected && data.selected !== 'new'"
-            data-path="{{data.selected}}"
-            data-badges-path="{{badgesPath}}"
-            data-pool-path="{{poolPath}}"
-            data-show-description="showDescription"
-            data-on-submit="submit"
-            data-on-cancel="cancel"></adh-badge-assignment-edit>
+    <adh-badge-assignment-edit
+       data-ng-if="data.selected && data.selected !== 'new'"
+       data-path="{{data.selected}}"
+       data-pool-path="{{poolPath}}"
+       data-show-description="showDescription"
+       data-on-submit="submit"
+       data-on-cancel="cancel"></adh-badge-assignment-edit>
 
-        <adh-badge-assignment-create
-            data-ng-if="data.selected === 'new'"
-            data-badgeable-path="{{badgeablePath}}"
-            data-badges-path="{{badgesPath}}"
-            data-pool-path="{{poolPath}}"
-            data-show-description="showDescription"
-            data-on-submit="submit"
-            data-on-cancel="cancel"></adh-badge-assignment-create>
-    </div>
+    <adh-badge-assignment-create
+       data-ng-if="data.selected === 'new'"
+       data-badgeable-path="{{badgeablePath}}"
+       data-pool-path="{{poolPath}}"
+       data-show-description="showDescription"
+       data-on-submit="submit"
+       data-on-cancel="cancel"></adh-badge-assignment-create>
 </div>


### PR DESCRIPTION
Fixes that the existing badge UI can't be used to assign batches from groups.