### PR TITLE
make bower dependencies more stable 

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,4 +1,0 @@
-[url "https://"]
-    insteadOf = git://
-[url "https://github.com"]
-    insteadOf = git@github.com

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,4 @@
+[url "https://"]
+    insteadOf = git://
+[url "https://github.com"]
+    insteadOf = git@github.com

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -147,7 +147,7 @@ inline =
         "devDependencies": {
             "typescript": "1.8.7",
             "tslint": "3.5.0",
-            "bower": "1.7.7",
+            "bower": "1.7.9",
             "jasmine": "2.4.1",
             "protractor": "2.2.0",
             "sync-exec": "0.6.2",

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -214,12 +214,12 @@ packages =
     moment#2.11.1
     relatively-sticky#2.0.0
     ng-flow#2.6.1
-    nidico/socialshareprivacy#protocol-relative-urls
+    nidico/socialshareprivacy#392c61fef7b99b75dec90d16213c8c7a702d1809
     webshim#1.15.10
     lato#0.3.0
     webfont-opensans#0.0.2
     roboto-fontface#0.4.3
-    merriweather-fontface
+    merriweather-fontface#f5fee770c034a92a3a551d52fcd34f210acf23d2
 
 executable = ${buildout:bin-directory}/node ${buildout:directory}/node_modules/.bin/bower --config.interactive=false
 base-directory = ${adhocracy:frontend.static_dir}/lib


### PR DESCRIPTION
* update bower to 1.7.9		

* Force "https://" instead of "git://" to checkout git repositories

      - some proxies allow only http/https connection scheme (like my mobile network)
      - seems to make less connection problems when running bower recipe

* use revision number to checkout  socialsherprivacy/merriweather to allow caching