### PR TITLE
add functions to report + delete proposals in IdeaCollection

### DIFF
--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -93,7 +93,11 @@ export var workbenchDirective = (
 
 export var proposalDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhHttp : AdhHttp.Service<any>,
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service,
+    $location : angular.ILocationService,
+    $window : Window
 ) => {
     return {
         restrict: "E",
@@ -102,6 +106,22 @@ export var proposalDetailColumnDirective = (
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
+            adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "versionOptions");
+            scope.delete = () => {
+                var proposalClass = RIGeoProposal;
+                if (scope.isKiezkasse) {
+                    proposalClass = RIKiezkasseProposal;
+                } else if (scope.isBuergerhaushalt) {
+                    proposalClass = RIBuergerhaushaltProposal;
+                }
+                // FIXME: translate
+                if ($window.confirm("Do you really want to delete this?")) {
+                    adhHttp.hide(AdhUtil.parentPath(scope.proposalUrl), proposalClass.content_type)
+                        .then(() => {
+                            adhTopLevelState.goToCameFrom("/");
+                        });
+                }
+            };
         }
     };
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -107,7 +107,7 @@ export var proposalDetailColumnDirective = (
             column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "versionOptions");
-            scope.delete = () => {
+            scope.hide = () => {
                 var proposalClass = RIGeoProposal;
                 if (scope.isKiezkasse) {
                     proposalClass = RIKiezkasseProposal;

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -106,7 +106,6 @@ export var proposalDetailColumnDirective = (
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
-            adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "versionOptions");
             scope.hide = () => {
                 var proposalClass = RIGeoProposal;
                 if (scope.isKiezkasse) {

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
@@ -42,7 +42,8 @@ export var register = (angular) => {
         .directive("adhMeinberlinIdeaCollectionWorkbench", [
             "adhTopLevelState", "adhConfig", "adhHttp", IdeaCollection.workbenchDirective])
         .directive("adhMeinberlinIdeaCollectionProposalDetailColumn", [
-            "adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", "$location", "$window", IdeaCollection.proposalDetailColumnDirective])
+            "adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", "$location", "$window",
+            IdeaCollection.proposalDetailColumnDirective])
         .directive("adhMeinberlinIdeaCollectionProposalCreateColumn", [
             "adhConfig", IdeaCollection.proposalCreateColumnDirective])
         .directive("adhMeinberlinIdeaCollectionProposalEditColumn", ["adhConfig", IdeaCollection.proposalEditColumnDirective])

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
@@ -42,7 +42,12 @@ export var register = (angular) => {
         .directive("adhMeinberlinIdeaCollectionWorkbench", [
             "adhTopLevelState", "adhConfig", "adhHttp", IdeaCollection.workbenchDirective])
         .directive("adhMeinberlinIdeaCollectionProposalDetailColumn", [
-            "adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", "$location", "$window",
+            "adhConfig",
+            "adhHttp",
+            "adhPermissions",
+            "adhTopLevelState",
+            "$location",
+            "$window",
             IdeaCollection.proposalDetailColumnDirective])
         .directive("adhMeinberlinIdeaCollectionProposalCreateColumn", [
             "adhConfig", IdeaCollection.proposalCreateColumnDirective])

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
@@ -42,7 +42,7 @@ export var register = (angular) => {
         .directive("adhMeinberlinIdeaCollectionWorkbench", [
             "adhTopLevelState", "adhConfig", "adhHttp", IdeaCollection.workbenchDirective])
         .directive("adhMeinberlinIdeaCollectionProposalDetailColumn", [
-            "adhConfig", "adhPermissions", IdeaCollection.proposalDetailColumnDirective])
+            "adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", "$location", "$window", IdeaCollection.proposalDetailColumnDirective])
         .directive("adhMeinberlinIdeaCollectionProposalCreateColumn", [
             "adhConfig", IdeaCollection.proposalCreateColumnDirective])
         .directive("adhMeinberlinIdeaCollectionProposalEditColumn", ["adhConfig", IdeaCollection.proposalEditColumnDirective])

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -29,7 +29,7 @@
                     data-parent-path="true"
                     data-resource-path="{{proposalUrl}}"></adh-report-action>
                 <a href=""
-                    data-ng-click="delete()"
+                    data-ng-click="hide()"
                     data-ng-if="versionOptions.hide"
                     class="action-bar-item"
                     title="{{ 'TR__DELETE' | translate }}">

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -16,21 +16,23 @@
     </a>
 
     <div data-ng-switch-when="body">
-        <adh-resource-actions
-            data-resource-path="{{proposalUrl}}"
-            data-parent-path="true"
-            data-edit="true"
-            data-print="true">
-        </adh-resource-actions>
-        <a href=""
-            data-ng-click="delete()"
-            data-ng-if="versionOptions.hide"
-            class="comment-header-link"
-            title="{{ 'TR__DELETE' | translate }}">
-            <i class="comment-header-icon icon-x"></i>
-        </a>
         <adh-recompile-on-change
             data-value="{{proposalUrl}}">
+            <div class="action-bar">
+                <adh-edit-action
+                    data-ng-if="proposalUrl && proposalItemOptions.PUT"
+                    data-class="action-bar-item"
+                    data-parent-path="true"
+                    data-resource-path="{{proposalUrl}}"></adh-edit-action>
+                <a href=""
+                    data-ng-click="delete()"
+                    data-ng-if="versionOptions.hide"
+                    class="action-bar-item"
+                    title="{{ 'TR__DELETE' | translate }}">
+                    {{ 'TR__DELETE' | translate }}</a>
+                <adh-print-action
+                    data-class="action-bar-item"></adh-print-action>
+            </div>
             <adh-meinberlin-proposal-detail
                 data-ng-if="proposalUrl"
                 data-is-buergerhaushalt="isBuergerhaushalt"

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -30,7 +30,7 @@
                     data-resource-path="{{proposalUrl}}"></adh-report-action>
                 <a href=""
                     data-ng-click="hide()"
-                    data-ng-if="versionOptions.hide"
+                    data-ng-if="proposalItemOptions.hide"
                     class="action-bar-item"
                     title="{{ 'TR__DELETE' | translate }}">
                     {{ 'TR__DELETE' | translate }}</a>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -24,6 +24,10 @@
                     data-class="action-bar-item"
                     data-parent-path="true"
                     data-resource-path="{{proposalUrl}}"></adh-edit-action>
+                <adh-report-action
+                    data-class="action-bar-item"
+                    data-parent-path="true"
+                    data-resource-path="{{proposalUrl}}"></adh-report-action>
                 <a href=""
                     data-ng-click="delete()"
                     data-ng-if="versionOptions.hide"
@@ -41,4 +45,9 @@
             </adh-meinberlin-proposal-detail>
         </adh-recompile-on-change>
     </div>
+    <adh-report-abuse
+        data-ng-switch-when="overlays"
+        data-ng-if="overlay === 'abuse'"
+        data-url="{{ shared.abuseUrl | adhParentPath | adhResourceUrl | adhCanonicalUrl }}">
+    </adh-report-abuse>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -45,9 +45,10 @@
             </adh-meinberlin-proposal-detail>
         </adh-recompile-on-change>
     </div>
+
     <adh-report-abuse
         data-ng-switch-when="overlays"
         data-ng-if="overlay === 'abuse'"
-        data-url="{{ shared.abuseUrl | adhParentPath | adhResourceUrl | adhCanonicalUrl }}">
+        data-url="{{ proposalUrl | adhParentPath | adhResourceUrl | adhCanonicalUrl }}">
     </adh-report-abuse>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -22,7 +22,13 @@
             data-edit="true"
             data-print="true">
         </adh-resource-actions>
-
+        <a href=""
+            data-ng-click="delete()"
+            data-ng-if="versionOptions.hide"
+            class="comment-header-link"
+            title="{{ 'TR__DELETE' | translate }}">
+            <i class="comment-header-icon icon-x"></i>
+        </a>
         <adh-recompile-on-change
             data-value="{{proposalUrl}}">
             <adh-meinberlin-proposal-detail


### PR DESCRIPTION
this continues #2329.

- report is taken from `adhResourceAction`, as was the case for edit and print.
- the delete ResourceAction doesn't work for this (see #2268), so it's done as in `adhComment`.
- the template needed a little adjustment to the fact that edit, print and report are directives and delete isn't (see 		0ae6446).

I'm a little unsure about permission (checks):
- By default, users currently can't delete their own proposals. - I think this is fine.
- Everyone can now report proposals in Buergerhaushalt, ISEK and Kiezkasse processes. - I don't know the status of this. (Everyone can report comments, this has always been the case.)
