### PR TITLE
Simplify check code and compile

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -240,30 +240,33 @@ static_directories =
     ${adhocracy:frontend.core.static_dir}
 inline =
     #!/usr/bin/env python
+    """ Merge static directories of multiple packages.
+
+        Assumes that this script is in full control of all symlinks under
+        target_dir. If symlinks are manually set or created by other
+        scripts, they will be deleted.
+    """
     import os
     import os.path
 
     target_dir = "${adhocracy:frontend.static_dir}"
     source_dirs = "${:static_directories}".split()
 
-    # remove old links
+    # remove old links from target dir
+    for target_root, dirnames, filenames in os.walk(target_dir):
+        for filename in filenames:
+            link_name = os.path.join(target_root, filename)
+            if os.path.islink(link_name):
+                os.unlink(link_name)
+
+    # set new symlinks
     for source_dir in source_dirs:
         for source_root, dirnames, filenames in os.walk(source_dir):
             target_root = os.path.join(target_dir, os.path.relpath(source_root, source_dir))
-
             if not os.path.exists(target_root):
                 os.makedirs(target_root)
             elif not os.path.isdir(target_root):
                 raise Exception("unexpcted file {}".format(target_root))
-
-            for filename in filenames:
-                link_name = os.path.join(target_root, filename)
-                if os.path.islink(link_name):
-                    os.unlink(link_name)
-
-    for source_dir in source_dirs:
-        for source_root, dirnames, filenames in os.walk(source_dir):
-            target_root = os.path.join(target_dir, os.path.relpath(source_root, source_dir))
 
             for filename in filenames:
                 link_name = os.path.join(target_root, filename)


### PR DESCRIPTION
 - delete all symlinks in target dir upon start
 - fixes error with moved or delted files in any source dir