### PR TITLE
Force "https://" instead of "git://" to checkout git repositories

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -8,6 +8,7 @@ parts +=
     merge_static_directories
     do_merge_static_directories
     frontend.current.link
+    force_https
     bower
     AdhocracySpec.ts
     meta_api
@@ -189,6 +190,14 @@ command =
     ${buildout:bin-directory}/webdriver-manager update
 update-command = ${:command}
 stop-on-error = yes
+
+[force_https]
+# Force "https://" instead of "git://" to checkout git repositories
+# some proxies allow only http/https connection scheme 
+# seems to make less connection problems when running bower recipe
+recipe = collective.recipe.cmd
+on_install=true
+cmds = git config url.https://.insteadOf git://
 
 [bower]
 recipe = bowerrecipe


### PR DESCRIPTION
some proxies allow only http/https connection scheme
seems to make less connection problems when running bower recipe