### PR TITLE
add mercator test setup script

### DIFF
--- a/src/mercator/mercator/tests/acceptance/setup_tests.sh
+++ b/src/mercator/mercator/tests/acceptance/setup_tests.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+./bin/import_resources etc/test.ini src/adhocracy_mercator/adhocracy_mercator/workflows/test_mercator2/resources.json
+./bin/set_workflow_state etc/test.ini /organisation/advocate-europe2 announce participate


### PR DESCRIPTION
Motivation:

Almost all acceptance test for mercator start with 404 not found, because the default process expected by the 
frontend was not created. This is quite confusing when debugging tests and also slows down the tests.

Proposal:

add test setup script to create initial content for mercator