### PR TITLE
Fix #2276: force buildout to update git checkouts

### DIFF
--- a/src/adhocracy_core/sources.cfg
+++ b/src/adhocracy_core/sources.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extensions = mr.developer
 auto-checkout = *
+always-checkout = Force
 
 [sources]
 supervisor = git https://github.com/Supervisor/supervisor.git rev=a5aedd836fe2c77eb5e16844e61393c32a84c60d


### PR DESCRIPTION
Fixes #2276 

All git repos checked out by buildout ( src/adhocracy_core/sources.cfg)
are updated now if the tag/reversion number changes.
 Manual changes are overriden.