### PR TITLE
try to make acceptance tests faster and more stable

### DIFF
--- a/etc/frontend_development.ini.in
+++ b/etc/frontend_development.ini.in
@@ -101,6 +101,7 @@ cachebust.method = init
 use = egg:gunicorn#main
 host = 0.0.0.0
 port = 6551
+workers = 4
 
 [loggers]
 keys = root, adhocracy_frontend

--- a/etc/frontend_test.ini.in
+++ b/etc/frontend_test.ini.in
@@ -41,6 +41,7 @@ adhocracy.custom.mercator_platform_path = /mercator/advocate/
 use = egg:gunicorn#main
 host = localhost
 port = 9090
+workers = 4
 
 [loggers]
 keys = root, adhocracy_frontend

--- a/etc/test.ini.in
+++ b/etc/test.ini.in
@@ -34,6 +34,7 @@ adhocracy.frontend_url = http://localhost:9090
 use = egg:gunicorn#main
 host = localhost
 port = 9080
+workers = 2
 
 [websockets]
 port = 8081

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/CommentSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/CommentSpec.js
@@ -2,10 +2,11 @@
 
 var shared = require("./shared.js");
 var EmbeddedCommentsPage = require("./EmbeddedCommentsPage.js");
-
+var UserPages = require("./UserPages.js");
 
 describe("comments", function() {
-    beforeEach(function() {
+
+    beforeAll(function() {
         shared.loginParticipant();
     });
 
@@ -46,40 +47,6 @@ describe("comments", function() {
         expect(page.getCommentText(comment)).toEqual("comment 0a");
     });
 
-    it("can not be edited by anonymous", function() {
-        var page = new EmbeddedCommentsPage("c5").get();
-        var comment = page.createComment("comment 1");
-        shared.logout();
-        expect(page.getEditLink(comment).isPresent()).toBe(false);
-    });
-
-    it("can not be edited by other user", function() {
-        var page = new EmbeddedCommentsPage("c6").get();
-        var comment = page.createComment("comment 1");
-        shared.logout();
-        shared.loginOtherParticipant();
-        page.get();
-        expect(page.getEditLink(comment).isPresent()).toBe(false);
-    });
-
-    it("can not be replied to by anonymous", function() {
-        var page = new EmbeddedCommentsPage("c7").get();
-        var comment = page.createComment("comment 1");
-        shared.logout();
-        expect(page.getReplyLink(comment).isPresent()).toBe(false);
-    });
-
-    it("can be replied to by other user", function() {
-        var page = new EmbeddedCommentsPage("c8").get();
-        var comment = page.createComment("comment 1");
-        shared.logout();
-        shared.loginOtherParticipant();
-        page.get();
-        expect(page.getReplyLink(comment).isPresent()).toBe(true);
-        var reply = page.createReply(comment, "reply 1");
-        expect(page.getCommentText(reply)).toEqual("reply 1");
-    });
-
     it("can be edited twice", function() {
         var page = new EmbeddedCommentsPage("c9").get();
         var comment = page.createComment("comment 1");
@@ -105,6 +72,49 @@ describe("comments", function() {
         var changedComment = page.editComment(parent, ["comment 1 - edited"]);
         var reply = page.createReply(changedComment, "reply 1");
 
+        expect(page.getCommentText(reply)).toEqual("reply 1");
+    });
+
+    it("can not be edited by anonymous", function() {
+        shared.loginParticipant();
+        var page = new EmbeddedCommentsPage("c5").get();
+        var comment = page.createComment("comment 1");
+        shared.logout();
+        expect(page.getEditLink(comment).isPresent()).toBe(false);
+    });
+
+    it("can not be replied to by anonymous", function() {
+        shared.loginParticipant();
+        var page = new EmbeddedCommentsPage("c7").get();
+        var comment = page.createComment("comment 1");
+        shared.logout();
+        expect(page.getReplyLink(comment).isPresent()).toBe(false);
+    });
+});
+
+describe("comments of other user", function() {
+    
+    var page;
+    
+    beforeAll( function () {
+        shared.loginParticipant();
+        page = new EmbeddedCommentsPage("c6").get();
+        page.createComment("comment 1");
+        shared.logout();
+        shared.loginOtherParticipant();
+    });
+    
+    it("can not be edited", function() {
+        page.get();
+        var comment = page.getFirstComment();
+        expect(page.getEditLink(comment).isPresent()).toBe(false);
+    });
+
+    it("can be replied", function() {
+        page.get();
+        var comment = page.getFirstComment();
+        expect(page.getReplyLink(comment).isPresent()).toBe(true);
+        var reply = page.createReply(comment, "reply 1");
         expect(page.getCommentText(reply)).toEqual("reply 1");
     });
 });

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/CommentSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/CommentSpec.js
@@ -2,10 +2,9 @@
 
 var shared = require("./shared.js");
 var EmbeddedCommentsPage = require("./EmbeddedCommentsPage.js");
-var UserPages = require("./UserPages.js");
+
 
 describe("comments", function() {
-
     beforeAll(function() {
         shared.loginParticipant();
     });
@@ -93,9 +92,8 @@ describe("comments", function() {
 });
 
 describe("comments of other user", function() {
-    
     var page;
-    
+
     beforeAll( function () {
         shared.loginParticipant();
         page = new EmbeddedCommentsPage("c6").get();
@@ -103,7 +101,7 @@ describe("comments of other user", function() {
         shared.logout();
         shared.loginOtherParticipant();
     });
-    
+
     it("can not be edited", function() {
         page.get();
         var comment = page.firstComment;

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/CommentSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/CommentSpec.js
@@ -13,22 +13,22 @@ describe("comments", function() {
     it("can be created", function() {
         var page = new EmbeddedCommentsPage("c1").get();
         var comment = page.createComment("comment 1");
-        expect(comment.isPresent()).toBe(true);
+        expect(comment.isDisplayed()).toBe(true);
         expect(page.getCommentText(comment)).toEqual("comment 1");
         expect(page.getCommentAuthor(comment)).toEqual(shared.participantName);
     });
 
     it("cannot be created empty", function() {
         var page = new EmbeddedCommentsPage("c2").get();
-        var comment = page.createComment("");
-        expect(comment.isPresent()).toBe(false);
+        page.createEmptyComment();
+        expect(page.allComments.count()).toBe(0);
     });
 
     it("can be created nested", function() {
         var createNestedReplies = function(parent, parentName, remaining) {
             var name = parentName + ".1";
             var reply = page.createReply(parent, name);
-            expect(reply.isPresent()).toBe(true);
+            expect(reply.isDisplayed()).toBe(true);
             expect(page.getCommentText(reply)).toEqual(name);
             if (remaining > 0) {
                 createNestedReplies(reply, name, remaining - 1);
@@ -106,13 +106,13 @@ describe("comments of other user", function() {
     
     it("can not be edited", function() {
         page.get();
-        var comment = page.getFirstComment();
+        var comment = page.firstComment;
         expect(page.getEditLink(comment).isPresent()).toBe(false);
     });
 
     it("can be replied", function() {
         page.get();
-        var comment = page.getFirstComment();
+        var comment = page.firstComment;
         expect(page.getReplyLink(comment).isPresent()).toBe(true);
         var reply = page.createReply(comment, "reply 1");
         expect(page.getCommentText(reply)).toEqual("reply 1");

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
@@ -43,6 +43,10 @@ var EmbeddedCommentsPage = function(referer) {
         //                   })
         //        });
     };
+    
+    this.getFirstComment = function() {
+        return this.listing.element(by.xpath("(//adh-comment)[1]"));
+    } 
 
     this.getReplyLink = function(comment) {
         return comment.element(by.css(".icon-reply"));

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
@@ -38,20 +38,12 @@ var EmbeddedCommentsPage = function(referer) {
         browser.wait(new_comment.isDisplayed);
         // FIXME: Return created comment
         return this.firstComment;
-        // return all.reduce(function(acc, elem) {
-        //            return protractor.promise.all(
-        //                acc.getAttribute("data-path"),
-        //                elem.getAttribute("data-path")
-        //            ).then(function(paths) {
-        //                       return (path[0] > path[1] ? acc : elem);
-        //                   })
-        //        });
     };
 
      this.createEmptyComment = function() {
          this.submitButton.click();
      }
-    
+
     this.getReplyLink = function(comment) {
         return comment.element(by.css(".icon-reply"));
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
@@ -10,6 +10,8 @@ var EmbeddedCommentsPage = function(referer) {
         + "?key=" + referer + "&pool-path=" + this.poolPath;
 
     this.listing = element(by.tagName("adh-comment-listing"));
+    this.firstComment = this.listing.all(by.tagName("adh-comment")).first();
+    this.allComments = this.listing.all(by.tagName("adh-comment"));
     this.listingCreateForm = this.listing.element(by.css(".listing-create-form"));
     this.commentInput = this.listingCreateForm.element(by.model("data.content"));
     this.submitButton = this.listingCreateForm.element(by.css("input[type=\"submit\"]"));
@@ -25,15 +27,17 @@ var EmbeddedCommentsPage = function(referer) {
     };
 
     this.fillComment = function(content) {
+        browser.wait(this.commentInput.isDisplayed);
         this.commentInput.sendKeys(content);
     };
 
     this.createComment = function(content) {
         this.fillComment(content);
         this.submitButton.click();
+        var new_comment = element(by.cssContainingText('.comment-content', content));
+        browser.wait(new_comment.isDisplayed);
         // FIXME: Return created comment
-        return this.listing.element(by.xpath("(//adh-comment)[1]"));
-
+        return this.firstComment;
         // return all.reduce(function(acc, elem) {
         //            return protractor.promise.all(
         //                acc.getAttribute("data-path"),
@@ -43,11 +47,11 @@ var EmbeddedCommentsPage = function(referer) {
         //                   })
         //        });
     };
-    
-    this.getFirstComment = function() {
-        return this.listing.element(by.xpath("(//adh-comment)[1]"));
-    } 
 
+     this.createEmptyComment = function() {
+         this.submitButton.click();
+     }
+    
     this.getReplyLink = function(comment) {
         return comment.element(by.css(".icon-reply"));
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
@@ -27,7 +27,7 @@ var EmbeddedCommentsPage = function(referer) {
     };
 
     this.fillComment = function(content) {
-        browser.wait(this.commentInput.isDisplayed);
+        browser.wait(this.commentInput.isDisplayed());
         this.commentInput.sendKeys(content);
     };
 
@@ -35,7 +35,7 @@ var EmbeddedCommentsPage = function(referer) {
         this.fillComment(content);
         this.submitButton.click();
         var new_comment = element(by.cssContainingText('.comment-content', content));
-        browser.wait(new_comment.isDisplayed);
+        browser.wait(new_comment.isDisplayed());
         // FIXME: Return created comment
         return this.firstComment;
     };
@@ -57,7 +57,7 @@ var EmbeddedCommentsPage = function(referer) {
         parent.element(by.model("data.content")).sendKeys(content);
         parent.element(by.css("input[type=\"submit\"]")).click();
         var new_comment = element(by.cssContainingText('.comment-content', content));
-        browser.wait(new_comment.isDisplayed);
+        browser.wait(new_comment.isDisplayed());
         return parent.all(by.css('.comment-children .comment')).first();
     };
 
@@ -68,7 +68,7 @@ var EmbeddedCommentsPage = function(referer) {
         var content = textarea.getAttribute('value');
         comment.element(by.css("input[type=\"submit\"]")).click();
         var edited_comment = element(by.cssContainingText('.comment-content', content));
-        browser.wait(edited_comment.isDisplayed);
+        browser.wait(edited_comment.isDisplayed());
         return comment;
     };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/RateSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/RateSpec.js
@@ -39,20 +39,18 @@ describe("ratings", function() {
     });
 
     it("is not affected by the edition of the comment", function() {
-        var page = new EmbeddedCommentsPage("c2");
-        page.getUrl().then(function() {
-            // at this point annotator may not be logged
-            // if we don't add the first shared.loginParticipant();
-            // even if the same call is performed by the beforeEach
-            // function?!
-            var comment = page.createComment("c4");
-            var rate = page.getRateWidget(comment);
+        var page = new EmbeddedCommentsPage("c2").get();
+        // at this point annotator may not be logged
+        // if we don't add the first shared.loginParticipant();
+        // even if the same call is performed by the beforeEach
+        // function?!
+        var comment = page.createComment("c4");
+        var rate = page.getRateWidget(comment);
 
-            rate.element(by.css(".rate-pro")).click();
+        rate.element(by.css(".rate-pro")).click();
 
-            var changedComment = page.editComment(comment, ["c4 - edited"]);
-            var rate2 = page.getRateWidget(changedComment);
-            expect(rate2.element(by.css(".rate-difference")).getText()).toEqual("+1");
-        });
+        var changedComment = page.editComment(comment, ["c4 - edited"]);
+        var rate2 = page.getRateWidget(changedComment);
+        expect(rate2.element(by.css(".rate-difference")).getText()).toEqual("+1");
     });
 });

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/RateSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/RateSpec.js
@@ -7,8 +7,11 @@ var EmbeddedCommentsPage = require("./EmbeddedCommentsPage.js");
 describe("ratings", function() {
     var page;
 
-    beforeEach(function() {
+    beforeAll(function() {
         shared.loginParticipant();
+    });
+
+    beforeEach(function() {
         page = new EmbeddedCommentsPage("c1").get();
     });
 
@@ -36,7 +39,6 @@ describe("ratings", function() {
     });
 
     it("is not affected by the edition of the comment", function() {
-        shared.loginParticipant();
         var page = new EmbeddedCommentsPage("c2");
         page.getUrl().then(function() {
             // at this point annotator may not be logged

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/RateSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/RateSpec.js
@@ -40,10 +40,6 @@ describe("ratings", function() {
 
     it("is not affected by the edition of the comment", function() {
         var page = new EmbeddedCommentsPage("c2").get();
-        // at this point annotator may not be logged
-        // if we don't add the first shared.loginParticipant();
-        // even if the same call is performed by the beforeEach
-        // function?!
         var comment = page.createComment("c4");
         var rate = page.getRateWidget(comment);
 

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserPageSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserPageSpec.js
@@ -19,16 +19,14 @@ describe("user page", function() {
         expect(reviewerPage.getUserName()).toBe("admin");
     });
 
+    var currentDate = Date.now().toString();
+    var subject = "title" + currentDate;
+    var content = "content" + currentDate;
+
     it("is possible to send a message", function(done) {
         shared.loginOtherParticipant();
 
-        var mailsBeforeMessaging =
-            fs.readdirSync(browser.params.mail.queue_path + "/new");
-
         var annotatorPage = new UserPages.UserPage().get("0000001");
-        var currentDate = Date.now().toString();
-        var subject = "title" + currentDate;
-        var content = "content" + currentDate;
 
         annotatorPage.sendMessage(subject, content);
 
@@ -36,24 +34,14 @@ describe("user page", function() {
         var button = element(by.css(".user-profile-info-button"));
         browser.wait(EC.elementToBeClickable(button), 5000);
         expect(EC.elementToBeClickable(button)).toBeTruthy();
+        done();
+    });
 
-        var flow = browser.controlFlow();
-        // ensures the tests are executed after the click() from sendMessage()
-        // and after the previous expectation.
-        // see http://spin.atomicobject.com/2014/12/17/asynchronous-testing-protractor-angular/
-        // and https://code.google.com/p/selenium/wiki/WebDriverJs#Control_Flows
-        // for an explanation
-        flow.execute(function() {
-            var mailsAfterMessaging =
-                fs.readdirSync(browser.params.mail.queue_path + "/new");
+    it("backend sends message as email", function(done) {
 
-            expect(mailsAfterMessaging.length).toEqual(mailsBeforeMessaging.length + 1);
-
-            var newMails = _.difference(mailsAfterMessaging, mailsBeforeMessaging);
-            expect(newMails.length).toEqual(1);
-
-            var mailpath = browser.params.mail.queue_path + "/new/" + newMails[0];
-
+            var newMails = fs.readdirSync(browser.params.mail.queue_path + "/new");
+            var lastMail = newMails.length - 1
+            var mailpath = browser.params.mail.queue_path + "/new/" + newMails[lastMail];
             shared.parseEmail(mailpath, function(mail) {
                 expect(mail.text).toContain(content);
                 expect(mail.subject).toContain(subject);
@@ -61,6 +49,5 @@ describe("user page", function() {
                 expect(mail.to[0].address).toContain("participant");
                 done();
             });
-        });
     });
 });

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserPageSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/UserPageSpec.js
@@ -38,16 +38,15 @@ describe("user page", function() {
     });
 
     it("backend sends message as email", function(done) {
-
-            var newMails = fs.readdirSync(browser.params.mail.queue_path + "/new");
-            var lastMail = newMails.length - 1
-            var mailpath = browser.params.mail.queue_path + "/new/" + newMails[lastMail];
-            shared.parseEmail(mailpath, function(mail) {
-                expect(mail.text).toContain(content);
-                expect(mail.subject).toContain(subject);
-                expect(mail.from[0].address).toContain("noreply");
-                expect(mail.to[0].address).toContain("participant");
-                done();
-            });
+        var newMails = fs.readdirSync(browser.params.mail.queue_path + "/new");
+        var lastMail = newMails.length - 1
+        var mailpath = browser.params.mail.queue_path + "/new/" + newMails[lastMail];
+        shared.parseEmail(mailpath, function(mail) {
+            expect(mail.text).toContain(content);
+            expect(mail.subject).toContain(subject);
+            expect(mail.from[0].address).toContain("noreply");
+            expect(mail.to[0].address).toContain("participant");
+            done();
+        });
     });
 });


### PR DESCRIPTION
* refactor: simplify send message acceptance test		
* refactor: prefere beforeAll instead of beforeEach in acceptance tests 
     Page loads like for Login/Logout in tests need a lot of time and may cause timeout
    problems (angular app is not fully loaded but protractor thinks otherwise)
   With using BeforAll instead of beforeEach we can redduce the nummer of page loads .

* stablize CommentsPage acceptance test helper			
* increase backend server workers to slightly improve accptance test speed