### PR TITLE
physical deletion

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -5,7 +5,7 @@ permissions:
   - [create,                         ~,         A,             ~,            ~,         ~,       ~,         ~] # default permission to create resource sheets/fields; general guard to create resources (POST requests)
   - [edit,                           ~,         ~,             ~,            ~,         A,       ~,         A] # default permission to edit resourche sheets/fields
   - [edit_some,                      ~,         A,             ~,            ~,         ~,       ~,         ~] # General guard permission to edit non versionable resources (do put requests)
-  - [delete,                         ~,         ~,             ~,            A,         A,       ~,         A] # mark resources as "deleted"
+  - [delete,                         ~,         ~,             ~,            A,         A,       ~,         A] # delete resources
   - [hide,                           ~,         ~,             ~,            ~,         ~,       ~,         A] # mark resources as "hidden" because there are legal problems.
   - [do_transition,                  ~,         ~,             ~,            ~,         ~,       A,         A] # default permission to do transition to next workflow state (phase)
   - [message_to_user,                ~,         A,             ~,            ~,         ~,       ~,         ~] # send message to user

--- a/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
@@ -7,6 +7,7 @@ from substanced.event import ACLModified
 
 from adhocracy_core.interfaces import IItem
 from adhocracy_core.interfaces import IResource
+from adhocracy_core.interfaces import IResourceWillBeDeleted
 from adhocracy_core.interfaces import IResourceSheetModified
 from adhocracy_core.interfaces import IItemVersionNewVersionAdded
 from adhocracy_core.interfaces import ISheetBackReferenceModified
@@ -139,3 +140,5 @@ def includeme(config):
     config.add_subscriber(add_changelog_visibility,
                           IResourceSheetModified,
                           event_isheet=IMetadata)
+    config.add_subscriber(add_changelog_visibility,
+                          IResourceWillBeDeleted)

--- a/src/adhocracy_core/adhocracy_core/events/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/events/__init__.py
@@ -13,6 +13,7 @@ from zope.interface.interfaces import IInterface
 from adhocracy_core.interfaces import IItemVersionNewVersionAdded
 from adhocracy_core.interfaces import ISheetReferenceNewVersion
 from adhocracy_core.interfaces import IResourceCreatedAndAdded
+from adhocracy_core.interfaces import IResourceWillBeDeleted
 from adhocracy_core.interfaces import IResourceSheetModified
 from adhocracy_core.interfaces import ILocalRolesModfied
 from adhocracy_core.interfaces import ISheet
@@ -36,6 +37,22 @@ class ResourceCreatedAndAdded:
         self.parent = parent
         self.registry = registry
         self.creator = creator
+
+
+@implementer(IResourceWillBeDeleted)
+class ResourceWillBeDeleted:
+    """An event type sent when a IResource will be deleted.
+
+    :param object(adhocracy_core.interfaces.IResource):
+    :param parent(adhocracy_core.interfaces.IResource):
+    :param registry(pyramid.registry.Registry):
+    """
+
+    def __init__(self, object, parent, registry):
+        """Initialize self."""
+        self.object = object
+        self.parent = parent
+        self.registry = registry
 
 
 @implementer(IResourceSheetModified)

--- a/src/adhocracy_core/adhocracy_core/events/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/events/test_init.py
@@ -23,6 +23,24 @@ class ResourceCreatedAndAddedUnitTest(unittest.TestCase):
         assert verifyObject(IResourceCreatedAndAdded, inst)
 
 
+class ResourceDeletedTest:
+
+    def make_one(self, *args):
+        from adhocracy_core.events import ResourceWillBeDeleted
+        return ResourceWillBeDeleted(*args)
+
+    def test_create(self):
+        from adhocracy_core.interfaces import IResourceWillBeDeleted
+        context = testing.DummyResource()
+        parent = testing.DummyResource()
+        registry = testing.DummyResource()
+
+        inst = self.make_one(context, parent, registry)
+
+        assert IResourceWillBeDeleted.providedBy(inst)
+        assert verifyObject(IResourceWillBeDeleted, inst)
+
+
 class ResourceSheetModifiedUnitTest(unittest.TestCase):
 
     def make_one(self, *arg):

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -8,6 +8,7 @@ from pyramid.interfaces import ILocation
 from pyramid.interfaces import IAuthorizationPolicy
 from pyramid.interfaces import IRequest
 from pyramid.security import ACLPermitsResult
+from pyramid.registry import Registry
 from zope.deprecation import deprecated
 from zope.interface import Attribute
 from zope.interface import Interface
@@ -389,6 +390,13 @@ class IPool(IResource):  # pragma: no cover
         """
     # TODO remove find_service, substanced.util.find_service does the same
 
+    def delete(name: str, registry: Registry):
+        """Remove subobject `name` from database.
+
+        :raises KeyError: if `name`is not a valid subresource name
+        """
+        # TODO add delete/undelete feature
+
 
 class IServicePool(IPool, IService):
     """Pool serving as a :term:`service`."""
@@ -474,6 +482,14 @@ class IResourceCreatedAndAdded(IObjectEvent):
     parent = Attribute('The parent of the new resource')
     registry = Attribute('The pyramid registry')
     creator = Attribute('User resource object of the authenticated User')
+
+
+class IResourceWillBeDeleted(IObjectEvent):
+    """An event type sent when a IResource will be deleted."""
+
+    object = Attribute('The going to be deleted resource')
+    parent = Attribute('The parent of the deleted resource')
+    registry = Attribute('The pyramid registry')
 
 
 class IItemVersionNewVersionAdded(IObjectEvent):

--- a/src/adhocracy_core/adhocracy_core/resources/pool.py
+++ b/src/adhocracy_core/adhocracy_core/resources/pool.py
@@ -95,7 +95,7 @@ class Pool(Base, Folder):
     def delete(self, name: str, registry: Registry):
         """Delete subresource `name` from database.
 
-        :raises KeyError: if `name`is not a valid subresource name
+        :raises KeyError: if `name` is not a valid subresource name
         """
         subresource = self[name]
         event = ResourceWillBeDeleted(object=subresource,

--- a/src/adhocracy_core/adhocracy_core/resources/test_pool.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_pool.py
@@ -102,3 +102,20 @@ class TestPoolClass:
         inst['service'] = service
         service = inst.find_service('service')
         assert service is inst['service']
+
+    def test_delete_removes_subresource(self, registry, context):
+        inst = self._makeOne()
+        inst['child'] = context
+        inst.delete('child', registry)
+        assert 'child' not in inst
+
+    def test_delete_sends_deleted_event(self, config, registry, context):
+        from adhocracy_core.testing import create_event_listener
+        from adhocracy_core.events import IResourceWillBeDeleted
+        deleted_listener = create_event_listener(config, IResourceWillBeDeleted)
+        inst = self._makeOne()
+        inst['child'] = context
+        inst.delete('child', registry)
+        event = deleted_listener[0]
+        assert event.parent == inst
+        assert event.object == context

--- a/src/adhocracy_core/adhocracy_core/rest/schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/schemas.py
@@ -266,6 +266,12 @@ class ResourceResponseSchema(ResourcePathSchema):
     updated_resources = UpdatedResourcesSchema()
 
 
+class DELETEResourceResponseSchema(MappingSchema):
+    """Data structure for Resource Delete requests."""
+
+    updated_resources = UpdatedResourcesSchema()
+
+
 class ItemResponseSchema(ResourceResponseSchema):
     """Data structure for responses of IItem requests."""
 
@@ -644,7 +650,7 @@ class POSTMessageUserViewRequestSchema(MappingSchema):
 class BatchHTTPMethod(SingleLine):
     """An HTTP method in a batch request."""
 
-    validator = OneOf(['GET', 'POST', 'PUT', 'OPTIONS'])
+    validator = OneOf(['GET', 'POST', 'PUT', 'OPTIONS', 'DELETE'])
     missing = required
 
 
@@ -1218,7 +1224,9 @@ options_resource_response_data_dict =\
      'PUT': {'request_body': {'content_type': '',
                               'data': {}},
              'response_body': {'content_type': '',
-                               'path': ''}}}
+                               'path': ''}},
+     'DELETE': {},
+     }
 
 
 @deferred

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -484,6 +484,7 @@ class TestItemRESTView:
         assert 'options' in dir(inst)
         assert 'get' in dir(inst)
         assert 'put' in dir(inst)
+        assert 'delete' in dir(inst)
 
     def test_get_item_with_first_version(self, request_, item,
                                          mock_tags_sheet):

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -395,6 +395,14 @@ class ItemRESTView(PoolRESTView):
         return cstruct
 
     @api_view(
+        request_method='DELETE',
+        permission='delete',
+    )
+    def delete(self) -> dict:  # pragma: no cover
+        """Delete resource."""
+        return super().delete()
+
+    @api_view(
         request_method='POST',
         permission='create',
         schema=POSTItemRequestSchema,

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -115,6 +115,12 @@ class DummyPool(testing.DummyResource):
         from substanced.util import find_service
         return find_service(self, service_name, *sub_service_names)
 
+    def delete(self, name, registry):
+        subresource = self[name]
+        del self[name]
+        subresource.__name__ = None
+        subresource.__parent__ = None
+
 
 def register_sheet(context, mock_sheet, registry, isheet=None) -> Mock:
     """Register `mock_sheet` for `context`. You can ony use this only once.
@@ -847,6 +853,14 @@ class AppUser:
                             headers=self.header,
                             params=params,
                             expect_errors=True)
+        return resp
+
+    def delete(self, path: str) -> TestResponse:
+        """Send delete request to the backend rest server."""
+        url = self._build_url(path)
+        resp = self.app.delete(url,
+                               headers=self.header,
+                               expect_errors=True)
         return resp
 
     def options(self, path: str) -> TestResponse:

--- a/src/adhocracy_core/adhocracy_core/utils/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/utils/test_init.py
@@ -227,6 +227,14 @@ class TestGetVisibilityChange:
         event.new_appstruct = {'deleted': False, 'hidden': False}
         assert self.call_fut(event) == VisibilityChange.visible
 
+    def test_return_invisible_if_deleted_event(self, context, pool):
+        from adhocracy_core.events import ResourceWillBeDeleted
+        from adhocracy_core.interfaces import VisibilityChange
+        event = ResourceWillBeDeleted(object=context,
+                                      parent=pool,
+                                      registry=None)
+        assert self.call_fut(event) == VisibilityChange.concealed
+
 
 def test_get_modification_date_not_cached():
     """The shared modification date is cached."""

--- a/src/adhocracy_core/docs/deletion.rst
+++ b/src/adhocracy_core/docs/deletion.rst
@@ -1,27 +1,46 @@
 .. _api-deletion:
 
-Deleting and Hiding Resources
-=============================
+Deleting Resources
+==================
 
-Two boolean fields (flags) defined in the
-*adhocracy_core.sheets.metadata.IMetadata* sheet can be used to delete or
-hide resources: *deleted* and *hidden*. Both default to false. If this sheet
-is omitted when POSTing new resources, the default values are used.
+Anyone who can edit a resource (editor role) can *delete* it by using
+the HTTP DELETE verb.  Deleted resources can not be recovered.
+
+Deleting an existing resource is only possible for updatable
+resources, i.e. *not* for Versions, as this would mess up the version
+DAG.
+
+The effect of deleting is as follows:
+
+* All child/descendant resources (whose resource path includes the path
+  of the deleted ancestor as prefix) are also deleted.
+* Deleted resources are no longer listed in parent pools or search
+  queries.
+* If the frontend attempts to retrieve a *deleted* resource via
+  GET, the backend responds with HTTP status code *404 Not Found*, just
+  as if the resource had never existed.
+* *Deleted* resources may still be referenced from other
+  resources. If the frontend follows such references it must therefore
+  be prepared to encounter *404 Not Found* responses and deal with them
+  appropriately (e.g. by silently skipping them or by showing an
+  explanation such as "Comment deleted").
+
+Hiding Resources
+================
+
+Apart from physically deleting a resource, it can also be marked as
+"hidden" using a boolean field (flag) defined in the
+*adhocracy_core.sheets.metadata.IMetadata* sheet. It default to false.
+If this sheet is omitted when POSTing new resources, the default value
+is used.
 
 The usecase for deleting is that users want to withdraw some content.
 The usecase for hiding is that moderators want to hide unapproriate
-content.  In terms of implementation, they differ only by permissions.
+content.
 
-Deleting or hiding an existing resource is only possible for updatable
+Hiding an existing resource is only possible for updatable
 resources, i.e. *not* for Versions (which are immutable and hence don't
 allow PUT).
-
-Anyone who can edit a resource (editor role) can *delete* it by PUTting an
-update with *IMetadata { deleted: true }*. Likewise they can undelete a
-deleted resource by PUTting an update with *IMetadata { deleted: false
-}*. For simplicity, our PUT works like the HTTP PATCH command (added in RFC
-5789): any sheet and fields not mentioned in the PUTted data structure are
-left unchanged.
 
 Anyone with the *hide_resource* permission (typically granted to the manager
 role) can *hide* a resource by PUTting an update with *IMetadata { hidden:
@@ -29,73 +48,61 @@ true }*. Likewise they can un-hide a hidden resource by PUTting an update with
 *IMetadata { hidden: false }*. Nobody else can change the value of the
 *hidden* field.
 
-Newly created resources can also be marked as *deleted* or *hidden* by
-setting the initial value of these flags accordingly. However,
-the same permission restrictions apply. This might be useful for creating a
-*deleted* version as a successor of another version to mark the preceding
-version as obsolete. POSTing a resource with *IMetadata { hidden: true }*
-requires the *hide_resource* permission and, frankly, doesn't make any sense.
-
 The effect of these flags is as follows:
 
-* A positive value of the *deleted* and *hidden* flags is inherited by
-  child/descendant resources (whose resource path includes the path of the
-  deleted/hidden ancestor as prefix). Hence a *deleted* resource is one
-  that has its own *deleted* flag set to true or that has an ancestor whose
-  *deleted* flag is true. Likewise for *hidden* resources.
-* Normally, only resources that are neither *deleted* nor *hidden* are
-  listed in parent pools and search queries.
-* FIXME Not implemented yet, since the frontend doesn't yet need it:
-  The parameter *include=deleted|hidden|all* can be used to include
-  deleted and/or hidden resources in pool listings and other search queries.
-  If its value is *deleted*, resources will be found regardless of the value
-  of their *deleted* flag, but only if they are not *hidden.* If its value is
-  *hidden*, resources will be found regardless of the value of their *hidden*
-  flag, but only if they are not *deleted.* If its value is *all*, all
-  resources will be found. Anyone can specify these flags and get the paths
-  of deleted and/or hidden resources. However, only those with *hide_resource*
-  permission are ever able to view the contents of hidden resources.
-  It's also possible to set *include=visible* to get only non-deleted and
-  non-hidden resources, but it's not necessary since that is the default.
-* If the frontend attempts to retrieve a *deleted* or *hidden* resource via
-  GET, the backend normally responds with HTTP status code *410 Gone*.
-  FIXME Not implemented yet, since the frontend doesn't yet need it:
-  The frontend can override this by adding the parameter
-  *include=deleted|hidden|all* to the GET request, just as in search queries.
-  Anybody can view deleted resources in this way, and managers (those with
-  *hide_resource* permission) can view hidden resources in these ways. Those
-  without this permission will still get a *410 Gone* if the resource is
-  hidden.
-* The body of the *410 Gone* is a small JSON document that explains why the
-  resource is gone (whether it was deleted or hidden). It also shows who
-  made the last change to the resource and when::
+* A positive value of the *hidden* flags is inherited by
+  child/descendant resources (whose resource path includes the path of
+  the hidden ancestor as prefix). Hence a *hidden* resource is one that
+  has its own *hidden* flag set to true or that has an ancestor whose
+  *hidden* flag is true.
+* Normally, only resources that are not *hidden* are listed in parent
+  pools and search queries.
+* FIXME Not implemented yet, since the frontend doesn't yet need it: The
+  parameter *include=hidden* can be used to include hidden resources in
+  pool listings and other search queries.  If its value is *hidden*,
+  resources will be found regardless of the value of their *hidden*
+  flag.  However, only those with *hide_resource* permission are ever
+  able to view the contents of hidden resources.  It's also possible to
+  set *include=visible* to get only non-deleted and non-hidden
+  resources, but it's not necessary since that is the default.
+* If the frontend attempts to retrieve a *hidden* resource via GET, the
+  backend normally responds with HTTP status code *410 Gone*.
+  FIXME Not implemented yet, since the frontend doesn't yet need it: The
+  frontend can override this by adding the parameter *include=hidden* to
+  the GET request, just as in search queries.  Managers (those with
+  *hide_resource* permission) can view hidden resources in this way.
+  Those without this permission will still get a *410 Gone* if the
+  resource is hidden.
+* The body of the *410 Gone* is a small JSON document that explains why
+  the resource is gone (for future use if there may be other reasons
+  than *hidden*). It also shows who made the last change to the resource
+  and when::
 
-      { "reason": "deleted|hidden|both",
+      { "reason": "hidden",
         "modified_by:" "<path-to-user>",
         "modification_date": "<timestamp>"}
 
-  Often the last modification will have been the deletion or hiding of
-  the resource, but there is no guarantee that this is always the case.
-  Especially, the resource may be marked as hidden/deleted because one of its
-  ancestors was hidden/deleted (as that status is inherited). In that case,
-  the person who last modified the child resource likely has nothing to do
-  with the person who hid/deleted the ancestor resource.
-* *Deleted* or *hidden* resources may still be referenced from other
-  resources. If the frontend follows such references it must therefore
-  be prepared to encounter *410 Gone* responses and deal with them
-  appropriately (e.g. by silently skipping them or by showing an
-  explanation such as "Comment deleted").
+  Often the last modification will have been the hiding of the resource,
+  but there is no guarantee that this is always the case.  Especially,
+  the resource may be marked as hidden because one of its ancestors was
+  hidden (as that status is inherited). In that case, the person who
+  last modified the child resource likely has nothing to do with the
+  person who hid the ancestor resource.
+* *Hidden* resources may still be referenced from other resources. If
+  the frontend follows such references it must therefore be prepared to
+  encounter *410 Gone* responses and deal with them appropriately (e.g.
+  by silently skipping them or by showing an explanation such as
+  "Comment deleted").
 * FIXME Not implemented yet, since the frontend doesn't yet need it.
-  *Deleted* and *hidden* resources will normally not be shown in
-  backreferences, which are calculated on demand. The
-  *include=deleted|hidden|all* parameter can be used to change that and
-  include backreferences to deleted and/or hidden resources. The same
-  restrictions apply, i.e. normal users can use this parameter to find out
-  whether hidden backreferences exist, but they won't be able to see their
-  contents. In any case the frontend should be prepared to deal with
-  *410 Gone* when following backreferences in the same way as when
-  following forward reference -- even if it didn't explicitly ask to include
-  them, they might show up due to caching.
+  *Hidden* resources will normally not be shown in backreferences, which
+  are calculated on demand. The *include=hidden* parameter can be used
+  to change that and include backreferences to hidden resources. The
+  same restrictions apply, i.e. normal users can use this parameter to
+  find out whether hidden backreferences exist, but they won't be able
+  to see their contents. In any case the frontend should be prepared to
+  deal with *410 Gone* when following backreferences in the same way as
+  when following forward reference -- even if it didn't explicitly ask
+  to include them, they might show up due to caching.
 
 FIXME We should extend the Meta API to expose the distinction between
 references and backreferences to the frontend, currently only the backend
@@ -103,21 +110,14 @@ knows this.
 
 Notes:
 
-* Physical deletion of resources (pruning them from the DB without hope of
-  resurrection) is not currently possible through the REST API. There may be
-  server-side processes that prune some specific or even all *hidden*
-  resources from the DB from time to time or when started by an admin, but
-  they cannot be controlled via REST and are not specified or documented
-  here.
-* The HTTP DELETE command is not used since it would imply physically
-  deleting a resource.
-* This document is about deletion of resources (JSON documents). Deletion
-  of uploaded assets (images, PDFs etc.) is outside its current scope.
-* Currently, the deleted/hidden status of resources isn't treated as special
-  by the Websocket server. So, if an resource is flagged as deleted/hidden
-  (or undeleted etc.), a "modified" event is sent to subscribers of that
-  resource and a "modified_child" event is sent to subscribers of the parent
-  pool. FIXME At same point in the future, we might want to change that and
+* This document is about deletion of resources (JSON documents).
+  Deletion of uploaded assets (images, PDFs etc.) is outside its current
+  scope.
+* Currently, the hidden status of resources isn't treated as special by
+  the Websocket server. So, if an resource is flagged as hidden, a
+  "modified" event is sent to subscribers of that resource and a
+  "modified_child" event is sent to subscribers of the parent pool.
+  FIXME At same point in the future, we might want to change that and
   send "removed"/"removed_item" messages instead.
 
 

--- a/src/adhocracy_core/docs/deletion.rst
+++ b/src/adhocracy_core/docs/deletion.rst
@@ -3,7 +3,7 @@
 Deleting Resources
 ==================
 
-Anyone who can edit a resource (editor role) can *delete* it by using
+Anyone with the *delete_resource* permission can *delete* it by using
 the HTTP DELETE verb.  Deleted resources can not be recovered.
 
 Deleting an existing resource is only possible for updatable

--- a/src/adhocracy_core/docs/deletion.rst
+++ b/src/adhocracy_core/docs/deletion.rst
@@ -182,11 +182,12 @@ it::
 
     >>> resp = participant.options(document_item).json
     >>> 'DELETE' in resp
+    True
 
 But they cannot hide it::
 
-    >>> 'adhocracy_core.sheets.metadata.IMetadata' not in pprint(resp['PUT']['request_body']['data'])
-    True
+    >>> pprint(resp['PUT']['request_body']['data']['adhocracy_core.sheets.metadata.IMetadata'])
+    {'deleted': [True, False]}
 
 -- that special right is reserved to managers::
 
@@ -284,11 +285,13 @@ resources::
 
 In the end we can cleanup with some real deletion::
 
-    >>> resp = participant.delete("/pool1")
+    >>> resp = admin.delete("/pool1")
     >>> resp.status_code
-    201
+    200
 
-    >>> resp = anonymous.get("/pool1")
+    >>> resp.json['updated_resources']['removed']
+    ['.../pool1...
+
+    >>> resp = admin.get("/pool1")
     >>> resp.status_code
-    410
-
+    404

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -254,7 +254,7 @@ JSON object that has the allowed request methods as keys::
 
     >>> resp_data = testapp.options(rest_url + "/", headers=god_header).json
     >>> sorted(resp_data.keys())
-    ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
+    ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
 
 If a GET, POST, or PUT request is allowed, the corresponding key will point
 to an object that contains at least "request_body" and "response_body" as

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -390,7 +390,7 @@ The response object has 3 top-level entries:
   contains a reference to its creator.
 
   The subkey 'removed' lists any resources that have been removed
-  by marking them as deleted or hidden (see :doc:`deletion`)::
+  by marking them as hidden (see :doc:`deletion`)::
 
       >>> resp_data['updated_resources']['removed']
       []

--- a/src/adhocracy_core/docs/websockets.rst
+++ b/src/adhocracy_core/docs/websockets.rst
@@ -145,7 +145,7 @@ that has been subscribed.
           "resource": "RESOURCE_PATH",
           "child": "CHILD_RESOURCE_PATH" }
 
-    In practice this usually means that the resource has been deletd or
+    In practice this usually means that the resource has been deleted or
     marked as hidden (see :doc:`deletion`).
 
   * If a child (sub-Pool or Item) in the Pool is modified::

--- a/src/adhocracy_core/docs/websockets.rst
+++ b/src/adhocracy_core/docs/websockets.rst
@@ -116,7 +116,7 @@ that has been subscribed.
 
         { "event": "removed", "resource": "RESOURCE_PATH" }
 
-    In practice this usually means that the resource has been delted or marked
+    In practice this usually means that the resource has been deleted or marked
     hidden (see :doc:`deletion`).
 
 * If resource is a Pool:

--- a/src/adhocracy_core/docs/websockets.rst
+++ b/src/adhocracy_core/docs/websockets.rst
@@ -116,8 +116,8 @@ that has been subscribed.
 
         { "event": "removed", "resource": "RESOURCE_PATH" }
 
-    In practice this usually means that the resource has been marked as deleted
-    or hidden (see :doc:`deletion`).
+    In practice this usually means that the resource has been delted or marked
+    hidden (see :doc:`deletion`).
 
 * If resource is a Pool:
 
@@ -145,8 +145,8 @@ that has been subscribed.
           "resource": "RESOURCE_PATH",
           "child": "CHILD_RESOURCE_PATH" }
 
-    In practice this usually means that the resource has been marked as deleted
-    or hidden (see :doc:`deletion`).
+    In practice this usually means that the resource has been deletd or
+    marked as hidden (see :doc:`deletion`).
 
   * If a child (sub-Pool or Item) in the Pool is modified::
 
@@ -207,7 +207,7 @@ that has been subscribed.
 A note about resource removal: if a resource is removed (deleted or hidden),
 any subscribers to it will automatically be unsubscribed, so they won't
 receive further updates about this resource, even if it later "revealed"
-(unhidden or undeleted) again. Subscribers to the parent pool will receive a
+(unhidden) again. Subscribers to the parent pool will receive a
 "new_child" or "new_version" message notifying them about the revealed
 resource just as if it had been newly created.
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -201,7 +201,7 @@ export var badgeAssignment = (
                                     };
                                     transaction.post(scope.poolPath, assignment);
                                 } else if (!checked && assignmentExisted) {
-                                    transaction.delete(scope.assignments[badgePath].path, RIBadgeAssignment.content_type);
+                                    transaction.delete(scope.assignments[badgePath].path);
                                 }
                             });
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Convert.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Convert.ts
@@ -167,13 +167,17 @@ export var importResource = <R extends ResourcesBase.IResource>(
  * far.
  */
 export var importBatchResources = (
+    requests : any[],
     responses,
     metaApi : AdhMetaApi.Service,
     preliminaryNames : AdhPreliminaryNames.Service,
     adhCache : AdhCache.Service
-) : ResourcesBase.IResource[] => {
+) : any[] => {
 
-    return responses.map((response) => {
+    return responses.map((response, index) => {
+        if (requests[index].method === "DELETE") {
+            return { path: requests[index].path };
+        }
         response.data = response.body;
         delete response.body;
         return importResource(response, metaApi, preliminaryNames, adhCache);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -268,7 +268,7 @@ export class Service<R extends ResourcesBase.IResource> {
 
     public delete(path : string, config : IHttpConfig = {}) : angular.IPromise<any> {
         if (this.adhPreliminaryNames.isPreliminary(path)) {
-            throw "attempt to http-put preliminary path: " + path;
+            throw "attempt to http-delete preliminary path: " + path;
         }
         path = this.formatUrl(path);
         var headers = this.parseConfig(config);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -267,15 +267,16 @@ export class Service<R extends ResourcesBase.IResource> {
     }
 
     public delete(path : string, contentType : string, config : IHttpConfig = {}) : angular.IPromise<any> {
-        var obj = {
-            content_type: contentType,
-            data: {}
-        };
-        obj.data[SIMetadata.nick] = {
-            deleted: true
-        };
+        if (this.adhPreliminaryNames.isPreliminary(path)) {
+            throw "attempt to http-put preliminary path: " + path;
+        }
+        path = this.formatUrl(path);
+        var headers = this.parseConfig(config);
+        this.adhCache.invalidate(path);
 
-        return this.put(path, <any>obj, _.extend({}, config, {keepMetadata: true}));
+        return this.adhCredentials.ready.then(() => this.$http.delete(path, {
+            headers: <any>headers
+        }));
     }
 
     public postRaw(path : string, obj : R, config : IHttpConfig = {}) : angular.IPromise<any> {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Http.ts
@@ -266,7 +266,7 @@ export class Service<R extends ResourcesBase.IResource> {
         return this.put(path, <any>obj, _.extend({}, config, {keepMetadata: true}));
     }
 
-    public delete(path : string, contentType : string, config : IHttpConfig = {}) : angular.IPromise<any> {
+    public delete(path : string, config : IHttpConfig = {}) : angular.IPromise<any> {
         if (this.adhPreliminaryNames.isPreliminary(path)) {
             throw "attempt to http-put preliminary path: " + path;
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
@@ -9,7 +9,6 @@ import * as ResourcesBase from "../../ResourcesBase";
 
 import RIParagraph from "../../Resources_/adhocracy_core/resources/paragraph/IParagraph";
 import * as SITags from "../../Resources_/adhocracy_core/sheets/tags/ITags";
-import * as SIMetadata from "../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
 
 import * as Convert from "./Convert";
 import * as Error from "./Error";
@@ -521,10 +520,9 @@ export var register = () => {
                 });
 
                 describe("delete", () => {
-                    it("sets the delete flag", () => {
-                        expect(request[delete1.index].body.data[SIMetadata.nick]).toBeDefined();
-                        expect(request[delete1.index].body.data[SIMetadata.nick].deleted).toBeDefined();
-                        expect(request[delete1.index].body.data[SIMetadata.nick].deleted).toBe(true);
+                    it("uses the DELETE method", () => {
+                        expect(request[delete1.index].body).not.toBeDefined();
+                        expect(request[delete1.index].method).toBe("DELETE");
                     });
                 });
             });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/HttpSpec.ts
@@ -458,7 +458,7 @@ export var register = () => {
                         post2 = httpTrans.post("/post/path/2", <any>{
                             content_type: RIParagraph.content_type
                         });
-                        delete1 = httpTrans.delete("/delete/path", RIParagraph.content_type);
+                        delete1 = httpTrans.delete("/delete/path");
                         get2 = httpTrans.get(post1.path);
                         return httpTrans.commit();
                     }).then(

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
@@ -61,7 +61,7 @@ export class Transaction {
         };
     }
 
-    public delete(path : string, contentType : string) : ITransactionResult {
+    public delete(path : string) : ITransactionResult {
         this.checkNotCommitted();
         this.requests.push({
             method: "DELETE",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
@@ -114,7 +114,7 @@ export class Transaction {
         };
     }
 
-    public commit(config = {}) : angular.IPromise<ResourcesBase.IResource[]> {
+    public commit(config = {}) : angular.IPromise<any[]> {
         var _self = this;
 
         this.checkNotCommitted();
@@ -129,7 +129,7 @@ export class Transaction {
         return this.adhHttp.postRaw("/batch", this.requests.map(conv), config).then(
             (response) => {
                 var imported = AdhConvert.importBatchResources(
-                    response.data.responses, this.adhMetaApi, this.adhPreliminaryNames, this.adhCache);
+                    this.requests, response.data.responses, this.adhMetaApi, this.adhPreliminaryNames, this.adhCache);
                 _self.adhCache.invalidateUpdated(response.data.updated_resources, <string[]>_.map(imported, "path"));
                 return imported;
             },

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Http/Transaction.ts
@@ -8,8 +8,6 @@ import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
 
 import * as ResourcesBase from "../../ResourcesBase";
 
-import * as SIMetadata from "../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
-
 import * as AdhCache from "./Cache";
 import * as AdhConvert from "./Convert";
 import * as AdhError from "./Error";
@@ -65,18 +63,10 @@ export class Transaction {
 
     public delete(path : string, contentType : string) : ITransactionResult {
         this.checkNotCommitted();
-        var request = {
-            method: "PUT",
-            path: path,
-            body: {
-                content_type: contentType,
-                data : {}
-            }
-        };
-        request.body.data[SIMetadata.nick] = {
-            deleted: true
-        };
-        this.requests.push(request);
+        this.requests.push({
+            method: "DELETE",
+            path: path
+        });
         return {
             index: this.requests.length - 1,
             path: path

--- a/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
+++ b/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
@@ -5,7 +5,6 @@ import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
 import * as AdhUtil from "../Util/Util";
 
-import RIDocument from "../../Resources_/adhocracy_core/resources/document/IDocument";
 import RIDocumentVersion from "../../Resources_/adhocracy_core/resources/document/IDocumentVersion";
 
 var pkgLocation = "/Blog";
@@ -102,7 +101,7 @@ export var detailDirective = (
             scope.delete = () => {
                 if ($window.confirm("Do you really want to delete this?")) {
                     var itemPath = AdhUtil.parentPath(scope.path);
-                    adhHttp.delete(itemPath, RIDocument.content_type)
+                    adhHttp.delete(itemPath)
                         .then(() => {
                             if (typeof scope.onChange !== "undefined") {
                                 scope.onChange();


### PR DESCRIPTION
* fixes parts of  #2336*

This is about replacing the current "flag as deleted" by a real delete. Hiding resources and the existing deleted flag should stay as it is.

TODO:

-  [x] update docs
-  [x] add 'delete' http method to REST API
-  [X] update frontend

TODO in upcomming pull request:

- [ ] add 'removed'/ 'removed_child' notification to the websocket api 
- [ ] remove 'delete' tag from metadata sheet / migration
- [ ] remove special 'hidden' field for metadatda sheet  in options requests 
-  [ ] backup 'deleted' resources for 2 weeks

