### PR TITLE
fix sphinx issues

### DIFF
--- a/docs/api/embed-api.rst
+++ b/docs/api/embed-api.rst
@@ -17,7 +17,7 @@ Host
 Widget
     A piece of adhocracy that can be embedded on its own.  Some
     functionality (e.g. registration) will require the user to switch
-    to the *platform*.  See also :doc:`../development/coding_guide/css_guidelines`.
+    to the *platform*.  See also :doc:`../development/coding_guides/css_guidelines`.
 
 Frontend URL
     This is where the actual adhocracy frontend is available.  Users are

--- a/docs/backend/architecture.rst
+++ b/docs/backend/architecture.rst
@@ -43,7 +43,7 @@ Frontend Technical Admin Interface (substanced)
       group resource_handling {
         label = "Resource Handling"
         registry;resource;
-      }rchitecture/index.html
+      }
 
     }
 

--- a/docs/backend/modules.rst
+++ b/docs/backend/modules.rst
@@ -106,7 +106,7 @@ Extend/Customize
 
 * must follow `Rules for extensible pyramid apps <http://docs.pylonsproject.org/projects/pyramid/en/master/narr/extending.html>`_:
   configuration, configuration extentensions, view/asset overriding, event subscribers.
-  Use :term:`imperative-configuration` , except for views :term:`configuration-declaration` .
+  Use imperative-configuration, except for views configuration-declaration.
 
 * may use the underlaying `zope component <http://docs.zope.org/zope.component/narr.html>`_ architecture
   provided by the :term:`application registry` directly.

--- a/docs/backend/modules.rst
+++ b/docs/backend/modules.rst
@@ -7,7 +7,7 @@ API and separation of responsibility
 *responsibility*
     (means reason to change code if functionality changes)
     should lay at one single point of code (packages/modules in this case),
-    see also :doc:`../coding_guides/refactore_guidelines`.
+    see also :doc:`../development/refactor_guidelines`.
 
 *layer*
     loosly group of modules that follow these rules:

--- a/docs/backend/softwarestack.rst
+++ b/docs/backend/softwarestack.rst
@@ -25,7 +25,7 @@ History
 
 We started 2012 with the plan to port adhocracy2 to pyramid.
 This become a long discussion how to build a framework for particpation
-processes based on fancy graph data structures :doc:`../attic/index.rst`.
+processes based on fancy graph data structures :doc:`../attic/index`.
 Mid 2013 we started serious efforts to start developing.
 We compared multiple framework - database combinations to find the right
 technical base that allows to start quickly but does not stand in they way if

--- a/docs/backend/softwarestack.rst
+++ b/docs/backend/softwarestack.rst
@@ -1,23 +1,23 @@
 Softwarestack
 =============
 
-- `Python 3 <https://www.python.org>`_ (programming language)
+-   `Python 3 <https://www.python.org>`_ (programming language)
 
-- `Pyramid <http://pylonsproject.org>`_  (web framework)
+-   `Pyramid <http://pylonsproject.org>`_  (web framework)
 
-- `substance D <http://docs.pylonsproject.org/projects/substanced/en/latest>`_ (application server)
+-   `substance D <http://docs.pylonsproject.org/projects/substanced/en/latest>`_ (application server)
 
-- `hypatia <https://github.com/Pylons/hypatia>`_ (search)
+-   `hypatia <https://github.com/Pylons/hypatia>`_ (search)
 
-- `ZODB <http://zodb.org>`_ (object database)
+-   `ZODB <http://zodb.org>`_ (object database)
 
-- `colander schema <http://docs.pylonsproject.org/projects/colander/en/latest/>`_ (data structures and validation)
+-   `colander schema <http://docs.pylonsproject.org/projects/colander/en/latest/>`_ (data structures and validation)
 
-- `Autobahn|Python <http://autobahn.ws/python/>`_ (websocket server)
+-   `Autobahn|Python <http://autobahn.ws/python/>`_ (websocket server)
 
-- `Varnish <https://www.varnish-cache.org/>`_ (http proxy cache server)
+-   `Varnish <https://www.varnish-cache.org/>`_ (http proxy cache server)
 
-- `buildout <http://www.buildout.org/en/latest/>`_ (build system)
+-   `buildout <http://www.buildout.org/en/latest/>`_ (build system)
 
 
 History
@@ -31,14 +31,14 @@ We compared multiple framework - database combinations to find the right
 technical base that allows to start quickly but does not stand in they way if
 the project grows. Doing this we had the following in mind:
 
-      * python 3 support
-      * active community and good documentation
-      * good extensibility -> `zope component` style like architecture
-      * fast references to resources and complex reference queries
-      * one system to search & store python objects and references
-      * ACID transactions
-      * resource tree, url traversal
-      * workflows, local permissions
+*    python 3 support
+*    active community and good documentation
+*    good extensibility -> `zope component` style like architecture
+*    fast references to resources and complex reference queries
+*    one system to search & store python objects and references
+*    ACID transactions
+*    resource tree, url traversal
+*    workflows, local permissions
 
 We did two prototypes to play with the neo4j graph database and dropped it
 mainly due to cutting edge python support and transaction features.
@@ -147,25 +147,25 @@ If we start a rewrite we would focus on full-stack frameworks for REST-APIs,
 standards, and simplified requirements. The following more recent projects
 are look promising.
 
-- http://ramses.tech/
+-   http://ramses.tech/
 
-    (full stack solution for REST-APIs,
-    easy prototyping/api specification,
-    good ElasticSearch "frontend" to handle all kind of requests)
+    -   full stack solution for REST-APIs
+    -   easy prototyping/api specification
+    -   good ElasticSearch "frontend" to handle all kind of requests
 
-- http://morepath.readthedocs.org/
+-   http://morepath.readthedocs.org/
 
-    (flexible micro framework for REST-API/HTML rendering,
-     combine/extend small application (like processXY, document management, user management, ...)
+    -   flexible micro framework for REST-API/HTML rendering
+    -   combine/extend small application (like processXY, document management, user management, ...)
 
-- django rest framework v3 / (or json-api extension) http://www.django-rest-framework.org/
+-   django rest framework v3 / (or json-api extension) http://www.django-rest-framework.org/
 
-  (full stack solution for REST-APIs)
+    -   full stack solution for REST-APIs
 
-- json-api https://py-jsonapi.readthedocs.org/en/latest/
+-   json-api https://py-jsonapi.readthedocs.org/en/latest/
 
-  (full stack solution for REST-APIs)
+    -   full stack solution for REST-APIs
 
-- http://pythonhosted.org/jsondata/
+-   http://pythonhosted.org/jsondata/
 
-  (data structure and patches based on JSON-Schema)
+    -   data structure and patches based on JSON-Schema

--- a/docs/development/development.rst
+++ b/docs/development/development.rst
@@ -43,8 +43,10 @@ protractor acceptance tests::
 
     bin/polytester acceptance
 
-.. NOTE:: You need to have chrome/chromium installed in order to run the
-acceptance tests.
+.. NOTE::
+
+    You need to have chrome/chromium installed in order to run the
+    acceptance tests.
 
 run backend functional tests::
 

--- a/docs/development/git_guidelines.rst
+++ b/docs/development/git_guidelines.rst
@@ -84,7 +84,7 @@ a list of options:
 
 Note that there's already standard messages for commits created by git
 (Revert "...") and conventions for review commits (``[R] prefix``) as
-described in the :doc:`code_review_process`.
+described in the :doc:`../attic/code_review_process`.
 
 
 Add feature branch

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,29 +12,29 @@ What is adhocracy?
 
 Adhocracy 3 aims to be a:
 
-    - python framework to build a REST-API *backend* for cms-like applications
-      with a focus on `participation processes` and `collaborative text work`.
+*   python framework to build a REST-API *backend* for cms-like applications
+    with a focus on `participation processes` and `collaborative text work`.
 
-    - javascript framework to build SinglePageApplication *frontends*.
+*   javascript framework to build SinglePageApplication *frontends*.
 
 It comes with these features out of the box:
 
-* Generic :doc:`../api/rest_api` based on the following concepts:
+*   Generic :doc:`../api/rest_api` based on the following concepts:
 
-    * `Hypermedia REST API`: loose coupling frontend/backend, no fixed endpoints,
-      (only half implemented, possible future:`A3 Hypermedia REST-API <http://www.jokasis.de/docs/api_talk/html/>`_)
+    *   `Hypermedia REST API`: loose coupling frontend/backend, no fixed endpoints,
+        (only half implemented, possible future:`A3 Hypermedia REST-API <http://www.jokasis.de/docs/api_talk/html/>`_)
 
-    * `Supergraph`: Resources are versioned and build non hierachical data structures with other Resources,
-      Versions never change, see :doc:`../attic/supergraph` and :doc:`../attic/no_patches`.
-      (only half implemented, Problem: build a usable REST-API on top of this concept).
+    *   `Supergraph`: Resources are versioned and build non hierachical data structures with other Resources,
+        Versions never change, see :doc:`../attic/supergraph` and :doc:`../attic/no_patches`.
+        (only half implemented, Problem: build a usable REST-API on top of this concept).
 
-* Generic `API Specifiaction to build generic frontend` (see :doc:`../api/rest_api`)
+*   Generic `API Specifiaction to build generic frontend` (see :doc:`../api/rest_api`)
 
-* Generic `Admin interface` (not implemented yet)
+*   Generic `Admin interface` (not implemented yet)
 
-* `Resource and workflow modellings` for participation processes.
+*   `Resource and workflow modellings` for participation processes.
 
-* `SinglePageApplication` frontends and backend customizations for `specific participation projects`
+*   `SinglePageApplication` frontends and backend customizations for `specific participation projects`
 
 
 

--- a/src/adhocracy_core/adhocracy_core/auditing/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/auditing/__init__.py
@@ -86,8 +86,8 @@ def audit_resources_changes_callback(request: Request,
                                      response: Response) -> None:
     """Add auditlog entries to the auditlog when the resources are changed.
 
-    This is a :term:`response- callback` that run after a request has
-    finished. To store the audit entry it adds an additional transaction.
+    This is a response-callback that runs after a request has finished. To
+    store the audit entry it adds an additional transaction.
     """
     registry = request.registry
     changelog_metadata = registry.changelog.values()

--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -234,7 +234,7 @@ class TokenHeaderAuthenticationPolicy(CallbackAuthenticationPolicy):
 def validate_user_headers(view: callable):
     """Decorator vor :term:`view` to check if the user token.
 
-    :raise `pyramid.httpexceptions.HTTPBadRequest: if user token is invalid
+    :raise pyramid.httpexceptions.HTTPBadRequest: if user token is invalid
     """
     def wrapped_view(context, request):
         token_is_set = UserTokenHeader in request.headers

--- a/src/adhocracy_core/adhocracy_core/authorization/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/__init__.py
@@ -67,10 +67,10 @@ class RoleACLAuthorizationPolicy(ACLAuthorizationPolicy):
 
 
 def set_local_roles(resource, new_local_roles: dict, registry: Registry=None):
-    """Set the :term:`local role`s mapping to ``new_local_roles``.
+    """Set the :term:`local role's <local role>` mapping to ``new_local_roles``.
 
     :param new_local_roles: Mapping from :term:`groupid`/:term:`userid` to
-                            a set of :term:`role`s for the `resource`:
+                            a set of :term:`roles <role>` for the `resource`:
 
                             {'system.Everyone': {'role:reader'}}
 
@@ -97,12 +97,12 @@ def _assert_values_have_set_type(mapping: dict):
 
 
 def get_local_roles(resource) -> dict:
-    """Return the :term:`local role`s of the resource."""
+    """Return the :term:`local roles <local role>` of the resource."""
     return getattr(resource, '__local_roles__', {})
 
 
 def get_local_roles_all(resource) -> dict:
-    """Return the :term:`local role`s of the resource and its parents.
+    """Return the :term:`local roles <local role>` of the resource and its parents.
 
     The `creator`role is not inherited by children.
     """

--- a/src/adhocracy_core/adhocracy_core/authorization/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/__init__.py
@@ -104,7 +104,7 @@ def get_local_roles(resource) -> dict:
 def get_local_roles_all(resource) -> dict:
     """Return the :term:`local roles <local role>` of the resource and its parents.
 
-    The `creator`role is not inherited by children.
+    The `creator` role is not inherited by children.
     """
     local_roles_all = defaultdict(set)
     local_roles_all.update(get_local_roles(resource))
@@ -165,7 +165,7 @@ def set_acms_for_app_root(event):
                   That way everytime the application starts the root `acm`
                   is updated.
 
-    The `root_acm`(:func:`root_acm_asset`) is extended by the :term:`acm`
+    The `root_acm` (:func:`root_acm_asset`) is extended by the :term:`acm`
     returned by the :class:`adhocracy_core.authorization.IRootACMExtension`
     adapter.
 

--- a/src/adhocracy_core/adhocracy_core/authorization/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/__init__.py
@@ -125,7 +125,7 @@ def acm_to_acl(acm: dict) -> [str]:
 
     Permissions for principals with high priority are listed first and override
     succeding permissions. The order is determined by
-    :var:`adhocracy_core.schema.ROLE_PRINCIPALS`. Pricipals with higher
+    :py:data:`adhocracy_core.schema.ROLE_PRINCIPALS`. Pricipals with higher
     index in this list have higer priority.
     """
     acl = _migrate_acm_to_acl(acm)

--- a/src/adhocracy_core/adhocracy_core/catalog/index.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/index.py
@@ -78,9 +78,11 @@ class ReferenceIndex(SDIndex, BaseIndexMixin, Persistent):
 
         :param query:
 
-            reference (Reference): reference with target or source
-            traverse (bool): traverse all references with same type, starting
-                             with the given target or source.
+            reference (Reference):
+                reference with target or source
+            traverse (bool):
+                traverse all references with same type, starting with the
+                given target or source.
         """
         return hypatia.query.Eq(self, query)
 
@@ -89,9 +91,11 @@ class ReferenceIndex(SDIndex, BaseIndexMixin, Persistent):
 
         :param query:
 
-            reference (Reference): reference with target or source
-            traverse (bool): traverse all references with same type, starting
-                             with the given target or source.
+            reference (Reference):
+                reference with target or source
+            traverse (bool):
+                traverse all references with same type, starting with the given
+                target or source.
         """
         if 'traverse' not in query:
             query['traverse'] = False

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -595,9 +595,10 @@ class ChangelogMetadata(namedtuple('ChangelogMetadata',
     last_version_in_transaction (None or IResource):
         The last Version created in this transaction (assuming linear history)
         (only for :class:`adhocracy_core.interfaces.IItem`)
-    changed_descendants (bool): child or grandchild is modified or has
-                                changed_backrefs
-    changed_backrefs (bool): References targeting this resource are changed
+    changed_descendants (bool):
+        child or grandchild is modified or has changed_backrefs
+    changed_backrefs (bool):
+        References targeting this resource are changed
     visibility (VisibilityChange):
         Tracks the visibility of the resource and whether it has changed
     """

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -619,7 +619,7 @@ class AuditlogEntry(namedtuple('AuditlogEntry', ['name',
     user_name: (str):
         name of responsible user
     user_path:
-        :term:`user_id` of responsible user
+        :term:`userid` of responsible user
     """
 
 
@@ -744,8 +744,8 @@ class SearchQuery(namedtuple('Query', ['interfaces',
     only_visible (bool):
         filter hidden and deleted resources
     allows ([str], str):
-        filter resources that don't allow the :term:`principal`s  the given
-        permission ([principal], permission).
+        filter resources that don't allow the :term:`principals <principal>`
+        the given permission ([principal], permission).
 
     Present search result
     ----------------------
@@ -801,10 +801,10 @@ class IRolesUserLocator(IUserLocator):  # pragma: no cover
         """Return the group roleids for :term:`userid` or None."""
 
     def get_groupids(userid: str) -> list:
-        """Get :term:`groupid`s for term:`userid` or return None."""
+        """Get :term:`groupids <groupid>` for term:`userid` or return None."""
 
     def get_groups(userid: str) -> list:
-        """Get :term:`group`s for term:`userid` or return None."""
+        """Get :term:`groups <group>` for term:`userid` or return None."""
 
     def get_user_by_activation_path(activation_path: str) -> IResource:
         """Find user per activation path or return None."""

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -859,7 +859,7 @@ class Reference(namedtuple('Reference', 'source isheet field target')):
 
 
 class HTTPCacheMode(Enum):
-    """Caching Mode for :class:`IHTTPCacheStrategy`s.
+    """Caching Mode for :class:`IHTTPCacheStrategy`.
 
     You can change the mode in you pyramid ini file with the
     `adhocracy_core.caching.http.mode` setting.

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -731,13 +731,14 @@ class SearchQuery(namedtuple('Query', ['interfaces',
         Available :class:`SearchComparator`s depend on the index type.
     references (Reference or (ReferenceComparator.traverse, Reference)):
         References with (source, isheet, isheet_field, target).
-        If `source` is None search for resources referencing target
-        (back references).
-        If `target` is None search for resources referenced by source
-        (Reference).
-        If the tuple (ReferenceComparator.traverse, Reference) is given,
-        the resource graph is traversed following all references with the same
-        type as the given reference.
+
+        -   If `source` is None search for resources referencing target
+            (back references).
+        -   If `target` is None search for resources referenced by source
+            (Reference).
+        -   If the tuple (ReferenceComparator.traverse, Reference) is given,
+            the resource graph is traversed following all references with the
+            same type as the given reference.
     root (IResource):
        root resource to start searching  in descendants
     depth (int):

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -349,9 +349,9 @@ class IPool(IResource):  # pragma: no cover
     def add(name: str, other) -> str:
         """Add subobject other.
 
-        :returns: The name used to place the subobject in the
-        folder (a derivation of ``name``, usually the result of
-        ``self.check_name(name)``).
+        :returns: The name used to place the subobject in the folder
+            (a derivation of ``name``, usually the result of
+            ``self.check_name(name)``).
         """
 
     def check_name(name: str) -> str:

--- a/src/adhocracy_core/adhocracy_core/messaging/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/messaging/__init__.py
@@ -220,12 +220,12 @@ class Messenger:
                              ):
         """Send invitation email with link to reset the user password.
 
-        :param:`subject_tmpl`: pyramid asset pointing to a mako
-                               template file. If not set the translation
-                               message is used for the mail subject.
-        :param:`body_tmpl`: pyramid asset pointing to a mako
-                           template file. If not set the translation message
-                           is used for the mail body.
+        :param subject_tmpl: pyramid asset pointing to a mako
+                             template file. If not set the translation
+                             message is used for the mail subject.
+        :param body_tmpl: pyramid asset pointing to a mako
+                          template file. If not set the translation message
+                          is used for the mail body.
         """
         mapping = {'reset_url': self._build_reset_url(password_reset),
                    'user_name': user.name,

--- a/src/adhocracy_core/adhocracy_core/renderers/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/renderers/__init__.py
@@ -4,10 +4,10 @@ from yaml import safe_load
 
 
 class YAMLToPython:
-    """YAML to python renderer using :func:`yaml.safe_load`."""
+    """YAML to python renderer using :py:func:`yaml.safe_load`."""
 
     def __init__(self, info: dict):
-        """See :method:`pyramid.interfaces.IRendererFactory.__call__`."""
+        """See :py:meth:`pyramid.interfaces.IRendererFactory.__call__`."""
 
     def __call__(self, value: dict, system: dict) -> object:
         """Render yaml file :term:asset` given in `system` to python.
@@ -16,7 +16,7 @@ class YAMLToPython:
         :param system: dict including `renderer_name` (yaml file asset)
         :raise ValueError: if the yaml file asset does not exist.
 
-        See :method:`pyramid.interfaces.IRenderer.__call__`
+        See :py:meth:`pyramid.interfaces.IRenderer.__call__`
         """
         asset = system['renderer_name']
         package, filename = asset.split(':')

--- a/src/adhocracy_core/adhocracy_core/resources/itemversion.py
+++ b/src/adhocracy_core/adhocracy_core/resources/itemversion.py
@@ -36,17 +36,18 @@ def update_last_tag(version, registry, options):
 def notify_new_itemversion_created(context, registry, options):
     """Notify referencing Resources after creating a new ItemVersion.
 
-    Args:
-        context (IItemversion): the newly created resource
-        registry (pyramid registry):
-        option (dict):
-            `root_versions`: List with root resources. Will be passed along to
-                            resources that reference old versions so they can
-                            decide whether they should update themselfes.
-            `creator`: User resource that passed to the creation events.
+    :param context: the newly created resource
+    :param registry: pyramid registry
+    :param option:
 
-    Returns:
-        None
+        root_versions:
+            List with root resources. Will be passed along to
+            resources that reference old versions so they can
+            decide whether they should update themselfes.
+        creator:
+            User resource that passed to the creation events.
+
+    :return: None
 
     """
     new_version = context

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -95,8 +95,8 @@ class IUser(IPool):
     active = Attribute('Whether the user account has been activated (bool)')
     activation_path = Attribute(
         'Activation path for not-yet-activated accounts (str)')
-    roles = Attribute('List of :term:`role`s')
-    group_ids = Attribute('List of :term:`group_id`s')
+    roles = Attribute('List of :term:`roles <role>`')
+    group_ids = Attribute('List of :term:`groupids <groupid>`')
     # TODO: add `password` attribute, this may be set by the
     # password authentication sheet
 
@@ -121,7 +121,7 @@ class User(Pool):
         super().__init__(data, family)
         self.roles = []
         self.group_ids = []
-        """Readonly :term:`group_id`s for this user."""
+        """Readonly :term:`groupids <groupid>` for this user."""
         self.hidden = True
 
     @property
@@ -345,14 +345,14 @@ class UserLocatorAdapter(object):
                              .format(users_count, index_name, value))
 
     def get_groupids(self, userid: str) -> [str]:
-        """Get :term:`groupid`s for term:`userid` or return None."""
+        """Get :term:`groupids <groupid>` for term:`userid` or return None."""
         groups = self.get_groups(userid)
         if groups is None:
             return None
         return ['group:' + g.__name__ for g in groups]
 
     def get_groups(self, userid: str) -> [IGroup]:
-        """Get :term:`group`s for term:`userid` or return None."""
+        """Get :term:`groups <group>` for term:`userid` or return None."""
         user = self.get_user_by_userid(userid)
         if user is None:
             return

--- a/src/adhocracy_core/adhocracy_core/resources/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/subscriber.py
@@ -348,7 +348,7 @@ def update_comments_count(resource: ICommentVersion,
                           registry: Registry):
     """Update all commentable resources related to `resource`.
 
-     Traverse all commentable resources that have a IComment or ISubresource
+    Traverse all commentable resources that have a IComment or ISubresource
     reference to `resource` and update the comment_count value with `delta`.
 
     Example reference structure that is traversed:

--- a/src/adhocracy_core/adhocracy_core/rest/exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/exceptions.py
@@ -97,7 +97,7 @@ def handle_error_x0x_exception(error, request):
 def handle_error_40x_exception(error, request):
     """Return JSON error for generic HTTPClientErrors.
 
-     If `error` is :class:`JSONHTTPClientError` it is
+    If `error` is :class:`JSONHTTPClientError` it is
     return without modifications.
     """
     if isinstance(error, JSONHTTPClientError):

--- a/src/adhocracy_core/adhocracy_core/rest/exceptions.py
+++ b/src/adhocracy_core/adhocracy_core/rest/exceptions.py
@@ -30,10 +30,10 @@ logger = logging.getLogger(__name__)
 class JSONHTTPClientError(HTTPClientError):
     """HTTPException with json body to describe the exception.
 
-    :param:`errors`: error entries to generate the error description.
-    :param:`request`: Request causing the error to log debug information.
-    :param:`code`: http status code
-    :param:`title`: http status title
+    :param errors: error entries to generate the error description.
+    :param request: Request causing the error to log debug information.
+    :param code: http status code
+    :param title: http status title
 
     The body contains a dictionary with the following data structure:
 

--- a/src/adhocracy_core/adhocracy_core/rest/schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/schemas.py
@@ -779,12 +779,13 @@ class GETPoolRequestSchema(MappingSchema):
                              validator=deferred_validate_aggregateby)
 
     def deserialize(self, cstruct=null):  # noqa
-        """ Deserialize the :term:`cstruct` into an :term:`appstruct`.
+        """Deserialize the :term:`cstruct` into an :term:`appstruct`.
 
         Adapt key/values to :class:`adhocracy_core.interfaces.SearchQuery`. for
         BBB.
-        TODO: CHANGE API according to internal SearchQuery api.
-             refactor to follow coding guideline better.
+
+        TODO: Change API according to internal SearchQuery api.
+        refactor to follow coding guideline better.
         """
         depth_cstruct = cstruct.get('depth', None)
         if depth_cstruct == 'all':

--- a/src/adhocracy_core/adhocracy_core/schema/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/schema/__init__.py
@@ -54,7 +54,8 @@ class SchemaNode(colander.SchemaNode):
 
     The constructor accepts these additional keyword arguments:
 
-        - ``readonly``: Disable deserialization. Default: False
+    readonly:
+        Disable deserialization. Default: False
     """
 
     readonly = False

--- a/src/adhocracy_core/adhocracy_core/schema/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/schema/__init__.py
@@ -443,13 +443,15 @@ class ResourceObjectType(SchemaType):
         """Initialize self."""
         self.serialization_form = serialization_form
         """
-        :param:`serialization_form`:
-            If 'url` the :term:`request` binding is used to serialize
-            to the resource url.
-            If `path` the :term:`context` binding is used to  serialize to
-            the :term:`Resource Location` path.
-            If `content` the :term:`request` and  'context' binding is used to
-            serialize the complete resource content and metadata.
+        :param serialization_form:
+
+            -   If 'url` the :term:`request` binding is used to serialize
+                to the resource url.
+            -   If `path` the :term:`context` binding is used to  serialize to
+                the :term:`Resource Location` path.
+            -   If `content` the :term:`request` and 'context' binding is used
+                to serialize the complete resource content and metadata.
+
             Default `url`.
         """
 
@@ -678,8 +680,8 @@ class DateTime(SchemaNode):
 
     Constructor arguments:
 
-    :param 'tzinfo': This timezone is used if the :term:`cstruct` is missing
-                     the tzinfo. Defaults to UTC
+    :param tzinfo: This timezone is used if the :term:`cstruct` is missing
+                   the tzinfo. Defaults to UTC
     """
 
     schema_type = DateTimeType
@@ -732,7 +734,7 @@ class PostPool(Reference):
 
     Constructor arguments:
 
-    :param 'iresource_or_service_name`:
+    :param iresource_or_service_name:
         The resource interface/:term:`service` name of this
         :term:`post_pool`. If it is a :term:`interface` the
         :term:`lineage` of the `context` is searched for the first matching
@@ -751,8 +753,8 @@ class PostPool(Reference):
 def create_post_pool_validator(child_node: Reference, kw: dict) -> callable:
     """Create validator to check `kw['context']` is inside :term:`post_pool`.
 
-    :param:`child_node` Reference to a sheet with :term:`post_pool` field.
-    :param:`kw`: dictionary with keys `context` and `registry`.
+    :param child_node: Reference to a sheet with :term:`post_pool` field.
+    :param kw: dictionary with keys `context` and `registry`.
     """
     isheet = child_node.reftype.getTaggedValue('target_isheet')
     context = kw['context']

--- a/src/adhocracy_core/adhocracy_core/sheets/badge.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/badge.py
@@ -160,8 +160,8 @@ def create_unique_badge_assignment_validator(badge_ref: Reference,
     Badge assignments is considered unique if there is at most one for each
     badge in :term:`post_pool`.
 
-    :param:`badge` Reference to a sheet with :term:`post_pool` field.
-    :param:`kw`: dictionary with keys `context` and `registry`.
+    :param badge: Reference to a sheet with :term:`post_pool` field.
+    :param kw: dictionary with keys `context` and `registry`.
     """
     context = kw['context']
     registry = kw['registry']

--- a/src/adhocracy_core/adhocracy_core/workflows/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/workflows/__init__.py
@@ -163,7 +163,7 @@ def transition_to_states(context, states: [str], registry: Registry,
     """Initialize workflow if needed and do transitions to the given states.
 
     :raises substanced.workflow.WorkflowError: if transition is missing to
-    do transitions to `states`.
+        do transitions to `states`.
     """
     request = create_fake_god_request(registry)
     workflow = registry.content.get_workflow(context)


### PR DESCRIPTION
While working on #2371 I noticed that building sphinx produces an extreme amount of warnings and errors. So I tried to fix at least some of them.

To reproduce, run the follwing commands:

```
$ rm -r docs/build
$ bin/ad_build_doc
```

Many issues I fixed were related to the fact that reStructuredText requires whitespace around inline directives. So ``:term:`resource`s`` is invalid. Instead you can do ``:term:`resources <resource>` ``.

Another issue I found was broken indentation. Please stick to the 4-space indentation rule and note that lists must not be indented (indentation signifies a blockquote).

I did not fix any warnings or errors related to broken python references (and there is a lot of them!). There were also some issues I could not fix because I did not know how to do that without violating against the maximum line length (e.g. in the docstring of `adhocracy_core.interfaces.SearchQuery`).