### PR TITLE
fix comment navigation in mercator

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Listing.html
@@ -1,5 +1,6 @@
 <adh-listing
     data-path="{{poolPath}}"
+    data-refers-to="{{custom.refersTo}}"
     data-content-type="{{contentType}}"
     data-sorts="sorts"
     data-params="params"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
@@ -41,8 +41,6 @@ export var register = (angular) => {
             "adhTopLevelState",
             "$location",
             AdhComment.adhCommentListing])
-        .directive("adhCreateOrShowCommentListing", [
-            "adhConfig", "adhDone", "adhHttp", "adhPreliminaryNames", "adhCredentials", AdhComment.adhCreateOrShowCommentListing])
         .directive("adhComment", [
             "adhConfig",
             "adhHttp",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -318,9 +318,7 @@ export class Listing<Container extends ResourcesBase.IResource> {
                     $scope.createPath = adhPreliminaryNames.nextPreliminary();
                 };
 
-                $scope.$watch("sort", (sort : string) => {
-                    $scope.update();
-                });
+                $scope.$watch("sort", () => $scope.update());
 
                 $scope.$watch("path", () => adaptListingToParameter($scope.poolPath, $scope));
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -123,6 +123,27 @@ export class Listing<Container extends ResourcesBase.IResource> {
             }
         };
 
+        var adaptListingToParameter = (parameter: any, $scope: ListingScope<Container>) => {
+            unregisterWebsocket($scope);
+            if (parameter) {
+                // NOTE: Ideally we would like to first subscribe to
+                // websocket messages and only then get the resource in
+                // order to not miss any messages in between. But in
+                // order to subscribe we already need the resource. So
+                // that is not possible.
+                $scope.update().then(() => {
+                    try {
+                        $scope.wsOff = adhWebSocket.register(parameter, () => $scope.update());
+                    } catch (e) {
+                        console.log(e);
+                        console.log("Will continue on resource " + parameter + " without server bind.");
+                    }
+                });
+            } else {
+                $scope.clear();
+            }
+        };
+
         return {
             restrict: "E",
             templateUrl: adhConfig.pkg_path + _class.templateUrl,
@@ -299,27 +320,8 @@ export class Listing<Container extends ResourcesBase.IResource> {
                     $scope.update();
                 });
 
-                $scope.$watch("path", (newPath : string) => {
-                    unregisterWebsocket($scope);
+                $scope.$watch("path", () => adaptListingToParameter($scope.poolPath, $scope));
 
-                    if (newPath) {
-                        // NOTE: Ideally we would like to first subscribe to
-                        // websocket messages and only then get the resource in
-                        // order to not miss any messages in between. But in
-                        // order to subscribe we already need the resource. So
-                        // that is not possible.
-                        $scope.update().then(() => {
-                            try {
-                                $scope.wsOff = adhWebSocket.register($scope.poolPath, () => $scope.update());
-                            } catch (e) {
-                                console.log(e);
-                                console.log("Will continue on resource " + $scope.poolPath + " without server bind.");
-                            }
-                        });
-                    } else {
-                        $scope.clear();
-                    }
-                });
             }]
         };
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -69,6 +69,7 @@ export type IPredicate = string | {[key : string]: string}
 
 export interface ListingScope<Container> extends angular.IScope {
     path : string;
+    refersTo? : string;
     contentType? : string;
     facets? : IFacet[];
     sort? : string;
@@ -149,6 +150,7 @@ export class Listing<Container extends ResourcesBase.IResource> {
             templateUrl: adhConfig.pkg_path + _class.templateUrl,
             scope: {
                 path: "@",
+                refersTo: "@",
                 contentType: "@",
                 facets: "=?",
                 sort: "=?",
@@ -322,6 +324,7 @@ export class Listing<Container extends ResourcesBase.IResource> {
 
                 $scope.$watch("path", () => adaptListingToParameter($scope.poolPath, $scope));
 
+                $scope.$watch("refersTo", () => adaptListingToParameter($scope.refersTo, $scope));
             }]
         };
     }


### PR DESCRIPTION
This fixes #2205 in a surprisingly indirect way.

`AdhListing` didn't use, nor watch, the `refersTo` value of comments. This value is crucial in Mercator, since all comments on (any parts of) a proposal are stored in one `pool`, but their `refersTo` values indicate which subresource they belong to.

(When you first loaded a given subresource comment view, this wan't a problem:
In `src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts`, in `registerRoutes.specific` assigned this same subresource as `commentableUrl`. But `registerRoutes` is not executed in the case of #2205.)