### PR TITLE
update listing on changed params

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.ts
@@ -299,6 +299,10 @@ export class Listing<Container extends ResourcesBase.IResource> {
                     $scope.update();
                 });
 
+                $scope.$watch("params", () => {
+                    $scope.update();
+                }, true);
+
                 $scope.$watch("path", (newPath : string) => {
                     unregisterWebsocket($scope);
 


### PR DESCRIPTION
*Continued from #2380*
*Fixes #2205*

As @der-john found out, the reason for #2205 was that the listing did not update when `refersTo` changed. The underlying issue is that the listing does not update when `scope.params` changes.

Note: I had to use the `objectEquality` argument to `$watch`([docs](https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$watch)). This is most likely a lot slower than strict comparison, but I hope that the performance impact is not too big because `scope.params` is a very simple object.