### PR TITLE
add description sheet to user

### DIFF
--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -713,6 +713,12 @@ def add_controversiality_index(root, registry):  # pragma: no cover
         index.reindex_resource(resource)
 
 
+@log_migration
+def add_description_sheet_to_user(root, registry):  # pragma: no cover
+    """Add description sheet to user."""
+    migrate_new_sheet(root, IUser, IDescription)
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -751,3 +757,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(allow_create_asset_for_users)
     config.add_evolution_step(update_workflow_state_acl_for_all_resources)
     config.add_evolution_step(add_controversiality_index)
+    config.add_evolution_step(add_description_sheet_to_user)

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -42,6 +42,7 @@ import adhocracy_core.sheets.rate
 import adhocracy_core.sheets.badge
 import adhocracy_core.sheets.image
 import adhocracy_core.sheets.asset
+import adhocracy_core.sheets.description
 
 _ = TranslationStringFactory('adhocracy')
 
@@ -148,6 +149,7 @@ user_meta = pool_meta._replace(
     content_class=User,
     basic_sheets=(adhocracy_core.sheets.principal.IUserBasic,
                   adhocracy_core.sheets.principal.IUserExtended,
+                  adhocracy_core.sheets.description.IDescription,
                   adhocracy_core.sheets.principal.ICaptcha,
                   adhocracy_core.sheets.principal.IPermissions,
                   adhocracy_core.sheets.metadata.IMetadata,

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -118,6 +118,7 @@ class TestUser:
         assert meta.is_implicit_addable is False
         assert meta.basic_sheets == (adhocracy_core.sheets.principal.IUserBasic,
                                      adhocracy_core.sheets.principal.IUserExtended,
+                                     adhocracy_core.sheets.description.IDescription,
                                      adhocracy_core.sheets.principal.ICaptcha,
                                      adhocracy_core.sheets.principal.IPermissions,
                                      adhocracy_core.sheets.metadata.IMetadata,


### PR DESCRIPTION
This allows to use the description field as a free text field to
describe the user. 

This is needed by the s1 process but also useful in general (discussed with moritz and @nidico  https://pad.liqd.net/p/paas-2016-06-09 )