### PR TITLE
make field sheets.image.IImageMetadata.mime_type readonly

### DIFF
--- a/src/adhocracy_core/adhocracy_core/resources/asset.py
+++ b/src/adhocracy_core/adhocracy_core/resources/asset.py
@@ -65,6 +65,7 @@ def add_metadata(context: IAsset, registry: Registry, **kwargs):
     meta_appstruct = {
         'size': file.size,
         'filename': file.title,
+        'mime_type': file.mimetype,
     }
     meta_sheet.set(meta_appstruct, omit_readonly=False)
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_asset.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_asset.py
@@ -90,6 +90,7 @@ class TestAsset:
         meta = registry.content.get_sheet(res, IAssetMetadata).get()
         assert meta['filename'] == 'title'
         assert meta['size'] == 100
+        assert meta['mime_type'] == 'image/png'
 
 
 class TestAssetsService:

--- a/src/adhocracy_core/adhocracy_core/rest/views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/views.py
@@ -41,9 +41,7 @@ from adhocracy_core.rest.schemas import POSTCreatePasswordResetRequestSchema
 from adhocracy_core.rest.schemas import POSTPasswordResetRequestSchema
 from adhocracy_core.rest.schemas import POSTReportAbuseViewRequestSchema
 from adhocracy_core.rest.schemas import POSTResourceRequestSchema
-from adhocracy_core.rest.schemas import POSTAssetRequestSchema
 from adhocracy_core.rest.schemas import PUTResourceRequestSchema
-from adhocracy_core.rest.schemas import PUTAssetRequestSchema
 from adhocracy_core.rest.schemas import GETPoolRequestSchema
 from adhocracy_core.rest.schemas import GETItemResponseSchema
 from adhocracy_core.rest.schemas import GETResourceResponseSchema
@@ -521,7 +519,7 @@ class AssetsServiceRESTView(PoolRESTView):
     @api_view(
         request_method='POST',
         permission='create_asset',
-        schema=POSTAssetRequestSchema,
+        schema=POSTResourceRequestSchema,
         accept='multipart/form-data',
     )
     def post(self):
@@ -539,7 +537,7 @@ class AssetRESTView(SimpleRESTView):
     @api_view(
         request_method='PUT',
         permission='create_asset',
-        schema=PUTAssetRequestSchema,
+        schema=PUTResourceRequestSchema,
         accept='multipart/form-data',
     )
     def put(self) -> dict:

--- a/src/adhocracy_core/adhocracy_core/sheets/asset.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/asset.py
@@ -1,6 +1,7 @@
 """Sheets for managing assets."""
 
 from colander import required
+from colander import deferred
 from persistent import Persistent
 from zope.deprecation import deprecated
 
@@ -12,9 +13,11 @@ from adhocracy_core.schema import FileStore
 from adhocracy_core.schema import Integer
 from adhocracy_core.schema import PostPool
 from adhocracy_core.schema import SingleLine
+from adhocracy_core.schema import SchemaNode
 from adhocracy_core.schema import UniqueReferences
 from adhocracy_core.sheets import add_sheet_to_registry
 from adhocracy_core.sheets import sheet_meta
+from adhocracy_core.utils import get_iresource
 
 
 class IHasAssetPool(ISheet, ISheetReferenceAutoUpdateMarker):
@@ -48,7 +51,7 @@ class AssetReference(SheetToSheet):
 class AssetMetadataSchema(MappingSchema):
     """Data structure storing asset metadata."""
 
-    mime_type = SingleLine(missing=required)
+    mime_type = SingleLine(readonly=True)
     size = Integer(readonly=True)
     filename = SingleLine(readonly=True)
     attached_to = UniqueReferences(readonly=True,
@@ -66,10 +69,24 @@ class IAssetData(ISheet, ISheetReferenceAutoUpdateMarker):
     """Marker interface for the actual asset data."""
 
 
+@deferred
+def deferred_validate_asset_mime_type(node: SchemaNode, kw: dict):
+    """Validate mime type for the uploaded asset file data."""
+    from .image import validate_image_data_mimetype
+    from adhocracy_core.resources.image import IImage
+    context = kw['context']
+    creating = kw['creating']
+    iresource = creating and creating.iresource or get_iresource(context)
+    is_image = iresource.isOrExtends(IImage)
+    if is_image:
+        return validate_image_data_mimetype
+
+
 class AssetDataSchema(MappingSchema):
     """Data structure storing for the actual asset data."""
 
-    data = FileStore(missing=required)
+    data = FileStore(missing=required,
+                     validator=deferred_validate_asset_mime_type)
 
 
 asset_data_meta = sheet_meta._replace(

--- a/src/adhocracy_core/adhocracy_core/sheets/image.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/image.py
@@ -1,6 +1,5 @@
 """image sheet."""
 from colander import OneOf
-from colander import required
 from colander import All
 from colander import Invalid
 from requests.exceptions import ConnectionError
@@ -17,6 +16,7 @@ from adhocracy_core.schema import Reference
 from adhocracy_core.schema import Resource
 from adhocracy_core.schema import SingleLine
 from adhocracy_core.schema import URL
+from adhocracy_core.schema import SchemaNode
 from adhocracy_core.interfaces import ISheet
 from adhocracy_core.interfaces import ISheetReferenceAutoUpdateMarker
 from adhocracy_core.interfaces import SheetToSheet
@@ -29,13 +29,19 @@ class IImageMetadata(IAssetMetadata):
 image_mime_type_validator = OneOf(('image/gif', 'image/jpeg', 'image/png'))
 
 
+def validate_image_data_mimetype(node: SchemaNode, value):
+    """Validate image mime type of `value`."""
+    mimetype = value.mimetype
+    image_mime_type_validator(node, mimetype)
+
+
 class ImageMetadataSchema(AssetMetadataSchema):
     """Data structure storing image asset metadata."""
 
-    mime_type = SingleLine(missing=required,
-                           validator=image_mime_type_validator)
-    detail = Resource(dimensions=Dimensions(width=800, height=800))
-    thumbnail = Resource(dimensions=Dimensions(width=100, height=100))
+    detail = Resource(dimensions=Dimensions(width=800, height=800),
+                      readonly=True)
+    thumbnail = Resource(dimensions=Dimensions(width=100, height=100),
+                         readonly=True)
 
 
 image_metadata_meta = asset_metadata_meta._replace(

--- a/src/adhocracy_core/docs/assets_and_images.rst
+++ b/src/adhocracy_core/docs/assets_and_images.rst
@@ -25,17 +25,13 @@ sheets:
 
 * `adhocracy_core.sheets.metadata.IMetadata`: provided by all resources,
   automatically created and updated by the backend
-* `adhocracy_core.sheets.asset.IAssetMetadata` with only one read-write field:
+* `adhocracy_core.sheets.asset.IAssetMetadata` with only readonly fields:
 
-  :mime_type: the MIME type of the asset; must be specified by the frontend,
-      but the backend will sanity-check the posted data and reject the asset
+  :mime_type: the MIME type of the asset; The mime_type provided by the uploaded
+      asset file will be sanity-check. The backend rejects the asset
       in case of a detectable mismatch (e.g. if the frontend posts a Word file
-      but gives "image/jpeg" as MIME type). Not all mismatches will be
+      the image mimetype "image/jpeg" is given). Not all mismatches will be
       detectable, e.g. different "text/" subtypes can be hard to distinguish.
-
-  All other following fields are read-only, they are automatically created and
-  updated by the backend:
-
   :size: the size of the asset (in bytes)
   :filename: the name of the file uploaded by the frontend (in the backend,
       the asset will have a different, auto-generated path)
@@ -127,8 +123,6 @@ request will have keys similar to the following:
 
 :content_type: the type of the resource that shall be created, e.g.
         "adhocracy_core.resources.image.IImage"
-:data\:adhocracy_core.sheets.asset.IAssetMetadata\:mime_type: the MIME type of
-    the uploaded file, e.g. "image/jpeg"
 :data\:adhocracy_core.sheets.asset.IAssetData\:data: the binary data of the
     uploaded file, as per the HTML `<input type="file" name="asset">` tag.
 
@@ -148,10 +142,7 @@ Now we can upload a sample picture::
 
     >>> upload_files = [('data:adhocracy_core.sheets.asset.IAssetData:data',
     ...     'python.jpg', open('docs/_static/python.jpg', 'rb').read())]
-    >>> request_body = {
-    ...    'content_type': 'adhocracy_core.resources.image.IImage',
-    ...    'data:adhocracy_core.sheets.image.IImageMetadata:mime_type':
-    ...        'image/jpeg'}
+    >>> request_body = {'content_type': 'adhocracy_core.resources.image.IImage'}
     >>> resp_data = testapp.post(asset_pool_path, request_body,
     ...             headers=god_header, upload_files=upload_files).json
 
@@ -260,8 +251,7 @@ To upload a new version of an asset, the frontend sends a PUT request with
 enctype="multipart/form-data" to the asset URL. The PUT request may contain
 the same keys as a POST request used to create a new asset.
 
-The `data:adhocracy_core.sheets.asset.IAssetData:data` and
-`data:adhocracy_core.sheets.asset.IAssetMetadata:mime_type` key is required,
+The `data:adhocracy_core.sheets.asset.IAssetData:data` key is required,
 since the only use case for a PUT request is uploading a new version of the
 binary data (everything else is just metadata).
 
@@ -280,10 +270,7 @@ Lets replace the uploaded python with another one::
 
     >>> upload_files = [('data:adhocracy_core.sheets.asset.IAssetData:data',
     ...     'python2.jpg', open('docs/_static/python2.jpg', 'rb').read())]
-    >>> request_body = {
-    ...    'content_type': 'adhocracy_core.resources.image.IImage',
-    ...    'data:adhocracy_core.sheets.image.IImageMetadata:mime_type':
-    ...        'image/jpeg'}
+    >>> request_body = {'content_type': 'adhocracy_core.resources.image.IImage'}
     >>> resp_data = testapp.put(pic_path, request_body,
     ...             headers=god_header, upload_files=upload_files).json
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -55,7 +55,6 @@ export var uploadImageFactory = (
 
     var formData = new FormData();
     formData.append("content_type", contentType);
-    formData.append("data:" + metadataSheet + ":mime_type", file.type);
     formData.append("data:adhocracy_core.sheets.asset.IAssetData:data", bytes());
 
     return adhHttp.get(poolPath)


### PR DESCRIPTION
API Change:

- make field sheets.image.IIMageMetadata.mime_type readonly

Backend Internal change:

- simplify mime type validation for uploaded assets

Editing this field is not needed (The mime type is given implicit by
uploaded file) and confusing when using auto generated form like for the
admin interface.