### PR TITLE
raise import error if python-magic is not properly installed

### DIFF
--- a/src/adhocracy_core/adhocracy_core/sheets/asset.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/asset.py
@@ -17,6 +17,10 @@ from adhocracy_core.sheets import add_sheet_to_registry
 from adhocracy_core.sheets import sheet_meta
 
 
+# check python-magic is installed properly to make mime type validation work
+import magic  # noqa
+
+
 class IHasAssetPool(ISheet, ISheetReferenceAutoUpdateMarker):
     """Marker interface for resources that have an asset pool."""
 


### PR DESCRIPTION
python-magic is hard dependency to make image upload work.
Checking this sould make error issues like #2396, #2273 less likely.