### PR TITLE
update Pillow from 2.7 to 3.2

### DIFF
--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -70,7 +70,7 @@ Chameleon = 2.22
 
 # Required by:
 # adhocracy-core==0.0
-Pillow = 2.7.0
+Pillow = 3.2.0
 
 # Required by:
 # substanced==0.0


### PR DESCRIPTION
Among other improvement zlib and libjpeg are now required (https://github.com/python-pillow/Pillow/issues/1412 ) ([changelog](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst)).
This should fix issues like https://github.com/liqd/adhocracy3/issues/2396 .