### PR TITLE
replace 'mark-as-deleted' with adhHideAction

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -25,7 +25,7 @@ var pkgLocation = "/Comment";
 export interface ICommentResourceScope extends angular.IScope {
     path : string;
     submit : () => any;
-    delete : () => angular.IPromise<void>;
+    hide : () => angular.IPromise<void>;
     refersTo : string;
     poolPath : string;
     hideCancel? : boolean;
@@ -175,7 +175,8 @@ export var commentDetailDirective = (
     adhTopLevelState : AdhTopLevelState.Service,
     adhRecursionHelper,
     $window : Window,
-    $q : angular.IQService
+    $q : angular.IQService,
+    $translate
 ) => {
     var _update = update(adhHttp, $q);
     var _postEdit = postEdit(adhHttp, adhPreliminaryNames);
@@ -238,7 +239,7 @@ export var commentDetailDirective = (
             });
         };
 
-        scope.delete = () : angular.IPromise<void> => {
+        scope.hide = () : angular.IPromise<void> => {
             // FIXME: translate
             if ($window.confirm("Do you really want to delete this?")) {
                 return adhHttp.hide(scope.data.itemPath, RIComment.content_type).then(() => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -31,10 +31,10 @@
 
                     </a>
                     <a href=""
-                        data-ng-click="delete()"
+                        data-ng-click="hide()"
                         data-ng-if="versionOptions.hide"
                         class="comment-header-link"
-                        title="{{ 'TR__DELETE' | translate }}">
+                        title="{{ 'TR__HIDE' | translate }}">
                         <i class="comment-header-icon icon-x"></i>
                     </a>
                     <a href=""

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -242,8 +242,11 @@ export var postEdit = (
     oldParagraphVersions : RIParagraphVersion[],
     hasMap : boolean = false
 ) : angular.IPromise<RIDocumentVersion> => {
-    // This function assumes that paragraphs can not be reordered or deleted
-    // and that new paragraphs are always appended to the end.
+    // This function assumes the following:
+    // - paragraphs can not be reordered
+    // - paragraphs can't really be deleted, only excluded from the
+    // next version of the document (by marking them as deleted here in the FE),
+    // - new paragraphs are always appended to the end.
 
     var documentPath = AdhUtil.parentPath(oldVersion.path);
     var poolPath = AdhUtil.parentPath(documentPath);
@@ -561,4 +564,3 @@ export var editDirective = (
         }
     };
 };
-

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
@@ -21,5 +21,6 @@ export var register = (angular) => {
         .directive("adhModerateAction", [
             "adhTopLevelState", "adhResourceUrlFilter", "$location", AdhResourceActions.moderateActionDirective])
         .directive("adhPrintAction", ["adhTopLevelState", "$window", AdhResourceActions.printActionDirective])
-        .directive("adhCancelAction", ["adhTopLevelState", "adhResourceUrlFilter", AdhResourceActions.cancelActionDirective]);
+        .directive("adhCancelAction", ["adhTopLevelState", "adhResourceUrlFilter", AdhResourceActions.cancelActionDirective])
+        .directive("adhHideAction", ["adhHttp", "adhTopLevelState", "$q", "$translate", "$window", AdhResourceActions.hideActionDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
@@ -16,7 +16,6 @@ export var register = (angular) => {
         .directive("adhResourceActions", ["adhPermissions", "adhConfig", AdhResourceActions.resourceActionsDirective])
         .directive("adhReportAction", [AdhResourceActions.reportActionDirective])
         .directive("adhShareAction", [AdhResourceActions.shareActionDirective])
-        .directive("adhDeleteAction", [AdhResourceActions.deleteActionDirective])
         .directive("adhEditAction", ["adhTopLevelState", "adhResourceUrlFilter", "$location", AdhResourceActions.editActionDirective])
         .directive("adhModerateAction", [
             "adhTopLevelState", "adhResourceUrlFilter", "$location", AdhResourceActions.moderateActionDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -15,11 +15,6 @@
     <adh-share-action
         data-ng-if="share"
         data-class="action-bar-item"></adh-share-action>
-    <adh-delete-action
-        data-ng-if="delete && resourcePath && proposalItemOptions.hide"
-        data-class="action-bar-item"
-        data-parent-path="parentPath"
-        data-resource-path="{{resourcePath}}"></adh-delete-action>
     <adh-print-action
         data-ng-if="print"
         data-class="action-bar-item"></adh-print-action>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -1,4 +1,5 @@
 import * as AdhConfig from "../Config/Config";
+import * as AdhHttp from "../Http/Http";
 import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
@@ -169,6 +170,38 @@ export var cancelActionDirective = (
                 var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
                 var url = adhResourceUrl(path);
                 adhTopLevelState.goToCameFrom(url);
+            };
+        }
+    };
+};
+
+export var hideActionDirective = (
+    adhHttp: AdhHttp.Service<any>,
+    adhTopLevelState: AdhTopLevelState.Service,
+    $q : angular.IQService,
+    $translate,
+    $window : Window
+) => {
+    return {
+        restrict: "E",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"hide();\">{{ 'TR__HIDE' | translate }}</a>",
+        require: "^adhMovingColumn",
+        scope: {
+            resourcePath: "@",
+            parentPath: "=?",
+            class: "@",
+            contentType: "@"
+        },
+        link: (scope, element) => {
+            scope.hide = (): angular.IPromise<void> => {
+                return $translate("TR__ASK_TO_CONFIRM_HIDE_ACTION").then((question) => {
+                    var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
+                    if ($window.confirm(question)) {
+                        adhHttp.hide(path, scope.contentType).then(() => {
+                            adhTopLevelState.goToCameFrom("/");
+                        });
+                    }
+                });
             };
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -63,24 +63,6 @@ export var shareActionDirective = () => {
     };
 };
 
-export var deleteActionDirective = () => {
-    return {
-        restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"delete();\">{{ 'TR__DELETE' | translate }}</a>",
-        require: "^adhMovingColumn",
-        scope: {
-            resourcePath: "@",
-            parentPath: "=?",
-            class: "@"
-        },
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            scope.delete = () => {
-                column.$broadcast("triggerDelete", scope.resourcePath);
-            };
-        }
-    };
-};
-
 export var printActionDirective = (
     adhTopLevelState : AdhTopLevelState.Service,
     $window : Window

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentDetailColumn.html
@@ -9,11 +9,12 @@
             data-ng-if="documentItemOptions.POST"
             data-ng-click="setCameFrom()"
             data-ng-href="{{ documentUrl | adhParentPath | adhResourceUrl:'edit' }}">{{ "TR__EDIT" | translate }}</a>
-        <a
-            class="moving-column-menu-button"
-            data-ng-if="documentItemOptions.hide"
-            data-ng-click="hide()"
-            href="">{{ "TR__HIDE" | translate }}</a>
+        <adh-hide-action
+            data-ng-if="proposalUrl && proposalItemOptions.hide"
+            data-class="action-bar-item"
+            data-parent-path="true"
+            data-resource-path="{{proposalUrl}}"
+            data-content-type="{{contentType}}"></adh-hide-action>
 
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -98,9 +98,7 @@ export var proposalDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
     adhPermissions : AdhPermissions.Service,
-    adhTopLevelState : AdhTopLevelState.Service,
-    $location : angular.ILocationService,
-    $window : Window
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
@@ -128,21 +126,12 @@ export var proposalDetailColumnDirective = (
                 scope.badgesExist = response.data[SIPool.nick].count > 0;
             });
 
-            scope.hide = () => {
-                var proposalClass = RIGeoProposal;
-                if (scope.isKiezkasse) {
-                    proposalClass = RIKiezkasseProposal;
-                } else if (scope.isBuergerhaushalt) {
-                    proposalClass = RIBuergerhaushaltProposal;
-                }
-                // FIXME: translate
-                if ($window.confirm("Do you really want to delete this?")) {
-                    adhHttp.hide(AdhUtil.parentPath(scope.proposalUrl), proposalClass.content_type)
-                        .then(() => {
-                            adhTopLevelState.goToCameFrom("/");
-                        });
-                }
-            };
+            scope.contentType = RIGeoProposal.content_type;
+            if (scope.isKiezkasse) {
+                scope.contentType = RIKiezkasseProposal.content_type;
+            } else if (scope.isBuergerhaushalt) {
+                scope.contentType = RIBuergerhaushaltProposal.content_type;
+            }
         }
     };
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -33,12 +33,12 @@
                     class="action-bar-item"
                     data-ng-click="ctrl.toggleOverlay('badges')"
                     data-ng-if="badgeAssignmentPoolOptions.POST && badgesExist">{{ "TR__MANAGE_BADGE_ASSIGNMENTS" | translate }}</a>
-                <a
-                    href=""
-                    data-ng-click="hide()"
-                    data-ng-if="proposalItemOptions.hide"
-                    class="action-bar-item"
-                    title="{{ 'TR__DELETE' | translate }}">{{ 'TR__DELETE' | translate }}</a>
+                <adh-hide-action
+                    data-ng-if="proposalUrl && proposalItemOptions.hide"
+                    data-class="action-bar-item"
+                    data-parent-path="true"
+                    data-resource-path="{{proposalUrl}}"
+                    data-content-type="{{contentType}}"></adh-hide-action>
                 <adh-print-action
                     data-class="action-bar-item"></adh-print-action>
             </div>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -262,21 +262,6 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
         return instance;
     }
 
-    public _handleDelete(
-        instance : AdhResourceWidgets.IResourceWidgetInstance<R, IScope>,
-        path : string
-    ) : angular.IPromise<void> {
-        var itemPath = AdhUtil.parentPath(path);
-        // FIXME: translate
-        if (this.$window.confirm("Do you really want to delete this?")) {
-            return this.adhHttp.hide(itemPath, RIMercatorProposal.content_type)
-                .then(() => {
-                    this.$location.url("/r/mercator");
-                });
-        }
-        return this.$q.when();
-    }
-
     private initializeScope(scope : IScope) : IScopeData {
         if (!scope.hasOwnProperty("data")) {
             scope.data = <IScopeData>{};

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/ProposalDetailColumn.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/ProposalDetailColumn.html
@@ -19,9 +19,15 @@
             data-edit="true"
             data-report="true"
             data-share="true"
-            data-delete="true"
-            data-print="true"></adh-resource-actions>
-
+            data-print="true">
+        </adh-resource-actions>
+        <adh-hide-action
+            data-ng-if="proposalUrl && proposalItemOptions.hide"
+            data-class="action-bar-item"
+            data-parent-path="true"
+            data-resource-path="{{proposalUrl}}"
+            data-content-type="{{contentType}}">
+        </adh-hide-action>
         <adh-document-create data-path="{{processUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon"></adh-document-create>
         <adh-resource-wrapper>
             <adh-mercator-2015-proposal-detail-view data-ng-if="proposalUrl" data-path="{{proposalUrl}}"></adh-mercator-2015-proposal-detail-view>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/ProposalDetailColumn.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/ProposalDetailColumn.html
@@ -14,20 +14,29 @@
     </a>
 
     <adh-recompile-on-change data-ng-switch-when="body" data-value="{{proposalUrl}}">
-        <adh-resource-actions
-            data-resource-path="{{proposalUrl}}"
-            data-edit="true"
-            data-report="true"
-            data-share="true"
-            data-print="true">
-        </adh-resource-actions>
-        <adh-hide-action
-            data-ng-if="proposalUrl && proposalItemOptions.hide"
-            data-class="action-bar-item"
-            data-parent-path="true"
-            data-resource-path="{{proposalUrl}}"
-            data-content-type="{{contentType}}">
-        </adh-hide-action>
+        <div class="action-bar">
+            <adh-edit-action
+                data-ng-if="proposalUrl && proposalItemOptions.PUT"
+                data-class="action-bar-item"
+                data-resource-path="{{proposalUrl}}"></adh-edit-action>
+            <adh-report-action
+                data-class="action-bar-item"
+                data-parent-path="true"
+                data-resource-path="{{proposalUrl}}"></adh-report-action>
+            <adh-share-action
+                data-class="action-bar-item">
+            </adh-share-action>
+            <adh-hide-action
+                data-ng-if="proposalUrl && proposalItemOptions.hide"
+                data-class="action-bar-item"
+                data-parent-path="true"
+                data-resource-path="{{proposalUrl}}"
+                data-content-type="{{contentType}}">
+            </adh-hide-action>
+            <adh-print-action
+                data-class="action-bar-item">
+            </adh-print-action>
+        </div>
         <adh-document-create data-path="{{processUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon"></adh-document-create>
         <adh-resource-wrapper>
             <adh-mercator-2015-proposal-detail-view data-ng-if="proposalUrl" data-path="{{proposalUrl}}"></adh-mercator-2015-proposal-detail-view>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
@@ -9,6 +9,7 @@ import * as AdhTopLevelState from "../../../TopLevelState/TopLevelState";
 import * as AdhUtil from "../../../Util/Util";
 
 import RICommentVersion from "../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
+import RIMercatorProposal from "../../../../Resources_/adhocracy_mercator/resources/mercator/IMercatorProposal";
 import RIMercatorProposalVersion from "../../../../Resources_/adhocracy_mercator/resources/mercator/IMercatorProposalVersion";
 import RIProcess from "../../../../Resources_/adhocracy_mercator/resources/mercator/IProcess";
 import * as SIComment from "../../../../Resources_/adhocracy_core/sheets/comment/IComment";
@@ -78,9 +79,7 @@ export var proposalDetailColumnDirective = (
             column.bindVariablesAndClear(scope, ["platformUrl", "proposalUrl"]);
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
-            scope.delete = () => {
-                column.$broadcast("triggerDelete", scope.proposalUrl);
-            };
+            scope.contentType = RIMercatorProposal.content_type;
 
             scope.print = () => {
                 // only the focused column is printed


### PR DESCRIPTION
(continues #2390 & #2394.) Needs #2420 for i18n.

I noticed that hide/delete functions were wrapped in extremely similar ways (including the browser window asking 'Do you really want to delete this?') in the following five places:

- IdeaCollection
- Alexanderplatz
- Blog
- Comment
- Mercator2015

@xi and I discussed the possibility to factor out this functionality. I suggested adding a resourceAction to replace `adhDeleteAction`, since HIDE should be used where 'mark-as-deleted' used to be used.

In this PR,

- a resourceAction called `adhHideAction` is implemented;
- the resourceAction called `adhDeleteAction` is removed - this fixes #2268.

The following use cases are replaced with `adhHideAction`:

- IdeaCollection
- Alexanderplatz
- Mercator2015

The following use cases are left untouched:

- Comment - because the template of the hide action is different (it's an icon).
- Blog - because it's a similar use case to deleting badge assignments (see #2365).