### PR TITLE
make printers print markers on map by default

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_map.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_map.scss
@@ -83,14 +83,27 @@ rather than in response to user action.
     @include border-radius(50%);
     @include box-shadow(0 0 1px 1px $color-text-inverted);
     background: $color-brand-two-normal;
+    border: solid 10px $color-brand-two-normal;
     color: $color-text-inverted;
     text-align: center;
 
     &.is-active, &:hover, &:focus {
         background: $color-brand-one-introvert;
+        border: solid 10px $color-brand-one-introvert;
     }
 
-    &.marker-cluster {
+@media print {
+    .marker-cluster {
+        border: solid 20px $color-brand-two-normal;
+
+        &.is-active, &:hover, &:focus {
+            border: solid 20px $color-brand-one-introvert;
+        }
+    }
+}
+
+@media screen {
+    .leaflet-marker-icon {
         display: table;
 
         div {


### PR DESCRIPTION
This continues #2417. It *partially* fixes #2382.

**First attempt (outdated):**
See: [MDN: -webkit-print-color-adjust](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-print-color-adjust)
According to MDN, this only works for Chrome + Safari and is not a part of any standard. Still, I think it's an improvement.