### PR TITLE
Remove hardcoded hostnames in s1 sample embed page

### DIFF
--- a/src/s1/s1/static/s1.html
+++ b/src/s1/s1/static/s1.html
@@ -14,9 +14,9 @@
     </head>
     <body>
         <!-- begin embed snipped -->
-        <script type="text/javascript" src="http://localhost:6551/AdhocracySDK.js"></script>
+        <script type="text/javascript" src="/AdhocracySDK.js"></script>
         <script type="text/javascript">
-            adhocracy.init("http://localhost:6551", function(adhocracy) {
+            adhocracy.init("", function(adhocracy) {
                 adhocracy.embed(".adhocracy_marker");
             });
         </script>


### PR DESCRIPTION
This allows to make use of the sample page on a server without
modification.