### PR TITLE
move embedded directives' registration

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
@@ -13,6 +13,7 @@ import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 import * as AdhAbuse from "../Abuse/Module";
 
 import * as AdhComment from "./Comment";
+import * as AdhEmbed from "../Embed/Embed";
 
 
 export var moduleName = "adhComment";
@@ -34,6 +35,11 @@ export var register = (angular) => {
             AdhTopLevelStateModule.moduleName,
             AdhAbuse.moduleName
         ])
+        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+            adhEmbedProvider
+                .registerDirective("comment-listing")
+                .registerDirective("create-or-show-comment-listing");
+        }])
         .directive("adhCommentListing", [
             "adhConfig",
             "adhHttp",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
@@ -35,7 +35,7 @@ export var register = (angular) => {
             AdhTopLevelStateModule.moduleName,
             AdhAbuse.moduleName
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
             adhEmbedProvider
                 .registerDirective("comment-listing")
                 .registerDirective("create-or-show-comment-listing");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
@@ -26,7 +26,7 @@ export var register = (angular) => {
             AdhResourceAreaModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
             adhEmbedProvider
                 .registerDirective("debate-workbench");
         }])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
@@ -7,6 +7,8 @@ import * as AdhPermissionsModule from "../Permissions/Module";
 import * as AdhResourceAreaModule from "../ResourceArea/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 
+import * as AdhEmbed from "../Embed/Embed";
+
 import * as DebateWorkbench from "./DebateWorkbench";
 
 
@@ -24,6 +26,10 @@ export var register = (angular) => {
             AdhResourceAreaModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
+        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+            adhEmbedProvider
+                .registerDirective("debate-workbench");
+        }])
         .directive("adhDebateWorkbench", ["adhConfig", "adhTopLevelState", DebateWorkbench.debateWorkbenchDirective])
         .directive("adhDocumentDetailColumn", ["adhConfig", "adhPermissions", DebateWorkbench.documentDetailColumnDirective])
         .directive("adhDocumentCreateColumn", ["adhConfig", DebateWorkbench.documentCreateColumnDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -30,12 +30,6 @@ export class Provider implements angular.IServiceProvider {
      */
     constructor() {
         this.directives = [
-            "document-workbench",
-            "comment-listing",
-            "create-or-show-comment-listing",
-            "login",
-            "register",
-            "user-indicator",
             "empty"
         ];
         this.directiveAliases = {};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -31,7 +31,6 @@ export class Provider implements angular.IServiceProvider {
     constructor() {
         this.directives = [
             "document-workbench",
-            "paragraph-version-detail",
             "comment-listing",
             "create-or-show-comment-listing",
             "login",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -16,6 +16,7 @@ import * as AdhCredentialsModule from "./CredentialsModule";
 import * as AdhUserModule from "./Module";
 import * as AdhImageModule from "../Image/Module";
 
+import * as AdhEmbed from "../Embed/Embed";
 import * as AdhHttp from "../Http/Http";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 
@@ -84,6 +85,12 @@ export var register = (angular) => {
                 .when("activate", ["adhConfig", "adhUser", "adhDone", "$rootScope", "$location", AdhUserViews.activateArea]);
         }])
         .config(["adhResourceAreaProvider", AdhUserViews.registerRoutes()])
+        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+            adhEmbedProvider
+                .registerDirective("login")
+                .registerDirective("register")
+                .registerDirective("user-indicator");
+        }])
         .directive("adhListUsers", ["adhCredentials", "adhConfig", AdhUserViews.userListDirective])
         .directive("adhUserListItem", ["adhConfig", AdhUserViews.userListItemDirective])
         .directive("adhUserProfile", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -85,7 +85,7 @@ export var register = (angular) => {
                 .when("activate", ["adhConfig", "adhUser", "adhDone", "$rootScope", "$location", AdhUserViews.activateArea]);
         }])
         .config(["adhResourceAreaProvider", AdhUserViews.registerRoutes()])
-        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
+        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
             adhEmbedProvider
                 .registerDirective("login")
                 .registerDirective("register")


### PR DESCRIPTION
`AdhEmbedProvider.registerDirective` gets used all over the place. So it's illogical to have seven directives be included in `AdhEmbed.Provider` by default for no reason. This PR moves them to the appropriate modules, so that only `empty` is left.