### PR TITLE
tidy up badge interfaces and functions

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -35,6 +35,49 @@ export interface IGetBadgeAssignments {
     (resource : SIBadgeable.HasSheet) : angular.IPromise<IBadgeAssignment[]>;
 }
 
+export interface IBadge {
+    name : string;
+    title? : string;
+    path : string;
+    groups? : string[];
+}
+
+export interface IBadgeGroup {
+    name : string;
+    title : string;
+    path : string;
+}
+
+var extractBadge = (badge): IBadge => {
+    return {
+        name: badge.data[SIName.nick].name,
+        title: badge.data[SITitle.nick].title,
+        path: badge.path,
+        groups: badge.data[SIBadge.nick].groups
+    };
+};
+
+var extractGroup = (group): IBadgeGroup => {
+    return {
+        name: group.data[SIName.nick].name,
+        title: group.data[SITitle.nick].title,
+        path: group.path
+    };
+};
+
+var collectBadgesByGroup = (groupPaths, badges) => {
+    var badgesByGroup = {};
+    _.forEach(groupPaths, (groupPath) => {
+        badgesByGroup[groupPath] = [];
+        _.forOwn(badges, (badge) => {
+            if (_.includes(badge.groups, groupPath)) {
+                badgesByGroup[groupPath].push(badge);
+            }
+        });
+    });
+    return badgesByGroup;
+};
+
 var createBadgeFacets = (badgeGroups, badges): AdhListing.IFacetItem[] => {
     var groupPaths = _.map(badgeGroups, "path");
     var badgesByGroup = collectBadgesByGroup(groupPaths, badges);
@@ -80,6 +123,7 @@ export var getBadgeFacets = (
             });
         });
     };
+
 export var getBadgesFactory = (
     adhHttp : AdhHttp.Service<any>,
     $q : angular.IQService
@@ -119,36 +163,6 @@ export var getBadgesFactory = (
     } else {
         return $q.all(_.map(assignmentPaths, getBadge));
     }
-};
-
-export var extractBadge = (badge) => {
-    return {
-        name: badge.data[SIName.nick].name,
-        title: badge.data[SITitle.nick].title,
-        path: badge.path,
-        groups: badge.data[SIBadge.nick].groups
-    };
-};
-
-export var extractGroup = (group) => {
-    return {
-        name: group.data[SIName.nick].name,
-        title: group.data[SITitle.nick].title,
-        path: group.path
-    };
-};
-
-export var collectBadgesByGroup = (groupPaths, badges) => {
-    var badgesByGroup = {};
-    _.forEach(groupPaths, (groupPath) => {
-        badgesByGroup[groupPath] = [];
-        _.forOwn(badges, (badge) => {
-            if (_.includes(badge.groups, groupPath)) {
-                badgesByGroup[groupPath].push(badge);
-            }
-        });
-    });
-    return badgesByGroup;
 };
 
 var bindPath = (

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -21,7 +21,7 @@ import * as SITitle from "../../Resources_/adhocracy_core/sheets/title/ITitle";
 
 var pkgLocation = "/Badge";
 
-export interface IBadge {
+export interface IBadgeAssignment {
     title : string;
     description : string;
     name : string;
@@ -29,17 +29,17 @@ export interface IBadge {
     badgePath : string;
 }
 
-export interface IGetBadges {
-    (resource : SIBadgeable.HasSheet) : angular.IPromise<IBadge[]>;
+export interface IGetBadgeAssignments {
+    (resource : SIBadgeable.HasSheet) : angular.IPromise<IBadgeAssignment[]>;
 }
 
 export var getBadgesFactory = (
     adhHttp : AdhHttp.Service<any>,
     $q : angular.IQService
-) : IGetBadges => (
+) : IGetBadgeAssignments => (
     resource : SIBadgeable.HasSheet,
     includeParent? : boolean
-) : angular.IPromise<IBadge[]> => {
+) : angular.IPromise<IBadgeAssignment[]> => {
     if (typeof includeParent === "undefined") {
         includeParent = !!resource.content_type.match(/Version$/);
     }
@@ -172,7 +172,7 @@ export var badgeAssignment = (
             adhHttp.get(scope.path).then((proposal) => {
                 scope.poolPath = proposal.data[SIBadgeable.nick].post_pool;
 
-                return adhGetBadges(proposal).then((assignments : IBadge[]) => {
+                return adhGetBadges(proposal).then((assignments : IBadgeAssignment[]) => {
 
                     bindPath(adhHttp, adhPermissions, $q)(scope);
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -48,7 +48,7 @@ export interface IBadgeGroup {
     path : string;
 }
 
-var extractBadge = (badge): IBadge => {
+var extractBadge = (badge) : IBadge => {
     return {
         name: badge.data[SIName.nick].name,
         title: badge.data[SITitle.nick].title,
@@ -57,7 +57,7 @@ var extractBadge = (badge): IBadge => {
     };
 };
 
-var extractGroup = (group): IBadgeGroup => {
+var extractGroup = (group) : IBadgeGroup => {
     return {
         name: group.data[SIName.nick].name,
         title: group.data[SITitle.nick].title,
@@ -78,14 +78,14 @@ var collectBadgesByGroup = (groupPaths, badges) => {
     return badgesByGroup;
 };
 
-var createBadgeFacets = (badgeGroups, badges): AdhListing.IFacetItem[] => {
+var createBadgeFacets = (badgeGroups, badges) : AdhListing.IFacetItem[] => {
     var groupPaths = _.map(badgeGroups, "path");
     var badgesByGroup = collectBadgesByGroup(groupPaths, badges);
-    return _.map(badgeGroups, (group: any) => {
+    return _.map(badgeGroups, (group : any) => {
         return {
             key: "badge",
             name: group.title,
-            items: _.map(badgesByGroup[group.path], (badge: any) => {
+            items: _.map(badgesByGroup[group.path], (badge : any) => {
                 return {
                     key: badge.name,
                     name: badge.title
@@ -96,12 +96,12 @@ var createBadgeFacets = (badgeGroups, badges): AdhListing.IFacetItem[] => {
 };
 
 export var getBadgeFacets = (
-    adhHttp: AdhHttp.Service<any>,
-    $q: angular.IQService
+    adhHttp : AdhHttp.Service<any>,
+    $q : angular.IQService
 ) => (
-    path: string
-): angular.IPromise<AdhListing.IFacetItem[]> => {
-        var httpMap = (paths: string[], fn): angular.IPromise<any[]> => {
+    path : string
+) : angular.IPromise<AdhListing.IFacetItem[]> => {
+        var httpMap = (paths : string[], fn) : angular.IPromise<any[]> => {
             return $q.all(_.map(paths, (path) => {
                 return adhHttp.get(path).then(fn);
             }));
@@ -212,8 +212,8 @@ var bindPath = (
 export var badgeAssignment = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
-    adhPermissions: AdhPermissions.Service,
-    adhPreliminaryNames: AdhPreliminaryNames.Service,
+    adhPermissions : AdhPermissions.Service,
+    adhPreliminaryNames : AdhPreliminaryNames.Service,
     $q : angular.IQService,
     adhCredentials : AdhCredentials.Service,
     adhGetBadges
@@ -226,7 +226,7 @@ export var badgeAssignment = (
             path: "@",
             showDescription: "=?"
         },
-        link: (scope, element, attrs, column: AdhMovingColumns.MovingColumnController) => {
+        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             scope.badgeablePath = scope.path;
             scope.data = {};
 
@@ -252,7 +252,7 @@ export var badgeAssignment = (
                             _.forOwn(scope.checkboxes, (checked, badgePath) => {
                                 var assignmentExisted = scope.assignments.hasOwnProperty(badgePath);
                                 if (checked && !assignmentExisted) {
-                                    var assignment = new RIBadgeAssignment({ preliminaryNames: adhPreliminaryNames });
+                                    var assignment = new RIBadgeAssignment({ preliminaryNames : adhPreliminaryNames });
                                     assignment.data[SIBadgeAssignment.nick] = {
                                         badge: badgePath,
                                         object: scope.badgeablePath,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -34,12 +34,6 @@ export interface IParagraph {
     selectedState? : string;
 }
 
-export interface IBadge {
-    title : string;
-    description : string;
-    name : string;
-}
-
 export interface IScope extends angular.IScope {
     path? : string;
     hasMap? : boolean;
@@ -57,7 +51,7 @@ export interface IScope extends angular.IScope {
 
         // optional features
         coordinates? : number[];
-        assignments?: IBadge[];
+        assignments?: AdhBadge.IBadgeAssignment[];
     };
     selectedState? : string;
     resource: any;
@@ -100,7 +94,7 @@ export var highlightSelectedParagraph = (
 export var bindPath = (
     $q : angular.IQService,
     adhHttp : AdhHttp.Service<any>,
-    adhGetBadges? : AdhBadge.IGetBadges,
+    adhGetBadges? : AdhBadge.IGetBadgeAssignments,
     adhTopLevelState? : AdhTopLevelState.Service
 ) => (
     scope : IScope,
@@ -349,7 +343,7 @@ export var detailDirective = (
     $q : angular.IQService,
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
@@ -374,7 +368,7 @@ export var listItemDirective = (
     $q : angular.IQService,
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
@@ -405,7 +399,7 @@ export var mapListItemDirective = (
     $q : angular.IQService,
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     adhTopLevelState : AdhTopLevelState.Service
 ) => {
     var directive : angular.IDirective = listItemDirective($q, adhConfig, adhHttp, adhGetBadges, adhTopLevelState);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -37,7 +37,7 @@ export interface IParagraph {
 export interface IScope extends angular.IScope {
     path? : string;
     hasMap? : boolean;
-    hasBadges?: boolean;
+    hasBadges? : boolean;
     options : AdhHttp.IOptions;
     errors? : AdhHttp.IBackendErrorItem[];
     data : {
@@ -51,10 +51,10 @@ export interface IScope extends angular.IScope {
 
         // optional features
         coordinates? : number[];
-        assignments?: AdhBadge.IBadgeAssignment[];
+        assignments? : AdhBadge.IBadgeAssignment[];
     };
     selectedState? : string;
-    resource: any;
+    resource : any;
 
     toggleCreateForm() : void;
     showCreateForm? : boolean;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -563,7 +563,7 @@ export var indicatorDirective = (
 export var metaDirective = (
     adhConfig : AdhConfig.IService,
     adhResourceArea : AdhResourceArea.Service,
-    adhGetBadges : AdhBadge.IGetBadges
+    adhGetBadges : AdhBadge.IGetBadgeAssignments
 ) => {
     return {
         restrict: "E",
@@ -619,7 +619,7 @@ export var userListItemDirective = (adhConfig : AdhConfig.IService) => {
             adhHttp : AdhHttp.Service<any>,
             $scope,
             adhTopLevelState : AdhTopLevelState.Service,
-            adhGetBadges : AdhBadge.IGetBadges
+            adhGetBadges : AdhBadge.IGetBadgeAssignments
         ) => {
             if ($scope.path) {
                 adhHttp.resolve($scope.path)
@@ -651,7 +651,7 @@ export var userProfileDirective = (
     adhPermissions : AdhPermissions.Service,
     adhTopLevelState : AdhTopLevelState.Service,
     adhUser : AdhUser.Service,
-    adhGetBadges : AdhBadge.IGetBadges
+    adhGetBadges : AdhBadge.IGetBadgeAssignments
 ) => {
     return {
         restrict: "E",

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Proposal.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Proposal/Proposal.ts
@@ -46,7 +46,7 @@ var bindPath = (
     adhPermissions: AdhPermissions.Service,
     adhRate: AdhRate.Service,
     adhTopLevelState: AdhTopLevelState.Service,
-    adhGetBadges: AdhBadge.IGetBadges,
+    adhGetBadges: AdhBadge.IGetBadgeAssignments,
     $q: angular.IQService
 ) => (
     scope: IScope,
@@ -143,7 +143,7 @@ export var detailDirective = (
     adhPermissions: AdhPermissions.Service,
     adhRate: AdhRate.Service,
     adhTopLevelState: AdhTopLevelState.Service,
-    adhGetBadges: AdhBadge.IGetBadges,
+    adhGetBadges: AdhBadge.IGetBadgeAssignments,
     $q: angular.IQService
 ) => {
     return {
@@ -164,7 +164,7 @@ export var listItemDirective = (
     adhPermissions: AdhPermissions.Service,
     adhRate: AdhRate.Service,
     adhTopLevelState: AdhTopLevelState.Service,
-    adhGetBadges: AdhBadge.IGetBadges,
+    adhGetBadges: AdhBadge.IGetBadgeAssignments,
     $q: angular.IQService
 ) => {
     return {
@@ -236,7 +236,7 @@ export var editDirective = (
     adhShowError,
     adhSubmitIfValid,
     adhTopLevelState: AdhTopLevelState.Service,
-    adhGetBadges: AdhBadge.IGetBadges,
+    adhGetBadges: AdhBadge.IGetBadgeAssignments,
     $location: angular.ILocationService,
     $q: angular.IQService
 ) => {

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Process.ts
@@ -6,7 +6,6 @@ import * as _ from "lodash";
 import * as AdhBadge from "../../../Badge/Badge";
 import * as AdhConfig from "../../../Config/Config";
 import * as AdhHttp from "../../../Http/Http";
-import * as AdhListing from "../../../Listing/Listing";
 import * as AdhMovingColumns from "../../../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../../../Permissions/Permissions";
 import * as AdhProcess from "../../../Process/Process";
@@ -16,62 +15,14 @@ import RIBuergerhaushaltProposalVersion from "../../../../Resources_/adhocracy_m
 import RIGeoProposalVersion from "../../../../Resources_/adhocracy_core/resources/proposal/IGeoProposalVersion";
 import RIKiezkasseProposalVersion from "../../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion";
 
-import * as SIBadge from "../../../../Resources_/adhocracy_core/sheets/badge/IBadge";
 import * as SIImageReference from "../../../../Resources_/adhocracy_core/sheets/image/IImageReference";
 import * as SILocationReference from "../../../../Resources_/adhocracy_core/sheets/geo/ILocationReference";
 import * as SIMultiPolygon from "../../../../Resources_/adhocracy_core/sheets/geo/IMultiPolygon";
 import * as SIName from "../../../../Resources_/adhocracy_core/sheets/name/IName";
-import * as SIPool from "../../../../Resources_/adhocracy_core/sheets/pool/IPool";
 import * as SITitle from "../../../../Resources_/adhocracy_core/sheets/title/ITitle";
 import * as SIWorkflow from "../../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
 
 var pkgLocation = "/Meinberlin/IdeaCollection/Process";
-
-var createBadgeFacets = (badgeGroups, badges) : AdhListing.IFacetItem[] => {
-    var groupPaths = _.map(badgeGroups, "path");
-    var badgesByGroup = AdhBadge.collectBadgesByGroup(groupPaths, badges);
-    return _.map(badgeGroups, (group : any) => {
-        return {
-            key: "badge",
-            name: group.title,
-            items: _.map(badgesByGroup[group.path], (badge : any) => {
-                return {
-                    key: badge.name,
-                    name: badge.title
-                };
-            })
-        };
-    });
-};
-
-var getFacets = (
-    adhHttp : AdhHttp.Service<any>,
-    $q : angular.IQService
-) => (
-    path : string
-) : angular.IPromise<AdhListing.IFacetItem[]> => {
-    var httpMap = (paths : string[], fn) : angular.IPromise<any[]> => {
-        return $q.all(_.map(paths, (path) => {
-            return adhHttp.get(path).then(fn);
-        }));
-    };
-
-    var params = {
-        elements: "content",
-        depth: 4,
-        content_type: SIBadge.nick
-    };
-
-    return adhHttp.get(path, params).then((response) => {
-        var badgePaths = <string[]>_.map(response.data[SIPool.nick].elements, "path");
-        return httpMap(badgePaths, AdhBadge.extractBadge).then((badges) => {
-            var groupPaths = _.union.apply(_, _.map(badges, "groups"));
-            return httpMap(groupPaths, AdhBadge.extractGroup).then((badgeGroups) => {
-                return createBadgeFacets(badgeGroups, badges);
-            });
-        });
-    });
-};
 
 
 export var detailDirective = (
@@ -90,7 +41,7 @@ export var detailDirective = (
         },
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            getFacets(adhHttp, $q)(scope.path).then((facets) => {
+            AdhBadge.getBadgeFacets(adhHttp, $q)(scope.path).then((facets) => {
                 scope.facets = facets;
             });
 

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Proposal/Proposal.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Proposal/Proposal.ts
@@ -45,7 +45,7 @@ export interface IScope extends angular.IScope {
         lng : number;
         lat : number;
         polygon: number[][];
-        assignments : AdhBadge.IBadge[];
+        assignments : AdhBadge.IBadgeAssignment[];
 
         budget? : number;
         creatorParticipate? : boolean;
@@ -65,7 +65,7 @@ var bindPath = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => (
     scope : IScope,
@@ -240,7 +240,7 @@ export var detailDirective = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => {
     return {
@@ -264,7 +264,7 @@ export var listItemDirective = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => {
     return {
@@ -297,7 +297,7 @@ export var mapListItemDirective = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => {
     return {
@@ -395,7 +395,7 @@ export var editDirective = (
     adhShowError,
     adhSubmitIfValid,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $location : angular.ILocationService,
     $q : angular.IQService
 ) => {

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -31,7 +31,7 @@ export interface IScope extends angular.IScope {
         rateCount : number;
         creationDate : string;
         commentCount : number;
-        assignments : AdhBadge.IBadge[];
+        assignments : AdhBadge.IBadgeAssignment[];
     };
     selectedState? : string;
     resource : any;
@@ -43,7 +43,7 @@ var bindPath = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => (
     scope : IScope,
@@ -125,7 +125,7 @@ export var detailDirective = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => {
     return {

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -212,7 +212,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
         adhHttp : AdhHttp.Service<any>,
         adhPreliminaryNames : AdhPreliminaryNames.Service,
         private adhTopLevelState : AdhTopLevelState.Service,
-        private adhGetBadges : AdhBadge.IGetBadges,
+        private adhGetBadges : AdhBadge.IGetBadgeAssignments,
         private adhUploadImage,
         private flowFactory,
         private moment : moment.MomentStatic,
@@ -730,7 +730,7 @@ export class CreateWidget<R extends ResourcesBase.IResource> extends Widget<R> {
         adhHttp : AdhHttp.Service<any>,
         adhPreliminaryNames : AdhPreliminaryNames.Service,
         adhTopLevelState : AdhTopLevelState.Service,
-        adhGetBadges : AdhBadge.IGetBadges,
+        adhGetBadges : AdhBadge.IGetBadgeAssignments,
         adhUploadImage,
         private $timeout : angular.ITimeoutService,
         flowFactory,
@@ -792,7 +792,7 @@ export class DetailWidget<R extends ResourcesBase.IResource> extends Widget<R> {
         adhHttp : AdhHttp.Service<any>,
         adhPreliminaryNames : AdhPreliminaryNames.Service,
         adhTopLevelState : AdhTopLevelState.Service,
-        adhGetBadges : AdhBadge.IGetBadges,
+        adhGetBadges : AdhBadge.IGetBadgeAssignments,
         adhUploadImage,
         flowFactory,
         moment : moment.MomentStatic,
@@ -856,7 +856,7 @@ export var listItem = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges
+    adhGetBadges : AdhBadge.IGetBadgeAssignments
 ) => {
     return {
         restrict: "E",

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -497,7 +497,7 @@ var get = (
     $q : ng.IQService,
     adhHttp : AdhHttp.Service<any>,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges
+    adhGetBadges : AdhBadge.IGetBadgeAssignments
 ) => (path : string) : ng.IPromise<IDetailData> => {
     return adhHttp.get(path).then((proposal) => {
         var subs : {
@@ -703,7 +703,7 @@ export var editDirective = (
     adhTopLevelState : AdhTopLevelState.Service,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
     adhResourceUrl,
-    adhGetBadges : AdhBadge.IGetBadges
+    adhGetBadges : AdhBadge.IGetBadgeAssignments
 ) => {
     return {
         restrict: "E",
@@ -761,7 +761,7 @@ export var moderateDirective = (
     adhTopLevelState : AdhTopLevelState.Service,
     adhPreliminaryNames : AdhPreliminaryNames.Service,
     adhResourceUrl,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     adhCredentials : AdhCredentials.Service
 ) => {
     return {
@@ -829,7 +829,7 @@ export var listItem = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges
+    adhGetBadges : AdhBadge.IGetBadgeAssignments
 ) => {
     return {
         retrict: "E",
@@ -1008,7 +1008,7 @@ export var detailDirective = (
     adhHttp : AdhHttp.Service<any>,
     adhTopLevelState : AdhTopLevelState.Service,
     adhPermissions : AdhPermissions.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $translate
 ) => {
     return {

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Proposal/Proposal.ts
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Proposal/Proposal.ts
@@ -43,7 +43,7 @@ var bindPath = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => (
     scope : IScope,
@@ -142,7 +142,7 @@ export var detailDirective = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => {
     return {
@@ -163,7 +163,7 @@ export var listItemDirective = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => {
     return {
@@ -235,7 +235,7 @@ export var editDirective = (
     adhShowError,
     adhSubmitIfValid,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $location : angular.ILocationService,
     $q : angular.IQService
 ) => {

--- a/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
+++ b/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
@@ -55,7 +55,7 @@ var bindPath = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => (
     scope : IScope,
@@ -162,7 +162,7 @@ export var detailDirective = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => {
     return {
@@ -183,7 +183,7 @@ export var listItemDirective = (
     adhPermissions : AdhPermissions.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $q : angular.IQService
 ) => {
     return {
@@ -257,7 +257,7 @@ export var editDirective = (
     adhShowError,
     adhSubmitIfValid,
     adhTopLevelState : AdhTopLevelState.Service,
-    adhGetBadges : AdhBadge.IGetBadges,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
     $location : angular.ILocationService,
     $q : angular.IQService
 ) => {


### PR DESCRIPTION
Does a little cleaning up after #2373.

In this PR, I strongly suggest we rename `IBadge` to `IBadgeAssignment`. It becomes clear in `Badge.ts` and all its other use cases, that the values of this object are values connected to the backend resource called `BadgeAssignment`. Furthermore, in this PR, an interface for real badges is added.