### PR TITLE
make leaflet configurable

### DIFF
--- a/buildout-meinberlin.cfg
+++ b/buildout-meinberlin.cfg
@@ -12,6 +12,7 @@ frontend.static_dir = src/meinberlin/meinberlin/build
 frontend_package_name = meinberlin
 backend_package_name = adhocracy_meinberlin
 redirect_url = /r/organisation/kiezkasse/
+leaflet_options = "'https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png', {maxZoom: 18}, {attribution: '© berlinonline'}"
 
 [merge_static_directories]
 static_directories = src/meinberlin/meinberlin/static ${adhocracy:frontend.core.static_dir}

--- a/buildout-pcompass.cfg
+++ b/buildout-pcompass.cfg
@@ -10,6 +10,7 @@ frontend.static_dir = src/pcompass/pcompass/build
 frontend_package_name = pcompass
 backend_package_name = adhocracy_pcompass
 redirect_url = /r/adhocracy/
+leaflet_options = "'https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png', {maxZoom: 18}, {attribution: '© berlinonline'}"
 
 [merge_static_directories]
 static_directories = src/pcompass/pcompass/static ${adhocracy:frontend.core.static_dir}

--- a/buildout-s1.cfg
+++ b/buildout-s1.cfg
@@ -11,6 +11,7 @@ frontend_package_name = s1
 backend_package_name = adhocracy_s1
 frontend.profile_images_enabled = true
 redirect_url = /r/s1/
+leaflet_options = "'https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png', {maxZoom: 18}, {attribution: '© berlinonline'}"
 
 [merge_static_directories]
 static_directories = src/s1/s1/static ${adhocracy:frontend.core.static_dir}

--- a/buildout-spd.cfg
+++ b/buildout-spd.cfg
@@ -10,6 +10,7 @@ frontend.static_dir = src/spd/spd/build
 frontend_package_name = spd
 backend_package_name = adhocracy_spd
 redirect_url = /r/digital_leben/
+leaflet_options = "'https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png', {maxZoom: 18}, {attribution: '© berlinonline'}"
 
 [merge_static_directories]
 static_directories = src/spd/spd/static ${adhocracy:frontend.core.static_dir}

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
@@ -15,6 +15,7 @@ export interface IService {
     rest_platform_path : string;
     canonical_url : string;
     redirect_url : string;
+    leaflet_options : string;
     pkg_path : string;
     ws_url : string;
     embedded : boolean;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -114,7 +114,8 @@ export var mapInput = (
             mapElement.height(scope.height);
 
             var map = leaflet.map(mapElement[0]);
-            leaflet.tileLayer("https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png", {maxZoom: 18}).addTo(map);
+            var leafletOptions = JSON.parse(adhConfig.leaflet_options);
+            leaflet.tileLayer(leafletOptions).addTo(map);
 
             scope.polygon = leaflet.polygon(leaflet.GeoJSON.coordsToLatLngs(scope.rawPolygon), adhMapData.style);
             scope.polygon.addTo(map);


### PR DESCRIPTION
We want to display a different map in a demo case. So the options for using leaflet should be configurable per installation.