### PR TITLE
Fixup 4820d126: Add rtd dependency

### DIFF
--- a/rtd.txt
+++ b/rtd.txt
@@ -100,6 +100,7 @@ snowballstemmer==1.2.0
 sphinx-rtd-theme==0.1.9
 sphinxcontrib-blockdiag==1.5
 sphinxcontrib-actdiag==0.8.5
+sphinxcontrib-programoutput
 statsd==3.0.1
 testfixtures==4.1.2
 transaction==1.4.4


### PR DESCRIPTION
readthedocs broke yet again: https://readthedocs.org/projects/adhocracy3/builds/4118724/

This has happened several times already and is becoming an annoyance. Does someone know how to check for rtd build errors on every pull request (like travis)?