### PR TITLE
change the colors of overlay and badge

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
@@ -22,8 +22,8 @@ Badges for labeling things
     @include inline-block;
     @include rem(margin-right, 5px);
     @include rem(font-size, $font-size-smaller);
-    background: $color-structure-normal;
-    color: $color-text-normal;
+    background: $color-brand-two-normal;
+    color: $color-text-inverted;
     line-height: $badge-line-height;
     text-transform: uppercase;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -350,7 +350,8 @@ A list of alert messages to notify users in the moving column
 
 .moving-column-alert {
     @include rem(padding, 1rem);
-    background: $color-structure-normal;
+    background: $color-function-informative;
+    color: $color-text-inverted;
     text-align: center;
 
     &.m-error {
@@ -358,7 +359,7 @@ A list of alert messages to notify users in the moving column
     }
 
     &.m-warning {
-        background: mix($color-function-invalid, $color-structure-normal);
+        background: $color-function-warning;
     }
 
     &.m-success {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -10,9 +10,11 @@ $color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);
 $color-text-inverted: white;
 
 // Function colors
-$color-function-valid: #2eac66;
-$color-function-invalid: #e6332a;
+$color-function-valid: #4a6d21;
+$color-function-invalid: #b30000;
 $color-function-neutral: #f6d02b;
+$color-function-informative: #706047;
+$color-function-warning: #c80013;
 
 // Background colors
 $color-background-base: white;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -26,7 +26,7 @@ $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
 $color-structure-transparent: transparent;
 
-//Brand colors
+// Brand colors
 $color-brand-one-normal: #fcb813;
 $color-brand-one-introvert: darken($color-brand-one-normal, 10%);
 $color-brand-one-extrovert: lighten($color-brand-one-normal, 10%);
@@ -52,21 +52,21 @@ $moving-column-menu-height: 24px;
 $moving-column-border-width: 5px;
 $annotation-width: 34%;
 
-//Padding
+// Padding
 $padding-small: 0.5rem;
 $padding-medium: 1rem;
 
-//Other
+// Other
 $section-jump-navigation-width: 2rem;
 $moving-column-single-width-max: 55rem;
 $moving-column-single-width-min: 35rem;
 $badge-line-height: 1 + 4px / $font-size-smaller;
 $badge-height: $badge-line-height * $font-size-smaller;
 
-//Line-height (leading)
+// Line-height (leading)
 $line-height-normal: 1.15;
 $line-height-large: 1.2;
 $line-height-plus: 1.6;
 
-//Breakpoints
+// Breakpoints
 $breakpoint-small-device: 640px;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -92,6 +92,16 @@ category: Variables
         <td>For invalid content</td>
     </tr>
     <tr>
+        <td><div class="example-color color-function-warning"></div></td>
+        <td><code>color-function-warning</code></td>
+        <td>For warnings</td>
+    </tr>
+    <tr>
+        <td><div class="example-color color-function-informative"></div></td>
+        <td><code>color-function-informative</code></td>
+        <td>For messages</td>
+    </tr>
+    <tr>
         <td><div class="example-color color-function-neutral"></div></td>
         <td><code>color-function-neutral</code></td>
         <td>For neutral (neither valid nor invalid) content</td>
@@ -193,6 +203,8 @@ category: Variables
 .color-function-valid {background-color: $color-function-valid;}
 .color-function-invalid {background-color: $color-function-invalid;}
 .color-function-neutral {background-color: $color-function-neutral;}
+.color-function-warning {background-color: $color-function-warning;}
+.color-function-informative {background-color: $color-function-informative;}
 
 .color-background-base {background-color: $color-background-base;}
 .color-background-base-introvert {background-color: $color-background-base-introvert;}
@@ -219,3 +231,7 @@ category: Variables
 @include check-contrast($color-text-inverted, $color-text-highlight-normal);
 @include check-contrast($color-text-highlight-normal, $color-background-base);
 @include check-contrast($color-text-highlight-normal, $color-background-base-introvert);
+@include check-contrast($color-text-inverted, $color-function-valid);
+@include check-contrast($color-text-inverted, $color-function-invalid);
+@include check-contrast($color-text-inverted, $color-function-informative);
+@include check-contrast($color-text-inverted, $color-function-warning);

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -30,7 +30,7 @@ Badge modifiers for labeling if a proposal has been realized or not.
     }
 
     &.m-is-realized {
-        background-color: $color-brand-two-normal;
+        background-color: $color-brand-one-normal;
     }
 
     &.m-is-not-realized {
@@ -39,7 +39,7 @@ Badge modifiers for labeling if a proposal has been realized or not.
 
     &.m-info {
         padding-left: 0;
-        background-color: $color-brand-two-normal;
+        background-color: $color-brand-one-normal;
 
         &:before {
             @include inline-block;

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
@@ -15,10 +15,6 @@ $color-text-highlight-introvert: $color-brand-two-introvert;
 $color-text-highlight-extrovert: #333;
 $color-text-inverted: white;
 
-// function colors
-$color-function-valid: #139156;
-$color-function-invalid: #f00;
-
 // background colors
 $color-background-base: white;
 $color-background-base-introvert: #f6f6f6;

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -1,11 +1,11 @@
-//brand colors
+// Brand colors
 $color-brand-one-normal: #fcb813;
 $color-brand-one-extrovert: #fcd370;
 $color-brand-two-normal: #00aae5;
 $color-brand-two-introvert: #0097d5;
 $color-brand-two-extrovert: #89c5ec;
 
-// text colors
+// Text colors
 $color-text-normal: #333;
 $color-text-introvert: #808080;
 $color-text-extrovert: #1c1c1b;
@@ -14,19 +14,19 @@ $color-text-highlight-introvert: #808080;
 $color-text-highlight-extrovert: #333;
 $color-text-inverted: white;
 
-// background colors
+// Background colors
 $color-background-base: white;
 $color-background-base-introvert: #f2f2f2;
 
-// structure colors
+// Structure colors
 $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
 
-//font sizes
+// Font sizes
 $font-size-plus: 16px;
 $font-size-large: 18px;
 $font-size-huge: 48px;
 
-//images
+// Images
 $thumbnail-width: 105px;
 $thumbnail-height: 90px;

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -14,10 +14,6 @@ $color-text-highlight-introvert: #808080;
 $color-text-highlight-extrovert: #333;
 $color-text-inverted: white;
 
-// function colors
-$color-function-valid: #73bf44;
-$color-function-invalid: #f00;
-
 // background colors
 $color-background-base: white;
 $color-background-base-introvert: #f2f2f2;

--- a/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
@@ -21,6 +21,3 @@ $color-text-normal: #4d4d4d;
 $color-text-extrovert: #1c1c1b;
 $color-text-highlight-normal: $color-brand-one-normal;
 
-// Function colors
-$color-function-valid: #73bf44;
-$color-function-invalid: #f00;

--- a/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
@@ -14,8 +14,6 @@ $color-text-highlight-introvert: $color-brand-two-introvert;
 $color-text-highlight-extrovert: $color-brand-two-extrovert;
 
 // Function colors
-$color-function-valid: #73bf44;
-$color-function-invalid: #f00;
 $color-function-winner: #f79321;
 
 $font-family-normal: "Roboto", sans-serif;

--- a/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
@@ -14,10 +14,10 @@ $font-family-normal: "Open Sans", sans-serif;
 $font-size-large: 18px;
 $font-size-huge: 20px;
 
-//images
+// Images
 $thumbnail-width: 105px;
 $thumbnail-height: 90px;
 
-//Buttons
+// Buttons
 $color-button-cta-base: $color-brand-two-normal;
 $color-button-cta-hover-background: $color-brand-two-introvert;

--- a/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
@@ -2,10 +2,6 @@
 $color-text-normal: #333;
 $color-text-highlight-normal: #00b4cc;
 
-// Function colors
-$color-function-valid: #73bf44;
-$color-function-invalid: #f00;
-
 // Brand colors
 $color-brand-one-normal: #00b4cc;
 $color-brand-one-introvert: darken($color-brand-one-normal, 10%);


### PR DESCRIPTION
Our meinberlin POs alerted us to the fact that the colors of badges and overlays are not easily readible. That's why we're changing it for adhocracy3.