### PR TITLE
allow to configure leaflet tile layer per installation

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/__init__.py
+++ b/src/adhocracy_frontend/adhocracy_frontend/__init__.py
@@ -1,4 +1,5 @@
 """Frontend view and simple pyramid app configurations."""
+import json
 import pkg_resources
 
 from pyramid.renderers import render
@@ -61,6 +62,18 @@ def config_view(request):
         'adhocracy.frontend.piwik_track_user_id', 'false'))
     config['profile_images_enabled'] = asbool(settings.get(
         'adhocracy.frontend.profile_images_enabled', 'true'))
+    config['map_tile_url'] = settings.get(
+        'adhocracy.frontend.map_tile_url',
+        'http://{s}.tile.osm.org/{z}/{x}/{y}.png')
+    map_tile_options = settings.get('adhocracy.frontend.map_tile_options')
+    if map_tile_options is not None:
+        config['map_tile_options'] = json.loads(map_tile_options)
+    else:
+        url = 'https://www.openstreetmap.org/copyright'
+        config['map_tile_options'] = {
+            'maxZoom': 18,
+            'attribution': '© <a href="%s">OpenStreetMap</a>' % url,
+        }
     use_cachbust = asbool(settings.get('cachebust.enabled', 'false'))
     if not use_cachbust:  # ease testing
         return config

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Config/Config.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../../lib2/types/angular.d.ts"/>
+/// <reference path="../../../lib2/types/leaflet.d.ts"/>
 
 /* tslint:disable:variable-name */
 
@@ -41,4 +42,6 @@ export interface IService {
     piwik_site_id : string;
     piwik_use_cookies : boolean;
     piwik_track_user_id : boolean;
+    map_tile_url : string;
+    map_tile_options : L.TileLayerOptions;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Mapping.ts
@@ -114,7 +114,7 @@ export var mapInput = (
             mapElement.height(scope.height);
 
             var map = leaflet.map(mapElement[0]);
-            leaflet.tileLayer("https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png", {maxZoom: 18}).addTo(map);
+            leaflet.tileLayer(adhConfig.map_tile_url, adhConfig.map_tile_options).addTo(map);
 
             scope.polygon = leaflet.polygon(leaflet.GeoJSON.coordsToLatLngs(scope.rawPolygon), adhMapData.style);
             scope.polygon.addTo(map);
@@ -227,6 +227,7 @@ export var mapInput = (
 };
 
 export var mapDetail = (
+    adhConfig : AdhConfig.IService,
     adhMapData : IMapData,
     leaflet : typeof L,
     $timeout : angular.ITimeoutService
@@ -250,7 +251,7 @@ export var mapDetail = (
             scope.map = leaflet.map(mapElement[0], {
                 scrollWheelZoom: false
             });
-            leaflet.tileLayer("https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png", {maxZoom: 18}).addTo(scope.map);
+            leaflet.tileLayer(adhConfig.map_tile_url, adhConfig.map_tile_options).addTo(scope.map);
             scope.polygon = leaflet.polygon(leaflet.GeoJSON.coordsToLatLngs(scope.polygon), adhMapData.style);
             scope.polygon.addTo(scope.map);
 
@@ -301,6 +302,7 @@ export class MapListingController {
     private scrollToItem;
 
     constructor(
+        private adhConfig : AdhConfig.IService,
         private adhMapData : IMapData,
         private $scope : IMapListScope,
         private $element,
@@ -369,7 +371,7 @@ export class MapListingController {
         mapElement.height(this.$scope.height);
 
         var map = this.leaflet.map(mapElement[0]);
-        this.leaflet.tileLayer("https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png", {maxZoom: 18}).addTo(map);
+        this.leaflet.tileLayer(this.adhConfig.map_tile_url, this.adhConfig.map_tile_options).addTo(map);
 
         this.$scope.polygon = this.leaflet.polygon(this.leaflet.GeoJSON.coordsToLatLngs(this.$scope.rawPolygon), this.adhMapData.style);
         this.$scope.polygon.addTo(map);
@@ -525,7 +527,7 @@ export var mapListingInternal = (
                 return adhConfig.pkg_path + pkgLocation + "/ListingInternalHorizontal.html";
             }
         },
-        controller: ["adhMapData", "$scope", "$element", "$attrs", "$timeout", "leaflet", MapListingController]
+        controller: ["adhConfig", "adhMapData", "$scope", "$element", "$attrs", "$timeout", "leaflet", MapListingController]
     };
 };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Mapping/Module.ts
@@ -56,7 +56,7 @@ export var register = (angular) => {
             };
         }])
         .directive("adhMapInput", ["adhConfig", "adhSingleClickWrapper", "adhMapData", "$timeout", "leaflet", AdhMapping.mapInput])
-        .directive("adhMapDetail", ["adhMapData", "leaflet", "$timeout", AdhMapping.mapDetail])
+        .directive("adhMapDetail", ["adhConfig", "adhMapData", "leaflet", "$timeout", AdhMapping.mapDetail])
         .directive("adhMapListingInternal", ["adhConfig", "adhHttp", AdhMapping.mapListingInternal])
         .directive("adhMapSwitch", ["adhConfig", AdhMapping.mapSwitch])
         .directive("adhMapListing", ["adhConfig", "adhWebSocket", (adhConfig, adhWebSocket) =>


### PR DESCRIPTION
*supersedes #2441*

Before this, we used `"https://maps.berlinonline.de/tile/bright/{z}/{x}/{y}.png"` as a tile layer for all maps. Now this is configurable per installation and the default is `"http://{s}.tile.osm.org/{z}/{x}/{y}.png"`.

The new default was selected because it covers the whole planet instead of only germany.

For development, we may want to stick with berlinonline for some installations.

For others, we may want to switch to mapbox (e.g. `"https://api.mapbox.com/styles/v1/liqd/cipo49m9w002ldfm1omjmi5nw/tiles/256/{z}/{x}/{y}"`) (ask me or @MagdaN for the access token). Note however that with a free plan this is only allowed for [non-comercial use](https://www.mapbox.com/help/commercial/). In any case, we need to add proper [attribution](https://www.mapbox.com/help/attribution/#other-mapping-frameworks)

@joka I did not add tests for the python code. Is this ok? (Pending review.)