### PR TITLE
change colors (of overlay and badge)

### DIFF
--- a/docs/development/coding_guides/css_guidelines.rst
+++ b/docs/development/coding_guides/css_guidelines.rst
@@ -481,7 +481,7 @@ different types of values starting from preferred.
 
       @include rem(margin, 10px 5px);
       @include rem(margin-bottom, 2rem);
-      @include rem(border, 3px solid $color-function-valid);
+      @include rem(border, 3px solid $color-function-positive);
 
    This automatically calculates ``rem`` units with a ``px`` fallback
    for older browsers.

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_badges.scss
@@ -22,8 +22,8 @@ Badges for labeling things
     @include inline-block;
     @include rem(margin-right, 5px);
     @include rem(font-size, $font-size-smaller);
-    background: $color-structure-normal;
-    color: $color-text-normal;
+    background: $color-brand-two-normal;
+    color: $color-text-inverted;
     line-height: $badge-line-height;
     text-transform: uppercase;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_comment.scss
@@ -246,7 +246,7 @@ parent: comment
         }
 
         &.comment-header-link-report {
-            color: $color-function-invalid;
+            color: $color-function-negative;
         }
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -92,9 +92,9 @@ Textinput that represents a title.
 */
 
 .error-state {
-    border-color: $color-function-invalid;
-    color: $color-function-invalid;
-    outline: 1px solid $color-function-invalid;
+    border-color: $color-function-negative;
+    color: $color-function-negative;
+    outline: 1px solid $color-function-negative;
 }
 
 input[type="text"],

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -204,9 +204,9 @@ Class to add styling to a label when the label itself is used as a container.
 
 .input-error {
     @include rem(font-size, $font-size-small);
+    @include rem(padding-top, 10px);
     display: block;
     color: $color-function-negative;
-    padding-top: 10px;
 }
 
 /*doc

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -125,6 +125,9 @@ textarea {
 
     &.ng-dirty.ng-invalid {
         @extend .error-state;
+        border-color: $color-function-negative;
+        color: $color-function-negative;
+        outline: 1px solid $color-function-negative;
     }
 
     &.ng-disabled,
@@ -202,7 +205,8 @@ Class to add styling to a label when the label itself is used as a container.
 .input-error {
     @include rem(font-size, $font-size-small);
     display: block;
-    color: $color-function-invalid;
+    color: $color-function-negative;
+    padding-top: 10px;
 }
 
 /*doc

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_forms.scss
@@ -138,7 +138,6 @@ textarea {
 }
 
 
-
 .ng-submitted {
     input[type="text"],
     input[type="url"],

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_map.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_map.scss
@@ -51,7 +51,7 @@ time.
     }
 
     &.ng-invalid {
-        background: $color-function-invalid;
+        background: $color-function-negative;
         font-weight: $font-weight-extrovert;
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_map.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_map.scss
@@ -53,11 +53,11 @@ time.
     &.ng-invalid {
         background: $color-function-negative;
         font-weight: $font-weight-extrovert;
-    }
 
-    &.ng-invalid a {
-        color: $color-text-inverted;
-        text-decoration: underline;
+        a {
+            color: inherit;
+            text-decoration: underline;
+        }
     }
 }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_map.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_map.scss
@@ -54,6 +54,11 @@ time.
         background: $color-function-invalid;
         font-weight: $font-weight-extrovert;
     }
+
+    &.ng-invalid a {
+        color: $color-text-inverted;
+        text-decoration: underline;
+    }
 }
 
 /*doc

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -350,7 +350,8 @@ A list of alert messages to notify users in the moving column
 
 .moving-column-alert {
     @include rem(padding, 1rem);
-    background: $color-structure-normal;
+    background: $color-function-informative;
+    color: $color-text-inverted;
     text-align: center;
 
     &.m-error {
@@ -358,7 +359,7 @@ A list of alert messages to notify users in the moving column
     }
 
     &.m-warning {
-        background: mix($color-function-invalid, $color-structure-normal);
+        background: $color-function-warning;
     }
 
     &.m-success {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -364,7 +364,8 @@ A list of alert messages to notify users in the moving column
     }
 
     &.m-success {
-        background: $color-function-valid;
+        background: $color-function-positive;
+        color: $color-text-inverted;
     }
 }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -360,7 +360,6 @@ A list of alert messages to notify users in the moving column
 
     &.m-success {
         background: $color-function-positive;
-        color: $color-text-inverted;
     }
 }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -349,8 +349,8 @@ A list of alert messages to notify users in the moving column
 
 .moving-column-alert {
     @include rem(padding, 1rem);
-    background: $color-function-informative;
-    color: $color-text-inverted;
+    background: $color-function-neutral;
+    color: $color-text-normal;
     text-align: center;
 
     &.m-error {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -331,7 +331,6 @@ A list of alert messages to notify users in the moving column
 ```html_example
 <ul class="moving-column-alerts static-example">
     <li class="moving-column-alert m-error">Error</li>
-    <li class="moving-column-alert m-warning">Warning</li>
     <li class="moving-column-alert m-info">Info</li>
     <li class="moving-column-alert m-success">Success</li>
 </ul>
@@ -357,11 +356,6 @@ A list of alert messages to notify users in the moving column
     &.m-error {
         background: $color-function-negative;
         color: $color-text-inverted;
-    }
-
-    &.m-warning {
-        background: $color-function-neutral;
-        color: $color-text-darkest;
     }
 
     &.m-success {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -359,7 +359,8 @@ A list of alert messages to notify users in the moving column
     }
 
     &.m-warning {
-        background: $color-function-warning;
+        background: $color-function-neutral;
+        color: $color-text-darkest;
     }
 
     &.m-success {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -355,7 +355,8 @@ A list of alert messages to notify users in the moving column
     text-align: center;
 
     &.m-error {
-        background: $color-function-invalid;
+        background: $color-function-negative;
+        color: $color-text-inverted;
     }
 
     &.m-warning {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
@@ -234,7 +234,7 @@ Click show results
         &:hover:not(.is-disabled),
         &:focus:not(.is-disabled),
         &:active:not(.is-disabled) {
-            color: $color-function-invalid;
+            color: $color-function-negative;
         }
     }
 
@@ -244,7 +244,7 @@ Click show results
         }
 
         &.is-negative {
-            color: $color-function-invalid;
+            color: $color-function-negative;
         }
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_rate.scss
@@ -80,10 +80,10 @@ $arrow-width: 1rem;
 
     &:active,
     &.is-rate-button-active {
-        background: $color-function-valid;
+        background: $color-function-positive;
 
         &:before {
-            border-right-color: $color-function-valid;
+            border-right-color: $color-function-positive;
         }
 
         // :focus is sometimes set on click and then stays.
@@ -225,7 +225,7 @@ Click show results
         &:hover:not(.is-disabled),
         &:focus:not(.is-disabled),
         &:active:not(.is-disabled) {
-            color: $color-function-valid;
+            color: $color-function-positive;
         }
     }
 
@@ -240,7 +240,7 @@ Click show results
 
     .rate-difference {
         &.is-positive {
-            color: $color-function-valid;
+            color: $color-function-positive;
         }
 
         &.is-negative {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_type.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_type.scss
@@ -340,7 +340,7 @@ parent: inline
 */
 ins {
     text-decoration: underline;
-    color: $color-function-valid;
+    color: $color-function-positive;
 }
 
 /*doc

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_type.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_type.scss
@@ -324,7 +324,7 @@ parent: inline
 */
 del {
     text-decoration: line-through;
-    color: $color-function-invalid;
+    color: $color-function-negative;
 }
 
 /*doc

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -10,8 +10,8 @@ $color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);
 $color-text-inverted: white;
 
 // Function colors
-$color-function-negative: #c72e51;
 $color-function-positive: #00af5d;
+$color-function-negative: #c72e51;
 $color-function-neutral: #fdd216;
 
 // Background colors

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -1,7 +1,7 @@
 /* documentation is in variables_doc */
 
 // Text colors
-$color-text-normal: #444;
+$color-text-normal: #222;
 $color-text-introvert: lighten($color-text-normal, 15%);
 $color-text-extrovert: darken($color-text-normal, 10%);
 $color-text-highlight-normal: #026dca;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -11,7 +11,6 @@ $color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);
 $color-text-inverted: white;
 
 // Function colors
-$color-function-valid: #4a6d21;
 $color-function-invalid: #b30000;
 $color-function-informative: #706047;
 $color-function-negative: #c72e51;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -12,9 +12,11 @@ $color-text-inverted: white;
 // Function colors
 $color-function-valid: #4a6d21;
 $color-function-invalid: #b30000;
-$color-function-neutral: #f6d02b;
 $color-function-informative: #706047;
 $color-function-warning: #c80013;
+$color-function-negative: #c72e51;
+$color-function-positive: #00af5d;
+$color-function-neutral: #fdd216;
 
 // Background colors
 $color-background-base: white;
@@ -60,7 +62,7 @@ $padding-medium: 1rem;
 $section-jump-navigation-width: 2rem;
 $moving-column-single-width-max: 55rem;
 $moving-column-single-width-min: 35rem;
-$badge-line-height: 1 + 4px / $font-size-smaller;
+$badge-line-height: 2;
 $badge-height: $badge-line-height * $font-size-smaller;
 
 //Line-height (leading)

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -10,9 +10,11 @@ $color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);
 $color-text-inverted: white;
 
 // Function colors
-$color-function-valid: #2eac66;
-$color-function-invalid: #e6332a;
+$color-function-valid: #4a6d21;
+$color-function-invalid: #b30000;
 $color-function-neutral: #f6d02b;
+$color-function-informative: #706047;
+$color-function-warning: #c80013;
 
 // Background colors
 $color-background-base: white;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -4,7 +4,6 @@
 $color-text-normal: #444;
 $color-text-introvert: lighten($color-text-normal, 15%);
 $color-text-extrovert: darken($color-text-normal, 10%);
-$color-text-darkest: black;
 $color-text-highlight-normal: #026dca;
 $color-text-highlight-introvert: darken($color-text-highlight-normal, 10%);
 $color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -11,7 +11,6 @@ $color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);
 $color-text-inverted: white;
 
 // Function colors
-$color-function-invalid: #b30000;
 $color-function-informative: #706047;
 $color-function-negative: #c72e51;
 $color-function-positive: #00af5d;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -10,7 +10,6 @@ $color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);
 $color-text-inverted: white;
 
 // Function colors
-$color-function-informative: #706047;
 $color-function-negative: #c72e51;
 $color-function-positive: #00af5d;
 $color-function-neutral: #fdd216;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -4,6 +4,7 @@
 $color-text-normal: #444;
 $color-text-introvert: lighten($color-text-normal, 15%);
 $color-text-extrovert: darken($color-text-normal, 10%);
+$color-text-darkest: black;
 $color-text-highlight-normal: #026dca;
 $color-text-highlight-introvert: darken($color-text-highlight-normal, 10%);
 $color-text-highlight-extrovert: lighten($color-text-highlight-normal, 10%);
@@ -13,7 +14,6 @@ $color-text-inverted: white;
 $color-function-valid: #4a6d21;
 $color-function-invalid: #b30000;
 $color-function-informative: #706047;
-$color-function-warning: #c80013;
 $color-function-negative: #c72e51;
 $color-function-positive: #00af5d;
 $color-function-neutral: #fdd216;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -26,7 +26,7 @@ $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
 $color-structure-transparent: transparent;
 
-//Brand colors
+// Brand colors
 $color-brand-one-normal: #fcb813;
 $color-brand-one-introvert: darken($color-brand-one-normal, 10%);
 $color-brand-one-extrovert: lighten($color-brand-one-normal, 10%);
@@ -52,21 +52,21 @@ $moving-column-menu-height: 24px;
 $moving-column-border-width: 5px;
 $annotation-width: 34%;
 
-//Padding
+// Padding
 $padding-small: 0.5rem;
 $padding-medium: 1rem;
 
-//Other
+// Other
 $section-jump-navigation-width: 2rem;
 $moving-column-single-width-max: 55rem;
 $moving-column-single-width-min: 35rem;
 $badge-line-height: 2;
 $badge-height: $badge-line-height * $font-size-smaller;
 
-//Line-height (leading)
+// Line-height (leading)
 $line-height-normal: 1.15;
 $line-height-large: 1.2;
 $line-height-plus: 1.6;
 
-//Breakpoints
+// Breakpoints
 $breakpoint-small-device: 640px;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -94,7 +94,7 @@ category: Variables
     <tr>
         <td><div class="example-color color-function-neutral"></div></td>
         <td><code>color-function-neutral</code></td>
-        <td>For neutral (neither valid nor invalid) content, e.g. badges saying 'on test'</td>
+        <td>For neutral (neither positive nor negative) content, e.g. badges saying 'on test'</td>
     </tr>
     <tr>
         <td><div class="example-color color-function-negative"></div></td>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -82,11 +82,6 @@ category: Variables
         <td colspan="3"><strong>Functional colors</strong></td>
     </tr>
     <tr>
-        <td><div class="example-color color-function-informative"></div></td>
-        <td><code>color-function-informative</code></td>
-        <td>For messages</td>
-    </tr>
-    <tr>
         <td><div class="example-color color-function-neutral"></div></td>
         <td><code>color-function-neutral</code></td>
         <td>For neutral (neither positive nor negative) content, e.g. badges saying 'on test'</td>
@@ -196,7 +191,6 @@ category: Variables
 .color-text-inverted {background-color: $color-text-inverted;}
 
 .color-function-neutral {background-color: $color-function-neutral;}
-.color-function-informative {background-color: $color-function-informative;}
 .color-function-negative {background-color: $color-function-negative;}
 .color-function-positive {background-color: $color-function-positive;}
 
@@ -227,4 +221,4 @@ category: Variables
 @include check-contrast($color-text-highlight-normal, $color-background-base-introvert);
 @include check-contrast($color-text-inverted, $color-function-negative);
 @include check-contrast($color-text-inverted, $color-function-positive);
-@include check-contrast($color-text-inverted, $color-function-informative);
+@include check-contrast($color-text-normal, $color-function-neutral);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -31,11 +31,6 @@ category: Variables
             <code>color-text-highlight-normal</code></td>
     </tr>
     <tr>
-        <td><div class="example-color color-text-darkest"></div></td>
-        <td><code>color-text-darkest</code></td>
-        <td>For text on 'function-color-warning' background</td>
-    </tr>
-    <tr>
         <td><div class="example-color color-text-highlight-normal"></div></td>
         <td><code>color-text-highlight-normal</code></td>
         <td>For highlighted content such as links</td>
@@ -195,7 +190,6 @@ category: Variables
 .color-text-normal {background-color: $color-text-normal;}
 .color-text-introvert {background-color: $color-text-introvert;}
 .color-text-extrovert {background-color: $color-text-extrovert;}
-.color-text-darkest {background-color: $color-text-darkest;}
 .color-text-highlight-normal {background-color: $color-text-highlight-normal;}
 .color-text-highlight-introvert {background-color: $color-text-highlight-introvert;}
 .color-text-highlight-extrovert {background-color: $color-text-highlight-extrovert;}
@@ -234,5 +228,3 @@ category: Variables
 @include check-contrast($color-text-inverted, $color-function-negative);
 @include check-contrast($color-text-inverted, $color-function-positive);
 @include check-contrast($color-text-inverted, $color-function-informative);
-@include check-contrast($color-text-darkest, $color-function-neutral);
-

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -82,9 +82,9 @@ category: Variables
         <td colspan="3"><strong>Functional colors</strong></td>
     </tr>
     <tr>
-        <td><div class="example-color color-function-neutral"></div></td>
-        <td><code>color-function-neutral</code></td>
-        <td>For neutral (neither positive nor negative) content, e.g. badges saying 'on test'</td>
+        <td><div class="example-color color-function-positive"></div></td>
+        <td><code>color-function-positive</code></td>
+        <td>For approved content, e.g. proposals that are realized, pro-rates</td>
     </tr>
     <tr>
         <td><div class="example-color color-function-negative"></div></td>
@@ -92,9 +92,9 @@ category: Variables
         <td>For negative content, e.g. proposals that aren't realized, wrong input</td>
     </tr>
     <tr>
-        <td><div class="example-color color-function-positive"></div></td>
-        <td><code>color-function-positive</code></td>
-        <td>For approved content, e.g. proposals that are realized, pro-rates</td>
+        <td><div class="example-color color-function-neutral"></div></td>
+        <td><code>color-function-neutral</code></td>
+        <td>For neutral (neither positive nor negative) content, e.g. badges saying 'on test'</td>
     </tr>
     <tr>
         <td colspan="3"><strong>Structural colors</strong></td>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -220,5 +220,5 @@ category: Variables
 @include check-contrast($color-text-highlight-normal, $color-background-base);
 @include check-contrast($color-text-highlight-normal, $color-background-base-introvert);
 @include check-contrast($color-text-inverted, $color-function-negative);
-@include check-contrast($color-text-inverted, $color-function-positive);
+@include check-contrast($color-text-normal, $color-function-positive);
 @include check-contrast($color-text-normal, $color-function-neutral);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -219,3 +219,8 @@ category: Variables
 @include check-contrast($color-text-inverted, $color-text-highlight-normal);
 @include check-contrast($color-text-highlight-normal, $color-background-base);
 @include check-contrast($color-text-highlight-normal, $color-background-base-introvert);
+@include check-contrast($color-text-inverted, $color-function-negative);
+@include check-contrast($color-text-inverted, $color-function-positive);
+@include check-contrast($color-text-inverted, $color-function-informative);
+@include check-contrast($color-text-darkest, $color-function-neutral);
+

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -31,6 +31,11 @@ category: Variables
             <code>color-text-highlight-normal</code></td>
     </tr>
     <tr>
+        <td><div class="example-color color-text-darkest"></div></td>
+        <td><code>color-text-darkest</code></td>
+        <td>For text on 'function-color-warning' background</td>
+    </tr>
+    <tr>
         <td><div class="example-color color-text-highlight-normal"></div></td>
         <td><code>color-text-highlight-normal</code></td>
         <td>For highlighted content such as links</td>
@@ -82,19 +87,24 @@ category: Variables
         <td colspan="3"><strong>Functional colors</strong></td>
     </tr>
     <tr>
-        <td><div class="example-color color-function-valid"></div></td>
-        <td><code>color-function-valid</code></td>
-        <td>For valid content</td>
-    </tr>
-    <tr>
-        <td><div class="example-color color-function-invalid"></div></td>
-        <td><code>color-function-invalid</code></td>
-        <td>For invalid content</td>
+        <td><div class="example-color color-function-informative"></div></td>
+        <td><code>color-function-informative</code></td>
+        <td>For messages</td>
     </tr>
     <tr>
         <td><div class="example-color color-function-neutral"></div></td>
         <td><code>color-function-neutral</code></td>
-        <td>For neutral (neither valid nor invalid) content</td>
+        <td>For neutral (neither valid nor invalid) content, e.g. badges saying 'on test'</td>
+    </tr>
+    <tr>
+        <td><div class="example-color color-function-negative"></div></td>
+        <td><code>color-function-negative</code></td>
+        <td>For negative content, e.g. proposals that aren't realized, wrong input</td>
+    </tr>
+    <tr>
+        <td><div class="example-color color-function-positive"></div></td>
+        <td><code>color-function-positive</code></td>
+        <td>For approved content, e.g. proposals that are realized, pro-rates</td>
     </tr>
     <tr>
         <td colspan="3"><strong>Structural colors</strong></td>
@@ -185,14 +195,16 @@ category: Variables
 .color-text-normal {background-color: $color-text-normal;}
 .color-text-introvert {background-color: $color-text-introvert;}
 .color-text-extrovert {background-color: $color-text-extrovert;}
+.color-text-darkest {background-color: $color-text-darkest;}
 .color-text-highlight-normal {background-color: $color-text-highlight-normal;}
 .color-text-highlight-introvert {background-color: $color-text-highlight-introvert;}
 .color-text-highlight-extrovert {background-color: $color-text-highlight-extrovert;}
 .color-text-inverted {background-color: $color-text-inverted;}
 
-.color-function-valid {background-color: $color-function-valid;}
-.color-function-invalid {background-color: $color-function-invalid;}
 .color-function-neutral {background-color: $color-function-neutral;}
+.color-function-informative {background-color: $color-function-informative;}
+.color-function-negative {background-color: $color-function-negative;}
+.color-function-positive {background-color: $color-function-positive;}
 
 .color-background-base {background-color: $color-background-base;}
 .color-background-base-introvert {background-color: $color-background-base-introvert;}

--- a/src/euth/euth/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/euth/euth/static/stylesheets/scss/general/_variables_theme.scss
@@ -1,5 +1,4 @@
 // Text colors
-$color-text-normal: #333;
 $color-text-highlight-normal: #008dd0;
 
 // Brand colors

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Proposal/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Proposal/Detail.html
@@ -7,8 +7,7 @@
             data-ng-class="{
                 'm-is-realized': assignment.name === 'going_to_be_realized',
                 'm-is-not-realized': assignment.name === 'not_realizeable',
-                'm-on-test': assignment.name === 'on_test',
-                'm-color': isBuergerhaushalt && (assignment.name === 'going_to_be_realized' || assignment.name === 'not_realizeable' || assignment.name === 'on_test')
+                'm-on-test': assignment.name === 'on_test'
             }">{{ assignment.title | translate }}</span>
 
         <ul class="meinberlin-proposal-detail-meta">
@@ -53,8 +52,7 @@
             data-ng-class="{
                 'm-is-realized': assignment.name === 'going_to_be_realized',
                 'm-is-not-realized': assignment.name === 'not_realizeable',
-                'm-on-test': assignment.name === 'on_test',
-                'm-color': isBuergerhaushalt && (assignment.name === 'going_to_be_realized' || assignment.name === 'not_realizeable' || assignment.name === 'on_test')
+                'm-on-test': assignment.name === 'on_test'
             }">
             <adh-parse-markdown data-parsetext="assignment.description"></adh-parse-markdown>
         </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Proposal/ListItem.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Proposal/ListItem.html
@@ -12,8 +12,7 @@
             data-ng-class="{
                 'm-is-realized': assignment.name === 'going_to_be_realized',
                 'm-is-not-realized': assignment.name === 'not_realizeable',
-                'm-on-test': assignment.name === 'on_test',
-                'm-color': isBuergerhaushalt && (assignment.name === 'going_to_be_realized' || assignment.name === 'not_realizeable' || assignment.name === 'on_test')
+                'm-on-test': assignment.name === 'on_test'
             }">{{ assignment.title | translate }}</span>
     </div>
     <div class="proposal-list-item-col-right">

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -30,7 +30,7 @@ Badge modifiers for labeling if a proposal has been realized or not.
     }
 
     &.m-is-realized {
-        background-color: $color-brand-two-normal;
+        background-color: $color-brand-one-normal;
     }
 
     &.m-is-not-realized {
@@ -39,7 +39,7 @@ Badge modifiers for labeling if a proposal has been realized or not.
 
     &.m-info {
         padding-left: 0;
-        background-color: $color-brand-two-normal;
+        background-color: $color-brand-one-normal;
 
         &:before {
             @include inline-block;

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -39,7 +39,7 @@ Badge modifiers for labeling if a proposal has been realized or not.
 
     &.m-on-test {
         background-color: $color-function-neutral;
-        color: $color-text-darkest;
+        color: $color-text-normal;
     }
 
     &.m-info {

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -68,7 +68,7 @@ Badge modifiers for labeling if a proposal has been realized or not.
         @include rem(padding-left, 0.5rem);
 
         &.m-is-realized {
-            border-left-color: $color-function-valid;
+            border-left-color: $color-function-positive;
         }
 
         &.m-is-not-realized {

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -30,11 +30,16 @@ Badge modifiers for labeling if a proposal has been realized or not.
     }
 
     &.m-is-realized {
-        background-color: $color-brand-one-normal;
+        background-color: $color-function-positive;
     }
 
     &.m-is-not-realized {
-        background-color: $color-text-introvert;
+        background-color: $color-function-negative;
+    }
+
+    &.m-on-test {
+        background-color: $color-function-neutral;
+        color: $color-text-darkest;
     }
 
     &.m-info {
@@ -53,21 +58,7 @@ Badge modifiers for labeling if a proposal has been realized or not.
 
     &.m-color {
         @include rem(border-width, 0 0 0 $badge-height);
-        background-color: $color-text-introvert;
-        border-style: solid;
         position: relative;
-
-        &.m-is-realized {
-            border-color: $color-function-valid;
-        }
-
-        &.m-is-not-realized {
-            border-color: $color-function-invalid;
-        }
-
-        &.m-on-test {
-            border-color: $color-function-neutral;
-        }
     }
 }
 

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -72,7 +72,7 @@ Badge modifiers for labeling if a proposal has been realized or not.
         }
 
         &.m-is-not-realized {
-            border-left-color: $color-function-invalid;
+            border-left-color: $color-function-negative;
         }
 
         &.m-on-test {

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/components/_badges_theme.scss
@@ -10,11 +10,9 @@ Badge modifiers for labeling if a proposal has been realized or not.
 ```html_example
 <span class="badge m-is-realized">Is Realized</span>
 <span class="badge m-is-not-realized">Is Not Realized</span>
+<span class="badge m-on-test">On Test</span>
 <span class="badge m-info">Information</span>
-<span class="badge m-color m-is-realized">Is Realized</span>
-<span class="badge m-color m-is-not-realized">Is Not Relaized</span>
-<span class="badge m-color m-on-test">On Test</span>
-<div class="badge-description m-color m-is-realized">
+<div class="badge-description m-is-realized">
     <p>Modified badge description</p>
 </div>
 ```
@@ -23,7 +21,6 @@ Badge modifiers for labeling if a proposal has been realized or not.
 
 .badge {
     &.m-info,
-    &.m-color,
     &.m-is-realized,
     &.m-is-not-realized {
         color: $color-text-inverted;
@@ -55,28 +52,21 @@ Badge modifiers for labeling if a proposal has been realized or not.
             vertical-align: baseline;
         }
     }
-
-    &.m-color {
-        @include rem(border-width, 0 0 0 $badge-height);
-        position: relative;
-    }
 }
 
 .badge-description {
-    &.m-color {
-        @include rem(border-left, 0.4rem solid $color-text-highlight-normal);
-        @include rem(padding-left, 0.5rem);
+    @include rem(border-left, 0.4rem solid $color-text-highlight-normal);
+    @include rem(padding-left, 0.5rem);
 
-        &.m-is-realized {
-            border-left-color: $color-function-positive;
-        }
+    &.m-is-realized {
+        border-left-color: $color-function-positive;
+    }
 
-        &.m-is-not-realized {
-            border-left-color: $color-function-negative;
-        }
+    &.m-is-not-realized {
+        border-left-color: $color-function-negative;
+    }
 
-        &.m-on-test {
-            border-left-color: $color-function-neutral;
-        }
+    &.m-on-test {
+        border-left-color: $color-function-neutral;
     }
 }

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
@@ -15,10 +15,6 @@ $color-text-highlight-introvert: $color-brand-two-introvert;
 $color-text-highlight-extrovert: #333;
 $color-text-inverted: white;
 
-// function colors
-$color-function-valid: #139156;
-$color-function-invalid: #f00;
-
 // background colors
 $color-background-base: white;
 $color-background-base-introvert: #f6f6f6;

--- a/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/meinberlin/meinberlin/static/stylesheets/scss/general/_variables_theme.scss
@@ -7,7 +7,6 @@ $color-brand-two-introvert: #ae0048;
 $color-brand-two-extrovert: #ed0062;
 
 // text colors
-$color-text-normal: #4c4c4c;
 $color-text-introvert: #666;
 $color-text-extrovert: #1c1c1b;
 $color-text-highlight-normal: $color-brand-two-normal;

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -1,11 +1,11 @@
-//brand colors
+// Brand colors
 $color-brand-one-normal: #fcb813;
 $color-brand-one-extrovert: #fcd370;
 $color-brand-two-normal: #00aae5;
 $color-brand-two-introvert: #0097d5;
 $color-brand-two-extrovert: #89c5ec;
 
-// text colors
+// Text colors
 $color-text-normal: #333;
 $color-text-introvert: #808080;
 $color-text-extrovert: #1c1c1b;
@@ -14,19 +14,19 @@ $color-text-highlight-introvert: #808080;
 $color-text-highlight-extrovert: #333;
 $color-text-inverted: white;
 
-// background colors
+// Background colors
 $color-background-base: white;
 $color-background-base-introvert: #f2f2f2;
 
-// structure colors
+// Structure colors
 $color-structure-normal: #e6e6e6;
 $color-structure-introvert: #ccc;
 
-//font sizes
+// Font sizes
 $font-size-plus: 16px;
 $font-size-large: 18px;
 $font-size-huge: 48px;
 
-//images
+// Images
 $thumbnail-width: 105px;
 $thumbnail-height: 90px;

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -6,7 +6,6 @@ $color-brand-two-introvert: #0097d5;
 $color-brand-two-extrovert: #89c5ec;
 
 // Text colors
-$color-text-normal: #333;
 $color-text-introvert: #808080;
 $color-text-extrovert: #1c1c1b;
 $color-text-highlight-normal: $color-brand-two-normal;

--- a/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/mercator/mercator/static/stylesheets/scss/general/_variables_theme.scss
@@ -14,10 +14,6 @@ $color-text-highlight-introvert: #808080;
 $color-text-highlight-extrovert: #333;
 $color-text-inverted: white;
 
-// function colors
-$color-function-valid: #73bf44;
-$color-function-invalid: #f00;
-
 // background colors
 $color-background-base: white;
 $color-background-base-introvert: #f2f2f2;

--- a/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
@@ -21,6 +21,3 @@ $color-text-normal: #4d4d4d;
 $color-text-extrovert: #1c1c1b;
 $color-text-highlight-normal: $color-brand-one-normal;
 
-// Function colors
-$color-function-valid: #73bf44;
-$color-function-invalid: #f00;

--- a/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/pcompass/pcompass/static/stylesheets/scss/general/_variables_theme.scss
@@ -20,4 +20,3 @@ $color-brand-two-extrovert: $color-brand-one-extrovert;
 $color-text-normal: #4d4d4d;
 $color-text-extrovert: #1c1c1b;
 $color-text-highlight-normal: $color-brand-one-normal;
-

--- a/src/s1/s1/static/stylesheets/scss/components/_rate_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_rate_theme.scss
@@ -1,6 +1,6 @@
 .rate {
     .rate-pro {
-        color: $color-function-valid;
+        color: $color-function-positive;
 
         &:hover, &:focus, &:active,
         &.is-rate-button-active {
@@ -15,7 +15,7 @@
             }
 
             &:active {
-                color: $color-function-valid;
+                color: $color-function-positive;
 
                 .s1-rate-icon:before {
                     @extend .icon-vote;

--- a/src/s1/s1/static/stylesheets/scss/components/_rate_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_rate_theme.scss
@@ -11,7 +11,7 @@
 
         &.is-rate-button-active {
             &:hover {
-                color: $color-function-invalid;
+                color: $color-function-negative;
             }
 
             &:active {

--- a/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
@@ -14,8 +14,6 @@ $color-text-highlight-introvert: $color-brand-two-introvert;
 $color-text-highlight-extrovert: $color-brand-two-extrovert;
 
 // Function colors
-$color-function-valid: #73bf44;
-$color-function-invalid: #f00;
 $color-function-winner: #f79321;
 
 $font-family-normal: "Roboto", sans-serif;

--- a/src/spd/spd/static/stylesheets/scss/components/_forms_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_forms_theme.scss
@@ -23,9 +23,6 @@ textarea {
 
     &.ng-dirty.ng-invalid {
         @extend %error-spacing;
-        border-color: $color-function-invalid;
-        color: $color-function-invalid;
-        outline: 1px solid $color-function-invalid;
     }
 }
 

--- a/src/spd/spd/static/stylesheets/scss/components/_forms_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/components/_forms_theme.scss
@@ -26,25 +26,6 @@ textarea {
     }
 }
 
-.ng-submitted {
-    input[type="text"],
-    input[type="url"],
-    input[type="password"],
-    input[type="email"],
-    input[type="date"],
-    input[type="time"],
-    input[type="number"],
-    input,
-    label,
-    div,
-    select,
-    textarea {
-        &.ng-invalid {
-            @extend %error-spacing;
-        }
-    }
-}
-
 .input-error {
     line-height: $error-line-height;
 }

--- a/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
@@ -14,10 +14,10 @@ $font-family-normal: "Open Sans", sans-serif;
 $font-size-large: 18px;
 $font-size-huge: 20px;
 
-//images
+// Images
 $thumbnail-width: 105px;
 $thumbnail-height: 90px;
 
-//Buttons
+// Buttons
 $color-button-cta-base: $color-brand-two-normal;
 $color-button-cta-hover-background: $color-brand-two-introvert;

--- a/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
@@ -2,10 +2,6 @@
 $color-text-normal: #333;
 $color-text-highlight-normal: #00b4cc;
 
-// Function colors
-$color-function-valid: #73bf44;
-$color-function-invalid: #f00;
-
 // Brand colors
 $color-brand-one-normal: #00b4cc;
 $color-brand-one-introvert: darken($color-brand-one-normal, 10%);

--- a/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/spd/spd/static/stylesheets/scss/general/_variables_theme.scss
@@ -1,5 +1,4 @@
 // Text colors
-$color-text-normal: #333;
 $color-text-highlight-normal: #00b4cc;
 
 // Brand colors


### PR DESCRIPTION
supersedes #2443.

Our meinberlin POs alerted us to the fact that the colors of badges and overlays are not easily readible. That's why we're changing it for adhocracy3. 

Then Nico Di Marco asked for some further style changes - see https://tree.taiga.io/project/ggr-meinberlinteam/us/287?milestone=80996. Then we also decided to replace the colors 'warning', 'valid' and 'invalid' with 'neutral', 'positive' and 'negative', so as not to have too many, and similar colors.