### PR TITLE
use resource actions + modals in comments

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -235,20 +235,6 @@ export var commentDetailDirective = (
             });
         };
 
-        scope.hide = () : angular.IPromise<void> => {
-            return $translate("TR__ASK_TO_CONFIRM_HIDE_ACTION").then((question) => {
-                if ($window.confirm(question)) {
-                    return adhHttp.hide(scope.data.itemPath).then(() => {
-                        if (scope.onSubmit) {
-                            scope.onSubmit();
-                        }
-                    });
-                } else {
-                    return $q.when();
-                }
-            });
-        };
-
         scope.column = column;
         scope.contentType = RIComment.content_type;
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -24,6 +24,8 @@ var pkgLocation = "/Comment";
 
 export interface ICommentResourceScope extends angular.IScope {
     path : string;
+    column? : AdhMovingColumns.MovingColumnController;
+    contentType : string;
     submit : () => any;
     hide : () => angular.IPromise<void>;
     refersTo : string;
@@ -182,12 +184,6 @@ export var commentDetailDirective = (
     var _postEdit = postEdit(adhHttp, adhPreliminaryNames);
 
     var link = (scope : ICommentResourceScope, element, attrs, column? : AdhMovingColumns.MovingColumnController) => {
-        if (column) {
-            scope.report = () => {
-                column.$scope.shared.abuseUrl = scope.data.path;
-                column.toggleOverlay("abuse");
-            };
-        }
 
         scope.$on("$destroy", adhTopLevelState.on("commentUrl", (commentVersionUrl) => {
             if (!commentVersionUrl) {
@@ -252,6 +248,9 @@ export var commentDetailDirective = (
                 }
             });
         };
+
+        scope.column = column;
+        scope.contentType = RIComment.content_type;
 
         adhPermissions.bindScope(scope, () => scope.data && scope.data.replyPoolPath, "poolOptions");
         adhPermissions.bindScope(scope, () => scope.data && scope.data.itemPath, "commentItemOptions");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -235,7 +235,6 @@ export var commentDetailDirective = (
             });
         };
 
-        scope.column = column;
         scope.contentType = RIComment.content_type;
 
         adhPermissions.bindScope(scope, () => scope.data && scope.data.replyPoolPath, "poolOptions");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -30,13 +30,14 @@
                         <i class="comment-header-icon icon-pencil"></i>
 
                     </a>
-                    <a href=""
-                        data-ng-click="hide()"
-                        data-ng-if="versionOptions.hide"
-                        class="comment-header-link"
-                        title="{{ 'TR__HIDE' | translate }}">
-                        <i class="comment-header-icon icon-x"></i>
-                    </a>
+                    <adh-hide-action
+                        data-ng-if="poolOptions.hide"
+                        data-modals="column"
+                        data-class="comment-header-link"
+                        data-parent-path="true"
+                        data-resource-path="{{data.path}}"
+                        data-content-type="{{contentType}}"
+                        ></adh-hide-action>
                     <adh-report-action
                         data-modals="column"
                         data-class="comment-header-link"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -29,21 +29,12 @@
                         title="{{ 'TR__EDIT' | translate }}">
                         <i class="comment-header-icon icon-pencil"></i>
                     </a>
-                    <adh-hide-action
-                        data-ng-if="poolOptions.hide"
-                        data-modals="column"
-                        data-class="comment-header-link"
-                        data-parent-path="true"
-                        data-resource-path="{{data.path}}"
+                    <adh-resource-actions
+                        data-resource-path="{{path}}"
                         data-content-type="{{contentType}}"
-                        ></adh-hide-action>
-                    <adh-report-action
-                        data-modals="column"
-                        data-class="comment-header-link"
                         data-parent-path="true"
-                        data-resource-path="{{data.path}}"
-                        data-content-type="{{contentType}}"
-                        ></adh-report-action>
+                        data-report="true"
+                        data-hide="true"></adh-resource-actions>
                 </span>
                 <adh-recompile-on-change data-value="{{data.path}}">
                     <adh-rate data-refers-to="{{data.path}}"></adh-rate>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -28,7 +28,6 @@
                         class="comment-header-link"
                         title="{{ 'TR__EDIT' | translate }}">
                         <i class="comment-header-icon icon-pencil"></i>
-
                     </a>
                     <adh-hide-action
                         data-ng-if="poolOptions.hide"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -37,13 +37,13 @@
                         title="{{ 'TR__HIDE' | translate }}">
                         <i class="comment-header-icon icon-x"></i>
                     </a>
-                    <a href=""
-                        data-ng-click="report()"
-                        data-ng-if="report"
-                        class="comment-header-link comment-header-link-report"
-                        title="{{ 'TR__REPORT' | translate }}">
-                        <i class="comment-header-icon icon-flag"></i>
-                    </a>
+                    <adh-report-action
+                        data-modals="column"
+                        data-class="comment-header-link"
+                        data-parent-path="true"
+                        data-resource-path="{{data.path}}"
+                        data-content-type="{{contentType}}"
+                        ></adh-report-action>
                 </span>
                 <adh-recompile-on-change data-value="{{data.path}}">
                     <adh-rate data-refers-to="{{data.path}}"></adh-rate>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -12,6 +12,7 @@
     <adh-report-action
         data-ng-if="report"
         data-modals="modals"
+        data-content-type="{{contentType}}"
         data-class="action-bar-item"></adh-report-action>
     <adh-share-action
         data-ng-if="share"
@@ -21,6 +22,7 @@
         data-ng-if="hide && resourcePath && options.hide"
         data-class="action-bar-item"
         data-parent-path="parentPath"
+        data-content-type="{{contentType}}"
         data-redirect-url="{{deleteRedirectUrl}}"
         data-resource-path="{{resourcePath}}"></adh-hide-action>
     <adh-resource-widget-delete-action

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -127,14 +127,18 @@ export var hideActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"hide();\">{{ 'TR__HIDE' | translate }}</a>",
+        template: "<a data-ng-if=\"!commentTemplate\" class=\"{{class}}\" href=\"\" data-ng-click=\"hide();\">" +
+            "{{ 'TR__HIDE' | translate }}</a><a data-ng-if=\"commentTemplate\" class=\"{{class}}\" href=\"\"" +
+            "data-ng-click=\"hide();\"><i class=\"comment-header-icon icon-x\"></i></a>",
         scope: {
             resourcePath: "@",
             parentPath: "=?",
             class: "@",
+            contentType: "@?",
             redirectUrl: "@?",
         },
         link: (scope, element) => {
+            scope.commentTemplate = scope.contentType === RIComment.content_type;
             scope.hide = () => {
                 return $translate("TR__ASK_TO_CONFIRM_HIDE_ACTION").then((question) => {
                     var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -5,6 +5,8 @@ import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhUtil from "../Util/Util";
 
+import RIComment from "../../Resources_/adhocracy_core/resources/comment/IComment";
+
 var pkgLocation = "/ResourceActions";
 
 
@@ -83,12 +85,16 @@ export var resourceActionsDirective = (
 export var reportActionDirective = () => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"report();\">{{ 'TR__REPORT' | translate }}</a>",
+        template: "<a data-ng-if=\"!commentTemplate\" class=\"{{class}}\" href=\"\" data-ng-click=\"report();\">" +
+            "{{ 'TR__REPORT' | translate }}</a><a data-ng-if=\"commentTemplate\" class=\"{{class}}\" href=\"\"" +
+            "data-ng-click=\"report();\"><i class=\"comment-header-icon icon-flag\"></i></a>",
         scope: {
             class: "@",
+            contentType: "@?",
             modals: "=",
         },
         link: (scope) => {
+            scope.commentTemplate = scope.contentType === RIComment.content_type;
             scope.report = () => {
                 scope.modals.toggleOverlay("abuse");
             };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -105,13 +105,13 @@ export var reportActionDirective = () => {
 export var shareActionDirective = () => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"report();\">{{ 'TR__SHARE' | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"share();\">{{ 'TR__SHARE' | translate }}</a>",
         scope: {
             class: "@",
             modals: "=",
         },
         link: (scope) => {
-            scope.report = () => {
+            scope.share = () => {
                 scope.modals.toggleOverlay("share");
             };
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -64,6 +64,7 @@ export var resourceActionsDirective = (
             resourcePath: "@",
             parentPath: "=?",
             deleteRedirectUrl: "@?",
+            contentType: "@?",
             share: "=?",
             hide: "=?",
             resourceWidgetDelete: "=?",
@@ -86,7 +87,7 @@ export var reportActionDirective = () => {
     return {
         restrict: "E",
         template: "<a data-ng-if=\"!commentTemplate\" class=\"{{class}}\" href=\"\" data-ng-click=\"report();\">" +
-            "{{ 'TR__REPORT' | translate }}</a><a data-ng-if=\"commentTemplate\" class=\"{{class}}\" href=\"\"" +
+            "{{ 'TR__REPORT' | translate }}</a><a data-ng-if=\"commentTemplate\" class=\"comment-header-link\" href=\"\"" +
             "data-ng-click=\"report();\"><i class=\"comment-header-icon icon-flag\"></i></a>",
         scope: {
             class: "@",
@@ -128,7 +129,7 @@ export var hideActionDirective = (
     return {
         restrict: "E",
         template: "<a data-ng-if=\"!commentTemplate\" class=\"{{class}}\" href=\"\" data-ng-click=\"hide();\">" +
-            "{{ 'TR__HIDE' | translate }}</a><a data-ng-if=\"commentTemplate\" class=\"{{class}}\" href=\"\"" +
+            "{{ 'TR__HIDE' | translate }}</a><a data-ng-if=\"commentTemplate\" class=\"comment-header-link\" href=\"\"" +
             "data-ng-click=\"hide();\"><i class=\"comment-header-icon icon-x\"></i></a>",
         scope: {
             resourcePath: "@",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
@@ -24,6 +24,11 @@
     }
 }
 
+.comment-header-links .action-bar {
+    display: inherit;
+    background: $color-background-base;
+}
+
 .action-bar {
     @include rem(font-size, $font-size-small);
     @include inline-block;


### PR DESCRIPTION
Needs #2451.

The create and edit functions on comment were too specific as to quickly make them into `resourceActions`. So this PR just converts report and hide - these are the ones currently using modals, anyways - we want to use the new moodal functionality (see #2451) and display it where the comment is. Unfortunately, right now the "overlay"/modal appears above the rate buttons, even though these buttons were originally right next to the hide and delete buttons. This should be changed.

I'm sure the design needs polishing - e.g. in the report-abuse helptext, there's unnecessary whitespace in front of the two links. Plus we should consider using something like `AdhMovingColumnsController.bindVariablesAndClear` so that the modal disappears when you click outside of it (or so).