### PR TITLE
pop-ins for comments

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -185,8 +185,9 @@ export var commentDetailDirective = (
     var _postEdit = postEdit(adhHttp, adhPreliminaryNames);
 
     var link = (scope : ICommentResourceScope, element) => {
+        scope.modals = new AdhResourceActions.Modals($timeout);
+
         scope.report = () => {
-            scope.modals = new AdhResourceActions.Modals($timeout);
             scope.modals.toggleOverlay("abuse");
         };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -6,6 +6,7 @@ import * as AdhHttp from "../Http/Http";
 import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
+import * as AdhResourceActions from "../ResourceActions/ResourceActions";
 import * as AdhResourceUtil from "../Util/ResourceUtil";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhUtil from "../Util/Util";
@@ -42,6 +43,7 @@ export interface ICommentResourceScope extends angular.IScope {
     afterCreateComment() : angular.IPromise<void>;
     item : any;
     report? : () => void;
+    modals : AdhResourceActions.Modals;
     // update resource
     update() : angular.IPromise<void>;
     // update outer listing
@@ -176,18 +178,17 @@ export var commentDetailDirective = (
     adhRecursionHelper,
     $window : Window,
     $q : angular.IQService,
+    $timeout,
     $translate
 ) => {
     var _update = update(adhHttp, $q);
     var _postEdit = postEdit(adhHttp, adhPreliminaryNames);
 
-    var link = (scope : ICommentResourceScope, element, attrs, column? : AdhMovingColumns.MovingColumnController) => {
-        if (column) {
-            scope.report = () => {
-                column.$scope.shared.abuseUrl = scope.data.path;
-                column.toggleOverlay("abuse");
-            };
-        }
+    var link = (scope : ICommentResourceScope, element) => {
+        scope.report = () => {
+            scope.modals = new AdhResourceActions.Modals($timeout);
+            scope.modals.toggleOverlay("abuse");
+        };
 
         scope.$on("$destroy", adhTopLevelState.on("commentUrl", (commentVersionUrl) => {
             if (!commentVersionUrl) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -28,7 +28,6 @@
                         class="comment-header-link"
                         title="{{ 'TR__EDIT' | translate }}">
                         <i class="comment-header-icon icon-pencil"></i>
-
                     </a>
                     <a href=""
                         data-ng-click="hide()"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -51,6 +51,21 @@
             </div>
         </div>
 
+        <ul class="moving-column-alerts">
+            <li data-ng-repeat="(id, alert) in modals.alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
+                {{ alert.message | translate }}
+            </li>
+        </ul>
+
+        <div class="action-bar-modal" data-ng-if="modals.overlay">
+            <adh-report-abuse
+                data-ng-if="modals.overlay === 'abuse'"
+                data-modals="modals"
+                class="report-abuse"
+                data-url="{{data.path}}">
+            </adh-report-abuse>
+        </div>
+
         <form class="comment-children-edit-form" data-ng-switch-when="1" data-ng-submit="submit()">
             <div class="form-error" data-ng-repeat="error in errors">
                 <p>{{ error | translate }}</p>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
@@ -58,6 +58,7 @@ export var register = (angular) => {
             "adhRecursionHelper",
             "$window",
             "$q",
+            "$timeout",
             "$translate",
             AdhComment.commentDetailDirective])
         .directive("adhCommentCreate", ["adhConfig", "adhHttp", "adhPreliminaryNames", AdhComment.commentCreateDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -8,7 +8,7 @@ import * as AdhUtil from "../Util/Util";
 var pkgLocation = "/ResourceActions";
 
 
-class Modals {
+export class Modals {
     public overlay : string;
     public alerts : {[id : number]: {message : string, mode : string}};
     private lastId : number;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -99,13 +99,13 @@ export var reportActionDirective = () => {
 export var shareActionDirective = () => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"report();\">{{ 'TR__SHARE' | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"share();\">{{ 'TR__SHARE' | translate }}</a>",
         scope: {
             class: "@",
             modals: "=",
         },
         link: (scope) => {
-            scope.report = () => {
+            scope.share = () => {
                 scope.modals.toggleOverlay("share");
             };
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -150,7 +150,6 @@ The menu should always have the same state as its columns.
 
 .moving-column-body,
 .moving-column-overlay,
-.moving-column-alerts,
 .moving-column-mask {
     position: absolute;
     top: $moving-column-menu-height;


### PR DESCRIPTION
Needs #2451. Replaces #2452. (I seriously considered implementing `adhResourceActions` in Comment. But a) the create and edit functions on comment were too specific as to quickly make them into `resourceActions`, and b) on triggering a pop-in, the rate interface was displayed below it.)

There was a design decision with Nico Di Marco last week: we will henceforth display overlays and alerts wherever they have been triggered - as pop-ins.

The reason is this: Up to now, when you saw an embedded adhocracy with a long list of comments and clicked on 'report' concerning the very last comment, an overlay was triggered at the very top of the iframe. But this might be momentarily invisible, the user would have to scroll to the top in order to either report an abuse or close the overlay and then scroll back down to the comment.

Todo (maybe outside of this PR):
- [ ] Design refinements are probably necessary.
- [ ] We need to decide whether a 'user action' outside of the pop-in should cause it to disappear.