### PR TITLE
cleanup #2451

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -49,11 +49,11 @@
         data-ng-if="modals.overlay === 'abuse'"
         data-modals="modals"
         class="report-abuse"
-        data-url="{{ proposalUrl | adhResourceUrl | adhCanonicalUrl }}">
+        data-url="{{ resourcePath | adhResourceUrl | adhCanonicalUrl }}">
     </adh-report-abuse>
 
     <div data-ng-if="modals.overlay === 'share'">
-        <adh-social-share data-uri="{{ proposalUrl | adhResourceUrl | adhCanonicalUrl }}"></adh-social-share>
+        <adh-social-share data-uri="{{ resourcePath | adhResourceUrl | adhCanonicalUrl }}"></adh-social-share>
         <a href="" class="button" data-ng-click="modals.hideOverlay('share')">{{ "TR__CANCEL" | translate }}</a>
     </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -76,6 +76,10 @@ export var resourceActionsDirective = (
             var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
             scope.modals = new Modals($timeout);
             adhPermissions.bindScope(scope, path, "options");
+
+            scope.$watch("resourcePath", () => {
+                scope.modals.clear();
+            });
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -49,6 +49,11 @@ class Modals {
             this.overlay = undefined;
         }
     }
+
+    public clear() : void {
+        this.alerts = {};
+        this.overlay = undefined;
+    }
 }
 
 export var resourceActionsDirective = (

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
@@ -117,4 +117,5 @@ An action can trigger showing a modal below the action bar
 
 .action-bar-modal {
     border-bottom: 2px solid $color-structure-normal;
+    padding: 1em;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
@@ -1,3 +1,66 @@
+/*doc
+---
+title: Action Bar
+name: action-bar
+category: Widgets
+---
+
+A bar that can be used to trigger actions. Use this widget to provide a
+consistent interface for actions like edit, delete, report, print, and share.
+It is typically located at the top of a larger widget, e.g. proposal detail.
+
+Elements of the action bar are called action bar items (`action-bar-item`).
+They can have the `m-selected` modifier.
+
+An action can trigger showing a modal below the action bar
+(`action-bar-modal`).  Only one modal is visible at a time.
+
+```html_example
+<div class="action-bar">
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item m-selected">delete</a>
+    <a class="action-bar-item">report</a>
+</div>
+<div class="action-bar-modal">
+    <form>
+        <input type="text" />
+        <input type="submit" class="button-cta" />
+    </form>
+</div>
+```
+
+```html_example
+<div class="action-bar">
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item">delete</a>
+    <a class="action-bar-item">report</a>
+</div>
+<div class="action-bar">
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item">delete</a>
+    <a class="action-bar-item">report</a>
+</div>
+<div class="action-bar">
+</div>
+<div class="action-bar">
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item">delete</a>
+    <a class="action-bar-item">report</a>
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item">delete</a>
+    <a class="action-bar-item">report</a>
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item">delete</a>
+    <a class="action-bar-item">report</a>
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item">delete</a>
+    <a class="action-bar-item">report</a>
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item">delete</a>
+    <a class="action-bar-item">report</a>
+</div>
+```
+*/
 .action-bar,
 .action-bar-link {
     line-height: 2;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
@@ -5,9 +5,9 @@ name: action-bar
 category: Widgets
 ---
 
-A bar that can be used to trigger actions. Use this widget to provide a
-consistent interface for actions like edit, delete, report, print, and share.
-It is typically located at the top of a larger widget, e.g. proposal detail.
+A bar with items that trigger actions. Use this widget to provide a
+consistent interface for actions like edit, delete, report, print, and share. 
+It is typically located at the top of a larger widget, e.g. a proposal detail.
 
 Elements of the action bar are called action bar items (`action-bar-item`).
 They can have the `m-selected` modifier.

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -150,7 +150,6 @@ The menu should always have the same state as its columns.
 
 .moving-column-body,
 .moving-column-overlay,
-.moving-column-alerts,
 .moving-column-mask {
     position: absolute;
     top: $moving-column-menu-height;


### PR DESCRIPTION
These are some amendments to #2451. I am sorry for this arbitrary collection, it was just stuff that I stumbled upon while trying to figure out what I have to do next.

I am not absolutely sure about 3bc252f: It seems like a useful replacement for `adhMovingColumnController.bindVariablesAndClear()`, but it is less flexible (only clears on changes of `resourceUrl`). It is also not necessary for the cases that I saw because `<adh-resource-actions>` is used inside of an `<adh-recompile-on-change>`.