### PR TITLE
use modals for user messages

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -184,7 +184,7 @@ export var commentDetailDirective = (
     var _update = update(adhHttp, $q);
     var _postEdit = postEdit(adhHttp, adhPreliminaryNames);
 
-    var link = (scope : ICommentResourceScope, element) => {
+    var link = (scope : ICommentResourceScope) => {
         scope.modals = new AdhResourceActions.Modals($timeout);
 
         scope.report = () => {
@@ -265,7 +265,6 @@ export var commentDetailDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Detail.html",
-        require: "?^adhMovingColumn",
         scope: {
             path: "@",
             onSubmit: "=?"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -3,26 +3,34 @@
         <div class="moving-column-tab">
             <i class="icon-user-unfilled moving-column-icon"></i>
         </div>
-        <a
-            class="moving-column-menu-button"
-            href=""
-            data-ng-click="ctrl.toggleOverlay('messaging')"
-            data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
     </div>
 
     <adh-recompile-on-change
         data-ng-switch-when="body"
         data-value="{{userUrl}}">
+        <div class="action-bar">
+            <a
+                class="action-bar-item"
+                href=""
+                data-ng-click="modals.toggleOverlay('messaging')"
+                data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
+        </div>
+        <ul class="moving-column-alerts">
+            <li data-ng-repeat="(id, alert) in modals.alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
+                {{ alert.message | translate }}
+            </li>
+        </ul>
+        <div class="action-bar-modal" data-ng-if="modals.overlay">
+            <adh-user-message
+                data-ng-if="modals.overlay === 'messaging'"
+                data-modals="modals"
+                data-recipient-url="{{userUrl}}">
+            </adh-user-message>
+        </div>
+
         <adh-user-profile
-            data-modals="ctrl"
+            data-modals="modals"
             data-path="{{userUrl}}">
         </adh-user-profile>
     </adh-recompile-on-change>
-
-    <adh-user-message
-        data-ng-switch-when="overlays"
-        data-ng-if="overlay === 'messaging'"
-        data-modals="ctrl"
-        data-recipient-url="{{userUrl}}">
-    </adh-user-message>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -14,6 +14,7 @@
         data-ng-switch-when="body"
         data-value="{{userUrl}}">
         <adh-user-profile
+            data-modals="ctrl"
             data-path="{{userUrl}}">
         </adh-user-profile>
     </adh-recompile-on-change>
@@ -21,6 +22,7 @@
     <adh-user-message
         data-ng-switch-when="overlays"
         data-ng-if="overlay === 'messaging'"
+        data-modals="ctrl"
         data-recipient-url="{{userUrl}}">
     </adh-user-message>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -657,16 +657,16 @@ export var userProfileDirective = (
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/UserProfile.html",
         transclude: true,
-        require: "^adhMovingColumn",
         scope: {
-            path: "@"
+            path: "@",
+            modals: "="
         },
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             adhPermissions.bindScope(scope, adhConfig.rest_url + "/message_user", "messageOptions");
 
             scope.showMessaging = () => {
                 if (scope.messageOptions.POST) {
-                    column.showOverlay("messaging");
+                    scope.modals.showOverlay("messaging");
                 } else if (!adhCredentials.loggedIn) {
                     adhTopLevelState.setCameFromAndGo("/login");
                 } else {
@@ -693,10 +693,10 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/UserMessage.html",
         scope: {
-            recipientUrl: "@"
+            recipientUrl: "@",
+            modals: "="
         },
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column)  => {
+        link: (scope)  => {
             adhHttp.get(scope.recipientUrl).then((recipient : RIUser) => {
                 scope.recipientName = recipient.data[SIUserBasic.nick].name;
             });
@@ -707,15 +707,15 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
                     title: scope.message.title,
                     text: scope.message.text
                 }).then(() => {
-                    column.hideOverlay();
-                    column.alert("TR__MESSAGE_STATUS_OK", "success");
+                    scope.modals.hideOverlay();
+                    scope.modals.alert("TR__MESSAGE_STATUS_OK", "success");
                 }, () => {
                     // FIXME
                 });
             };
 
             scope.cancel = () => {
-                column.hideOverlay();
+                scope.modals.hideOverlay();
             };
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -8,6 +8,7 @@ import * as AdhConfig from "../Config/Config";
 import * as AdhHttp from "../Http/Http";
 import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
+import * as AdhResourceActions from "../ResourceActions/ResourceActions";
 import * as AdhResourceArea from "../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhEmbed from "../Embed/Embed";
@@ -724,7 +725,8 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
 
 export var userDetailColumnDirective = (
     adhPermissions : AdhPermissions.Service,
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    $timeout : angular.ITimeoutService
 ) => {
     return {
         restrict: "E",
@@ -733,6 +735,7 @@ export var userDetailColumnDirective = (
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["userUrl"]);
             adhPermissions.bindScope(scope, adhConfig.rest_url + "/message_user", "messageOptions");
+            scope.modals = new AdhResourceActions.Modals($timeout);
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -135,7 +135,7 @@ export var register = (angular) => {
             "adhConfig", "adhResourceArea", "adhTopLevelState", "adhPermissions", "$location", AdhUserViews.indicatorDirective])
         .directive("adhUserMeta", ["adhConfig", "adhResourceArea", "adhGetBadges", AdhUserViews.metaDirective])
         .directive("adhUserMessage", ["adhConfig", "adhHttp", AdhUserViews.userMessageDirective])
-        .directive("adhUserDetailColumn", ["adhPermissions", "adhConfig", AdhUserViews.userDetailColumnDirective])
+        .directive("adhUserDetailColumn", ["adhPermissions", "adhConfig", "$timeout", AdhUserViews.userDetailColumnDirective])
         .directive("adhUserProfileImage", ["adhHttp", "adhConfig", AdhUserViews.adhUserProfileImageDirective])
         .directive("adhUserProfileImageEdit", ["adhHttp", "adhPermissions", "adhConfig", AdhUserViews.adhUserProfileImageEditDirective])
         .directive("adhUserActivityOverview", ["adhConfig", "adhHttp", AdhUserViews.adhUserActivityOverviewDirective])

--- a/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
+++ b/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
@@ -14,6 +14,7 @@
         data-ng-switch-when="body"
         data-value="{{userUrl}}">
         <adh-user-profile
+            data-modals="ctrl"
             data-path="{{userUrl}}">
 
             <adh-user-activity-overview
@@ -34,6 +35,7 @@
     <adh-user-message
         data-ng-switch-when="overlays"
         data-ng-if="overlay === 'messaging'"
+        data-modals="ctrl"
         data-recipient-url="{{userUrl}}">
     </adh-user-message>
 </div>

--- a/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
+++ b/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
@@ -3,18 +3,33 @@
         <div class="moving-column-tab">
             <i class="icon-user-unfilled moving-column-icon"></i>
         </div>
-        <a
-            class="moving-column-menu-button"
-            href=""
-            data-ng-click="ctrl.toggleOverlay('messaging')"
-            data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
     </div>
 
     <adh-recompile-on-change
         data-ng-switch-when="body"
         data-value="{{userUrl}}">
+        <div class="action-bar">
+            <a
+                class="action-bar-item"
+                href=""
+                data-ng-click="modals.toggleOverlay('messaging')"
+                data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
+        </div>
+        <ul class="moving-column-alerts">
+            <li data-ng-repeat="(id, alert) in modals.alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
+                {{ alert.message | translate }}
+            </li>
+        </ul>
+        <div class="action-bar-modal" data-ng-if="modals.overlay">
+            <adh-user-message
+                data-ng-if="modals.overlay === 'messaging'"
+                data-modals="modals"
+                data-recipient-url="{{userUrl}}">
+            </adh-user-message>
+        </div>
+
         <adh-user-profile
-            data-modals="ctrl"
+            data-modals="modals"
             data-path="{{userUrl}}">
 
             <adh-user-activity-overview
@@ -31,11 +46,4 @@
             </section>
         </adh-user-profile>
     </adh-recompile-on-change>
-
-    <adh-user-message
-        data-ng-switch-when="overlays"
-        data-ng-if="overlay === 'messaging'"
-        data-modals="ctrl"
-        data-recipient-url="{{userUrl}}">
-    </adh-user-message>
 </div>


### PR DESCRIPTION
Made possible by #2451. Part of decoupling functions from MovingColumns.

Note that using resource actions was not easily possible here because the modal can also be triggered from `<adh-user-profile>`.