### PR TITLE
implement adhAssignBadgesAction in meinberlin IdeaCollection

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -9,7 +9,6 @@ import * as AdhHttp from "../Http/Http";
 import * as AdhListing from "../Listing/Listing";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
-import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhUtil from "../Util/Util";
 
 import RIBadgeAssignment from "../../Resources_/adhocracy_core/resources/badge/IBadgeAssignment";
@@ -221,12 +220,12 @@ export var badgeAssignment = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Assignment.html",
-        require: "^adhMovingColumn",
         scope: {
+            modals: "=",
             path: "@",
             showDescription: "=?"
         },
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope, element) => {
             scope.badgeablePath = scope.path;
             scope.data = {};
 
@@ -266,8 +265,8 @@ export var badgeAssignment = (
 
                             return transaction.commit()
                                 .then((responses) => {
-                                    column.hideOverlay("badges");
-                                    column.alert("TR__BADGE_ASSIGNMENT_UPDATED", "success");
+                                    scope.modals.hideOverlay("badges");
+                                    scope.modals.alert("TR__BADGE_ASSIGNMENT_UPDATED", "success");
                                 }, (response) => {
                                     scope.serverError = response[0].description;
                                 });
@@ -275,7 +274,7 @@ export var badgeAssignment = (
                     };
 
                     scope.cancel = () => {
-                        column.hideOverlay("badges");
+                        scope.modals.hideOverlay("badges");
                     };
                 });
             });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -225,7 +225,7 @@ export var badgeAssignment = (
             path: "@",
             showDescription: "=?"
         },
-        link: (scope, element) => {
+        link: (scope) => {
             scope.badgeablePath = scope.path;
             scope.data = {};
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
@@ -13,7 +13,8 @@ export var register = (angular) => {
             AdhResourceAreaModule.moduleName,
             AdhMovingColumnsModule.moduleName
         ])
-        .directive("adhResourceActions", ["$timeout", "adhPermissions", "adhConfig", AdhResourceActions.resourceActionsDirective])
+        .directive("adhResourceActions", [
+            "$timeout", "adhHttp", "adhPermissions", "adhConfig", AdhResourceActions.resourceActionsDirective])
         .directive("adhReportAction", [AdhResourceActions.reportActionDirective])
         .directive("adhShareAction", [AdhResourceActions.shareActionDirective])
         .directive("adhHideAction", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
@@ -18,6 +18,7 @@ export var register = (angular) => {
         .directive("adhShareAction", [AdhResourceActions.shareActionDirective])
         .directive("adhHideAction", [
             "adhHttp", "adhTopLevelState", "adhResourceUrlFilter", "$translate", "$window", AdhResourceActions.hideActionDirective])
+        .directive("adhAssignBadgesAction", [AdhResourceActions.assignBadgesActionDirective])
         .directive("adhResourceWidgetDeleteAction", [AdhResourceActions.resourceWidgetDeleteActionDirective])
         .directive("adhEditAction", ["adhTopLevelState", "adhResourceUrlFilter", "$location", AdhResourceActions.editActionDirective])
         .directive("adhModerateAction", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -59,6 +59,7 @@
     </adh-report-abuse>
     <adh-badge-assignment
         data-ng-if="modals.overlay === 'badges'"
+        data-modals="modals"
         data-path="{{resourcePath}}">
     </adh-badge-assignment>
     <div data-ng-if="modals.overlay === 'share'">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -57,11 +57,13 @@
         class="report-abuse"
         data-url="{{ proposalUrl | adhResourceUrl | adhCanonicalUrl }}">
     </adh-report-abuse>
+
     <adh-badge-assignment
         data-ng-if="modals.overlay === 'badges'"
         data-modals="modals"
         data-path="{{resourcePath}}">
     </adh-badge-assignment>
+
     <div data-ng-if="modals.overlay === 'share'">
         <adh-social-share data-uri="{{ proposalUrl | adhResourceUrl | adhCanonicalUrl }}"></adh-social-share>
         <a href="" class="button" data-ng-click="modals.hideOverlay('share')">{{ "TR__CANCEL" | translate }}</a>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -10,7 +10,7 @@
         data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-moderate-action>
     <adh-assign-badges-action
-        data-ng-if="assignBadges && resourcePath && badgeAssignmentPoolOptions.PUT"
+        data-ng-if="assignBadges && resourcePath && badgesExist && badgeAssignmentPoolOptions.PUT"
         data-modals="modals"
         data-class="action-bar-item"
         data-parent-path="parentPath"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -9,6 +9,11 @@
         data-class="action-bar-item"
         data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-moderate-action>
+    <adh-assign-badges-action
+        data-ng-if="assignBadges && resourcePath && badgeAssignmentPoolOptions.PUT"
+        data-class="action-bar-item"
+        data-parent-path="parentPath"
+        data-resource-path="{{resourcePath}}"></adh-assign-badges-action>
     <adh-report-action
         data-ng-if="report"
         data-modals="modals"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -11,6 +11,7 @@
         data-resource-path="{{resourcePath}}"></adh-moderate-action>
     <adh-assign-badges-action
         data-ng-if="assignBadges && resourcePath && badgeAssignmentPoolOptions.PUT"
+        data-modals="modals"
         data-class="action-bar-item"
         data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-assign-badges-action>
@@ -56,7 +57,10 @@
         class="report-abuse"
         data-url="{{ proposalUrl | adhResourceUrl | adhCanonicalUrl }}">
     </adh-report-abuse>
-
+    <adh-badge-assignment
+        data-ng-if="modals.overlay === 'badges'"
+        data-path="{{resourcePath}}">
+    </adh-badge-assignment>
     <div data-ng-if="modals.overlay === 'share'">
         <adh-social-share data-uri="{{ proposalUrl | adhResourceUrl | adhCanonicalUrl }}"></adh-social-share>
         <a href="" class="button" data-ng-click="modals.hideOverlay('share')">{{ "TR__CANCEL" | translate }}</a>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -5,6 +5,7 @@ import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhUtil from "../Util/Util";
 
+import * as SIBadgeable from "../../Resources_/adhocracy_core/sheets/badge/IBadgeable";
 var pkgLocation = "/ResourceActions";
 
 
@@ -53,6 +54,7 @@ class Modals {
 
 export var resourceActionsDirective = (
     $timeout : angular.ITimeoutService,
+    adhHttp : AdhHttp.Service<any>,
     adhPermissions : AdhPermissions.Service,
     adhConfig: AdhConfig.IService
 ) => {
@@ -62,6 +64,7 @@ export var resourceActionsDirective = (
             resourcePath: "@",
             parentPath: "=?",
             deleteRedirectUrl: "@?",
+            assignBadges: "=?",
             share: "=?",
             hide: "=?",
             resourceWidgetDelete: "=?",
@@ -70,12 +73,23 @@ export var resourceActionsDirective = (
             cancel: "=?",
             edit: "=?",
             moderate: "=?",
+            modals: "=?"
         },
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ResourceActions.html",
         link: (scope, element) => {
             var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
             scope.modals = new Modals($timeout);
             adhPermissions.bindScope(scope, path, "options");
+
+            var badgeAssignmentPoolPath;
+            scope.$watch("resourcePath", (resourcePath) => {
+                if (resourcePath) {
+                    adhHttp.get(resourcePath).then((badgeable) => {
+                        badgeAssignmentPoolPath = badgeable.data[SIBadgeable.nick].post_pool;
+                    });
+                }
+            });
+            adhPermissions.bindScope(scope, () => badgeAssignmentPoolPath, "badgeAssignmentPoolOptions");
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -5,7 +5,10 @@ import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhUtil from "../Util/Util";
 
+import * as SIBadge from "../../Resources_/adhocracy_core/sheets/badge/IBadge";
 import * as SIBadgeable from "../../Resources_/adhocracy_core/sheets/badge/IBadgeable";
+import * as SIPool from "../../Resources_/adhocracy_core/sheets/pool/IPool";
+
 var pkgLocation = "/ResourceActions";
 
 
@@ -63,6 +66,7 @@ export var resourceActionsDirective = (
         scope: {
             resourcePath: "@",
             parentPath: "=?",
+            processUrl: "@?",
             deleteRedirectUrl: "@?",
             assignBadges: "=?",
             share: "=?",
@@ -90,6 +94,13 @@ export var resourceActionsDirective = (
                 }
             });
             adhPermissions.bindScope(scope, () => badgeAssignmentPoolPath, "badgeAssignmentPoolOptions");
+            var params = {
+                depth: 4,
+                content_type: SIBadge.nick
+            };
+            adhHttp.get(scope.processUrl, params).then((response) => {
+                scope.badgesExist = response.data[SIPool.nick].count > 0;
+            });
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -90,22 +90,24 @@ export var resourceActionsDirective = (
             scope.modals = new Modals($timeout);
             adhPermissions.bindScope(scope, path, "options");
 
-            var badgeAssignmentPoolPath;
-            scope.$watch("resourcePath", (resourcePath) => {
-                if (resourcePath) {
-                    adhHttp.get(resourcePath).then((badgeable) => {
-                        badgeAssignmentPoolPath = badgeable.data[SIBadgeable.nick].post_pool;
-                    });
-                }
-            });
-            adhPermissions.bindScope(scope, () => badgeAssignmentPoolPath, "badgeAssignmentPoolOptions");
-            var params = {
-                depth: 4,
-                content_type: SIBadge.nick
-            };
-            adhHttp.get(scope.resourceWithBadgesUrl, params).then((response) => {
-                scope.badgesExist = response.data[SIPool.nick].count > 0;
-            });
+            if (scope.assignBadges) {
+                var badgeAssignmentPoolPath;
+                scope.$watch("resourcePath", (resourcePath) => {
+                    if (resourcePath) {
+                        adhHttp.get(resourcePath).then((badgeable) => {
+                            badgeAssignmentPoolPath = badgeable.data[SIBadgeable.nick].post_pool;
+                        });
+                    }
+                });
+                adhPermissions.bindScope(scope, () => badgeAssignmentPoolPath, "badgeAssignmentPoolOptions");
+                var params = {
+                    depth: 4,
+                    content_type: SIBadge.nick
+                };
+                adhHttp.get(scope.resourceWithBadgesUrl, params).then((response) => {
+                    scope.badgesExist = response.data[SIPool.nick].count > 0;
+                });
+            }
 
             scope.$watch("resourcePath", () => {
                 scope.modals.clear();

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -71,7 +71,7 @@ export var resourceActionsDirective = (
         scope: {
             resourcePath: "@",
             parentPath: "=?",
-            processUrl: "@?",
+            resourceWithBadgesUrl: "@?",
             deleteRedirectUrl: "@?",
             assignBadges: "=?",
             share: "=?",
@@ -103,7 +103,7 @@ export var resourceActionsDirective = (
                 depth: 4,
                 content_type: SIBadge.nick
             };
-            adhHttp.get(scope.processUrl, params).then((response) => {
+            adhHttp.get(scope.resourceWithBadgesUrl, params).then((response) => {
                 scope.badgesExist = response.data[SIPool.nick].count > 0;
             });
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -112,6 +112,24 @@ export var shareActionDirective = () => {
     };
 };
 
+export var assignBadgesActionDirective = () => {
+    return {
+        restrict: "E",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"assignBadges();\">{{ 'TR__MANAGE_BADGE_ASSIGNMENTS' | translate }}</a>",
+        scope: {
+            resourcePath: "@",
+            parentPath: "=?",
+            class: "@",
+            modals: "=",
+        },
+        link: (scope) => {
+            scope.assignBadges = () => {
+                scope.modals.toggleOverlay("badges");
+            };
+        }
+    };
+};
+
 export var hideActionDirective = (
     adhHttp : AdhHttp.Service<any>,
     adhTopLevelState : AdhTopLevelState.Service,

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -34,6 +34,7 @@
     <adh-badge-assignment
         data-ng-switch-when="overlays"
         data-ng-if="overlay === 'badges'"
+        data-modals="column"
         data-path="{{proposalUrl}}">
     </adh-badge-assignment>
 </div>

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.ts
@@ -46,6 +46,7 @@ export var proposalDetailColumnDirective = (
             column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
+            scope.column = column;
             var badgeAssignmentPoolPath;
             scope.$watch("proposalUrl", (proposalUrl) => {
                 if (proposalUrl) {

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -20,7 +20,6 @@ import RIKiezkasseProcess from "../../../Resources_/adhocracy_meinberlin/resourc
 import RIKiezkasseProposal from "../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposal";
 import RIKiezkasseProposalVersion from "../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion";
 import * as SIBadge from "../../../Resources_/adhocracy_core/sheets/badge/IBadge";
-import * as SIBadgeable from "../../../Resources_/adhocracy_core/sheets/badge/IBadgeable";
 import * as SIComment from "../../../Resources_/adhocracy_core/sheets/comment/IComment";
 import * as SIPool from "../../../Resources_/adhocracy_core/sheets/pool/IPool";
 import * as SIWorkflow from "../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
@@ -109,16 +108,6 @@ export var proposalDetailColumnDirective = (
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
             scope.column = column;
-
-            var badgeAssignmentPoolPath;
-            scope.$watch("proposalUrl", (proposalUrl) => {
-                if (proposalUrl) {
-                    adhHttp.get(proposalUrl).then((proposal) => {
-                        badgeAssignmentPoolPath = proposal.data[SIBadgeable.nick].post_pool;
-                    });
-                }
-            });
-            adhPermissions.bindScope(scope, () => badgeAssignmentPoolPath, "badgeAssignmentPoolOptions");
 
             var params = {
                 depth: 4,

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -6,7 +6,6 @@ import * as AdhMovingColumns from "../../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../../Permissions/Permissions";
 import * as AdhResourceArea from "../../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../TopLevelState/TopLevelState";
-import * as AdhUtil from "../../Util/Util";
 
 import RIComment from "../../../Resources_/adhocracy_core/resources/comment/IComment";
 import RICommentVersion from "../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
@@ -103,9 +102,6 @@ export var proposalDetailColumnDirective = (
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
             column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
-            adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
-
-            scope.column = column;
         }
     };
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -19,9 +19,7 @@ import RIIdeaCollectionProcess from "../../../Resources_/adhocracy_meinberlin/re
 import RIKiezkasseProcess from "../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProcess";
 import RIKiezkasseProposal from "../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposal";
 import RIKiezkasseProposalVersion from "../../../Resources_/adhocracy_meinberlin/resources/kiezkassen/IProposalVersion";
-import * as SIBadge from "../../../Resources_/adhocracy_core/sheets/badge/IBadge";
 import * as SIComment from "../../../Resources_/adhocracy_core/sheets/comment/IComment";
-import * as SIPool from "../../../Resources_/adhocracy_core/sheets/pool/IPool";
 import * as SIWorkflow from "../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
 
 export var pkgLocation = "/Meinberlin/IdeaCollection";
@@ -108,14 +106,6 @@ export var proposalDetailColumnDirective = (
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
             scope.column = column;
-
-            var params = {
-                depth: 4,
-                content_type: SIBadge.nick
-            };
-            adhHttp.get(scope.processUrl, params).then((response) => {
-                scope.badgesExist = response.data[SIPool.nick].count > 0;
-            });
         }
     };
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -18,19 +18,17 @@
     <div data-ng-switch-when="body">
         <adh-recompile-on-change
             data-value="{{proposalUrl}}">
-            <div class="action-bar">
-                <adh-resource-actions
-                    data-resource-path="{{proposalUrl}}"
-                    data-process-url="{{processUrl}}"
-                    data-ng-if="proposalUrl"
-                    data-parent-path="true"
-                    data-edit="true"
-                    data-assign-badges="true"
-                    data-report="true"
-                    data-hide="true"
-                    data-print="true">
-                </adh-resource-actions>
-            </div>
+            <adh-resource-actions
+                data-resource-path="{{proposalUrl}}"
+                data-process-url="{{processUrl}}"
+                data-ng-if="proposalUrl"
+                data-parent-path="true"
+                data-edit="true"
+                data-assign-badges="true"
+                data-report="true"
+                data-hide="true"
+                data-print="true">
+            </adh-resource-actions>
             <adh-meinberlin-proposal-detail
                 data-ng-if="proposalUrl"
                 data-is-buergerhaushalt="isBuergerhaushalt"

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -20,7 +20,7 @@
             data-value="{{proposalUrl}}">
             <adh-resource-actions
                 data-resource-path="{{proposalUrl}}"
-                data-process-url="{{processUrl}}"
+                data-resource-with-badges-url="{{processUrl}}"
                 data-ng-if="proposalUrl"
                 data-parent-path="true"
                 data-edit="true"

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -37,11 +37,4 @@
             </adh-meinberlin-proposal-detail>
         </adh-recompile-on-change>
     </div>
-
-    <adh-report-abuse
-        data-ng-switch-when="overlays"
-        data-ng-if="overlay === 'abuse'"
-        data-modals="column"
-        data-url="{{ proposalUrl | adhParentPath | adhResourceUrl | adhCanonicalUrl }}">
-    </adh-report-abuse>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -29,12 +29,12 @@
                     data-class="action-bar-item"
                     data-parent-path="true"
                     data-resource-path="{{proposalUrl}}"></adh-report-action>
-                <adh-assign-badges-action
+                <adh-resource-actions
+                    data-assign-badges="true"
                     data-modals="column"
-                    data-ng-if="proposalUrl && badgesExist && badgeAssignmentPoolOptions.PUT"
-                    data-class="action-bar-item"
+                    data-ng-if="proposalUrl && badgesExist"
                     data-parent-path="true"
-                    data-resource-path="{{proposalUrl}}"></adh-assign-badges-action>
+                    data-resource-path="{{proposalUrl}}"></adh-resource-actions>
                 <adh-hide-action
                     data-ng-if="proposalUrl && proposalItemOptions.hide"
                     data-class="action-bar-item"
@@ -58,10 +58,4 @@
         data-modals="column"
         data-url="{{ proposalUrl | adhParentPath | adhResourceUrl | adhCanonicalUrl }}">
     </adh-report-abuse>
-
-    <adh-badge-assignment
-        data-ng-switch-when="overlays"
-        data-ng-if="overlay === 'badges'"
-        data-path="{{proposalUrl}}">
-    </adh-badge-assignment>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -29,11 +29,12 @@
                     data-class="action-bar-item"
                     data-parent-path="true"
                     data-resource-path="{{proposalUrl}}"></adh-report-action>
-                <a
-                    href=""
-                    class="action-bar-item"
-                    data-ng-click="ctrl.toggleOverlay('badges')"
-                    data-ng-if="badgeAssignmentPoolOptions.POST && badgesExist">{{ "TR__MANAGE_BADGE_ASSIGNMENTS" | translate }}</a>
+                <adh-assign-badges-action
+                    data-modals="column"
+                    data-ng-if="proposalUrl && badgesExist && badgeAssignmentPoolOptions.PUT"
+                    data-class="action-bar-item"
+                    data-parent-path="true"
+                    data-resource-path="{{proposalUrl}}"></adh-assign-badges-action>
                 <adh-hide-action
                     data-ng-if="proposalUrl && proposalItemOptions.hide"
                     data-class="action-bar-item"

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -19,30 +19,17 @@
         <adh-recompile-on-change
             data-value="{{proposalUrl}}">
             <div class="action-bar">
-                <adh-edit-action
-                    data-ng-if="proposalUrl && proposalItemOptions.PUT"
-                    data-class="action-bar-item"
-                    data-parent-path="true"
-                    data-resource-path="{{proposalUrl}}"></adh-edit-action>
-                <adh-report-action
-                    data-modals="column"
-                    data-class="action-bar-item"
-                    data-parent-path="true"
-                    data-resource-path="{{proposalUrl}}"></adh-report-action>
                 <adh-resource-actions
-                    data-assign-badges="true"
-                    data-modals="column"
+                    data-resource-path="{{proposalUrl}}"
                     data-process-url="{{processUrl}}"
                     data-ng-if="proposalUrl"
                     data-parent-path="true"
-                    data-resource-path="{{proposalUrl}}"></adh-resource-actions>
-                <adh-hide-action
-                    data-ng-if="proposalUrl && proposalItemOptions.hide"
-                    data-class="action-bar-item"
-                    data-parent-path="true"
-                    data-resource-path="{{proposalUrl}}"></adh-hide-action>
-                <adh-print-action
-                    data-class="action-bar-item"></adh-print-action>
+                    data-edit="true"
+                    data-assign-badges="true"
+                    data-report="true"
+                    data-hide="true"
+                    data-print="true">
+                </adh-resource-actions>
             </div>
             <adh-meinberlin-proposal-detail
                 data-ng-if="proposalUrl"

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -32,7 +32,8 @@
                 <adh-resource-actions
                     data-assign-badges="true"
                     data-modals="column"
-                    data-ng-if="proposalUrl && badgesExist"
+                    data-process-url="{{processUrl}}"
+                    data-ng-if="proposalUrl"
                     data-parent-path="true"
                     data-resource-path="{{proposalUrl}}"></adh-resource-actions>
                 <adh-hide-action

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/ProposalDetailColumn.html
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/ProposalDetailColumn.html
@@ -21,7 +21,6 @@
             data-report="true"
             data-share="true"
             data-print="true"></adh-resource-actions>
-
         <adh-mercator-2016-proposal-detail data-ng-if="proposalUrl" data-path="{{proposalUrl}}"></adh-mercator-2016-proposal-detail>
     </adh-recompile-on-change>
 </div>

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalDetailColumn.html
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalDetailColumn.html
@@ -33,6 +33,7 @@
     <adh-badge-assignment
         data-ng-switch-when="overlays"
         data-ng-if="overlay === 'badges'"
+        data-modals="column"
         data-path="{{proposalUrl}}">
     </adh-badge-assignment>
 </div>

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/Workbench.ts
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/Workbench.ts
@@ -46,6 +46,7 @@ export var proposalDetailColumnDirective = (
             column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
+            scope.column = column;
             var badgeAssignmentPoolPath;
             scope.$watch("proposalUrl", (proposalUrl) => {
                 if (proposalUrl) {


### PR DESCRIPTION
Needs + continues #2451.

This is another step towards abolishing moving columns, because the 'badges overlay' functionality of `MovingColumns` is moved to `Badge`.

Following soon (maybe in a different PR):
- [ ] switch PolicyCompass and Euth to `adhAssignBadgesAction` as well.