### PR TITLE
modal refactoring

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -149,7 +149,7 @@
     "TR__REPLY": "antworten",
     "TR__REPORT": "melden",
     "TR__REPORT_ABUSE_STATUS_OK": "Die Moderator*innen wurden benachrichtigt.",
-    "TR__REPORT_HELP": "Nutze dieses Fenster, um Verstöße gegen die [[linkNetiquette:Netiquette]] zu melden. Wenn Du einem Kommentar inhaltlich widersprechen möchtest, [[link:schließe bitte das Overlay]] und benutze den Antworte-Button.",
+    "TR__REPORT_HELP": "Nutze dieses Fenster, um Verstöße gegen die [[linkNetiquette:Netiquette]] zu melden. Wenn Du einem Kommentar inhaltlich widersprechen möchtest, [[link:schließe bitte den Modaldialog]] und benutze den Antworte-Button.",
     "TR__REPORT_PLACEHOLDER": "Bitte erkläre, wieso du diesen Beitrag melden möchtest.",
     "TR__RESET": "Zurücksetzen",
     "TR__SAVE": "speichern",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -149,7 +149,7 @@
     "TR__REPLY": "reply",
     "TR__REPORT": "report",
     "TR__REPORT_ABUSE_STATUS_OK": "The moderators have been notified.",
-    "TR__REPORT_HELP": "Please only use this form to report violations in [[linkNetiquette:Netiquette]]. To be a normal part of this discussion please [[link:close this overlay]] and use the regular reply functionality.",
+    "TR__REPORT_HELP": "Please only use this form to report violations in [[linkNetiquette:Netiquette]]. To be a normal part of this discussion please [[link:close this modal]] and use the regular reply functionality.",
     "TR__REPORT_PLACEHOLDER": "Please explain why would you like to report this comment.",
     "TR__RESET": "Reset",
     "TR__SAVE": "save",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Abuse.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Abuse.ts
@@ -19,7 +19,7 @@ export var reportAbuseDirective = (adhHttp : AdhHttp.Service<any>, adhConfig : A
                     url: scope.url,
                     remark: scope.remark
                 }).then(() => {
-                    scope.modals.hideOverlay("abuse");
+                    scope.modals.hideModal("abuse");
                     scope.modals.alert("TR__REPORT_ABUSE_STATUS_OK", "success");
                 }, () => {
                     // FIXME
@@ -27,7 +27,7 @@ export var reportAbuseDirective = (adhHttp : AdhHttp.Service<any>, adhConfig : A
             };
 
             scope.cancel = () => {
-                scope.modals.hideOverlay("abuse");
+                scope.modals.hideModal("abuse");
             };
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Abuse.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Abuse.ts
@@ -1,6 +1,5 @@
 import * as AdhConfig from "../Config/Config";
 import * as AdhHttp from "../Http/Http";
-import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 
 var pkgLocation = "/Abuse";
 
@@ -13,8 +12,7 @@ export var reportAbuseDirective = (adhHttp : AdhHttp.Service<any>, adhConfig : A
             url: "@",  // frontend URL
             modals: "=",
         },
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.netiquette_url = adhConfig.netiquette_url;
             scope.submit = () => {
                 return adhHttp.postRaw(adhConfig.rest_url + "/report_abuse", {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Abuse/Module.ts
@@ -1,5 +1,4 @@
 import * as AdhHttpModule from "../Http/Module";
-import * as AdhMovingColumnsModule from "../MovingColumns/Module";
 
 import * as AdhAbuse from "./Abuse";
 
@@ -10,7 +9,6 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhHttpModule.moduleName,
-            AdhMovingColumnsModule.moduleName
         ])
         .directive("adhReportAbuse", ["adhHttp", "adhConfig", AdhAbuse.reportAbuseDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -265,7 +265,7 @@ export var badgeAssignment = (
 
                             return transaction.commit()
                                 .then((responses) => {
-                                    scope.modals.hideOverlay("badges");
+                                    scope.modals.hideModal("badges");
                                     scope.modals.alert("TR__BADGE_ASSIGNMENT_UPDATED", "success");
                                 }, (response) => {
                                     scope.serverError = response[0].description;
@@ -274,7 +274,7 @@ export var badgeAssignment = (
                     };
 
                     scope.cancel = () => {
-                        scope.modals.hideOverlay("badges");
+                        scope.modals.hideModal("badges");
                     };
                 });
             });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Column.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Column.html
@@ -1,12 +1,7 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
-        <div class="moving-column-tab" data-ng-switch="overlay">
-            <span data-ng-switch-when="abuse">
-                <i class="icon-flag moving-column-icon"></i>
-            </span>
-            <span data-ng-switch-default="">
-                <i class="icon-speechbubbles moving-column-icon"></i>
-            </span>
+        <div class="moving-column-tab">
+            <i class="icon-speechbubbles moving-column-icon"></i>
         </div>
         <div class="moving-column-menu-nav">
             <a
@@ -21,11 +16,4 @@
         data-path="{{commentableUrl}}"
         data-ng-switch-when="body">
     </adh-comment-listing>
-
-    <adh-report-abuse
-        data-ng-switch-when="overlays"
-        data-ng-if="overlay === 'abuse'"
-        data-modals="column"
-        data-url="{{ shared.abuseUrl | adhParentPath | adhResourceUrl | adhCanonicalUrl }}">
-    </adh-report-abuse>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -438,7 +438,6 @@ export var commentColumnDirective = (
         link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("commentCloseUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("commentableUrl", scope));
-            scope.column = column;
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -188,7 +188,7 @@ export var commentDetailDirective = (
         scope.modals = new AdhResourceActions.Modals($timeout);
 
         scope.report = () => {
-            scope.modals.toggleOverlay("abuse");
+            scope.modals.toggleModal("abuse");
         };
 
         scope.$on("$destroy", adhTopLevelState.on("commentUrl", (commentVersionUrl) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -3,7 +3,6 @@ import * as _ from "lodash";
 import * as AdhConfig from "../Config/Config";
 import * as AdhCredentials from "../User/Credentials";
 import * as AdhHttp from "../Http/Http";
-import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
 import * as AdhResourceActions from "../ResourceActions/ResourceActions";
@@ -436,8 +435,7 @@ export var commentColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Column.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("commentCloseUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("commentableUrl", scope));
             scope.column = column;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Comment.ts
@@ -430,14 +430,16 @@ export var adhCreateOrShowCommentListing = (
 };
 
 export var commentColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Column.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["commentCloseUrl", "commentableUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("commentCloseUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("commentableUrl", scope));
             scope.column = column;
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -56,9 +56,9 @@
             </li>
         </ul>
 
-        <div class="action-bar-modal" data-ng-if="modals.overlay">
+        <div class="action-bar-modal" data-ng-if="modals.modal">
             <adh-report-abuse
-                data-ng-if="modals.overlay === 'abuse'"
+                data-ng-if="modals.modal === 'abuse'"
                 data-modals="modals"
                 class="report-abuse"
                 data-url="{{data.path}}">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -56,7 +56,7 @@
             </li>
         </ul>
 
-        <div class="action-bar-modal" data-ng-if="modals.modal">
+        <div class="modal" data-ng-if="modals.modal">
             <adh-report-abuse
                 data-ng-if="modals.modal === 'abuse'"
                 data-modals="modals"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Detail.html
@@ -50,8 +50,8 @@
             </div>
         </div>
 
-        <ul class="moving-column-alerts">
-            <li data-ng-repeat="(id, alert) in modals.alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
+        <ul class="alerts">
+            <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
                 {{ alert.message | translate }}
             </li>
         </ul>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Comment/Module.ts
@@ -62,5 +62,5 @@ export var register = (angular) => {
             "$translate",
             AdhComment.commentDetailDirective])
         .directive("adhCommentCreate", ["adhConfig", "adhHttp", "adhPreliminaryNames", AdhComment.commentCreateDirective])
-        .directive("adhCommentColumn", ["adhConfig", AdhComment.commentColumnDirective]);
+        .directive("adhCommentColumn", ["adhConfig", "adhTopLevelState", AdhComment.commentColumnDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DebateWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DebateWorkbench.ts
@@ -38,55 +38,61 @@ export var debateWorkbenchDirective = (
 
 export var documentDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "documentUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("documentUrl", scope));
             adhPermissions.bindScope(scope, () => scope.documentUrl && AdhUtil.parentPath(scope.documentUrl), "proposalItemOptions");
         }
     };
 };
 
 export var documentCreateColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
 };
 
 export var documentEditColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "documentUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("documentUrl", scope));
         }
     };
 };
 
 export var processDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProcessDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
         }
     };
@@ -94,9 +100,10 @@ export var processDetailColumnDirective = (
 
 export var processDetailAnnounceColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
-    var directive = processDetailColumnDirective(adhConfig, adhPermissions);
+    var directive = processDetailColumnDirective(adhConfig, adhPermissions, adhTopLevelState);
     directive.templateUrl = adhConfig.pkg_path + pkgLocation + "/ProcessDetailAnnounceColumn.html";
     return directive;
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DebateWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DebateWorkbench.ts
@@ -2,7 +2,6 @@
 
 import * as AdhConfig from "../Config/Config";
 import * as AdhHttp from "../Http/Http";
-import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhResourceArea from "../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
@@ -44,8 +43,7 @@ export var documentDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("documentUrl", scope));
             adhPermissions.bindScope(scope, () => scope.documentUrl && AdhUtil.parentPath(scope.documentUrl), "proposalItemOptions");
@@ -60,8 +58,7 @@ export var documentCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
@@ -74,8 +71,7 @@ export var documentEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("documentUrl", scope));
         }
@@ -90,8 +86,7 @@ export var processDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProcessDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
@@ -31,9 +31,12 @@ export var register = (angular) => {
                 .registerDirective("debate-workbench");
         }])
         .directive("adhDebateWorkbench", ["adhConfig", "adhTopLevelState", DebateWorkbench.debateWorkbenchDirective])
-        .directive("adhDocumentDetailColumn", ["adhConfig", "adhPermissions", DebateWorkbench.documentDetailColumnDirective])
-        .directive("adhDocumentCreateColumn", ["adhConfig", DebateWorkbench.documentCreateColumnDirective])
-        .directive("adhDocumentEditColumn", ["adhConfig", DebateWorkbench.documentEditColumnDirective])
-        .directive("adhDebateProcessDetailColumn", ["adhConfig", "adhPermissions", DebateWorkbench.processDetailColumnDirective])
-        .directive("adhDebateProcessDetailAnnounceColumn", ["adhConfig", DebateWorkbench.processDetailAnnounceColumnDirective]);
+        .directive("adhDocumentDetailColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", DebateWorkbench.documentDetailColumnDirective])
+        .directive("adhDocumentCreateColumn", ["adhConfig", "adhTopLevelState", DebateWorkbench.documentCreateColumnDirective])
+        .directive("adhDocumentEditColumn", ["adhConfig", "adhTopLevelState", DebateWorkbench.documentEditColumnDirective])
+        .directive("adhDebateProcessDetailColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", DebateWorkbench.processDetailColumnDirective])
+        .directive("adhDebateProcessDetailAnnounceColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", DebateWorkbench.processDetailAnnounceColumnDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumn.html
@@ -8,9 +8,9 @@
     <div class="moving-column-collapsed">
         <adh-inject data-transclusion-id="collapsed"></adh-inject>
     </div>
-    <div class="moving-column-mask" data-ng-show="overlay"></div>
-    <div class="moving-column-overlay" data-ng-if="overlay">
-        <adh-inject data-transclusion-id="overlays"></adh-inject>
+    <div class="moving-column-mask" data-ng-show="modal"></div>
+    <div class="moving-column-modal" data-ng-if="modal">
+        <adh-inject data-transclusion-id="modals"></adh-inject>
     </div>
     <ul class="moving-column-alerts">
         <li data-ng-repeat="(id, alert) in _alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="ctrl.removeAlert(id)">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumn.html
@@ -8,13 +8,4 @@
     <div class="moving-column-collapsed">
         <adh-inject data-transclusion-id="collapsed"></adh-inject>
     </div>
-    <div class="moving-column-mask" data-ng-show="modal"></div>
-    <div class="moving-column-modal" data-ng-if="modal">
-        <adh-inject data-transclusion-id="modals"></adh-inject>
-    </div>
-    <ul class="moving-column-alerts">
-        <li data-ng-repeat="(id, alert) in _alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="ctrl.removeAlert(id)">
-            {{ alert.message | translate }}
-        </li>
-    </ul>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -174,19 +174,6 @@ export class MovingColumnController {
     public $broadcast(name : string, ...args : any[]) {
         return this.$scope.$broadcast.apply(this.$scope, arguments);
     }
-
-    /**
-     * Bind variables from topLevelState and clear this column whenever one of them changes.
-     */
-    public bindVariablesAndClear(scope, keys : string[]) : void {
-        var self : MovingColumnController = this;
-
-        keys.forEach((key : string) => {
-            scope.$on("$destroy", self.adhTopLevelState.on(key, (value) => {
-                scope[key] = value;
-            }));
-        });
-    }
 }
 
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -159,19 +159,12 @@ export var movingColumns = (
 };
 
 
-export interface IMovingColumnScope extends angular.IScope {
-    // an object that can be used to share data between different parts of the column.
-    shared;
-}
-
 export class MovingColumnController {
     constructor(
         protected adhTopLevelState : AdhTopLevelState.Service,
-        public $scope : IMovingColumnScope,
+        public $scope : angular.IScope,
         protected $element : angular.IAugmentedJQuery
-    ) {
-        $scope.shared = {};
-    }
+    ) {}
 
     public focus() : void {
         var index = this.$element.index();

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -164,7 +164,7 @@ export var movingColumns = (
  *
  * Every moving column should be wrapped in an instance of this
  * directive.  It provides common functionality, e.g. alerts and
- * overlays via a controller that can be required by subelements.
+ * modals via a controller that can be required by subelements.
  *
  * Subelements can inject template code with the following transclusionIds
  * (see AdhInject):
@@ -172,17 +172,17 @@ export var movingColumns = (
  * -   body
  * -   menu
  * -   collapsed
- * -   overlays
+ * -   modals
  */
 export interface IMovingColumnScope extends angular.IScope {
-    // the controller with interfaces for alerts, overlays, ...
+    // the controller with interfaces for alerts, modals, ...
     ctrl : MovingColumnController;
 
     // an object that can be used to share data between different parts of the column.
     shared;
 
-    // key of the currently active overlay or undefined
-    overlay : string;
+    // key of the currently active modal or undefined
+    modal : string;
 
     // private
     _alerts : {[id : number]: {
@@ -214,7 +214,7 @@ export class MovingColumnController {
 
     public clear() : void {
         this.$scope._alerts = {};
-        this.$scope.overlay = undefined;
+        this.$scope.modal = undefined;
     }
 
     public alert(message : string, mode : string = "info", duration : number = 3000) : void {
@@ -231,21 +231,21 @@ export class MovingColumnController {
         delete this.$scope._alerts[id];
     }
 
-    public showOverlay(key : string) : void {
-        this.$scope.overlay = key;
+    public showModal(key : string) : void {
+        this.$scope.modal = key;
     }
 
-    public hideOverlay(key? : string) : void {
-        if (typeof key === "undefined" || this.$scope.overlay === key) {
-            this.$scope.overlay = undefined;
+    public hideModal(key? : string) : void {
+        if (typeof key === "undefined" || this.$scope.modal === key) {
+            this.$scope.modal = undefined;
         }
     }
 
-    public toggleOverlay(key : string, condition? : boolean) : void {
-        if (condition || (typeof condition === "undefined" && this.$scope.overlay !== key)) {
-            this.$scope.overlay = key;
-        } else if (this.$scope.overlay === key) {
-            this.$scope.overlay = undefined;
+    public toggleModal(key : string, condition? : boolean) : void {
+        if (condition || (typeof condition === "undefined" && this.$scope.modal !== key)) {
+            this.$scope.modal = key;
+        } else if (this.$scope.modal === key) {
+            this.$scope.modal = undefined;
         }
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/MovingColumns/MovingColumns.ts
@@ -159,94 +159,23 @@ export var movingColumns = (
 };
 
 
-/**
- * Moving Column directive
- *
- * Every moving column should be wrapped in an instance of this
- * directive.  It provides common functionality, e.g. alerts and
- * modals via a controller that can be required by subelements.
- *
- * Subelements can inject template code with the following transclusionIds
- * (see AdhInject):
- *
- * -   body
- * -   menu
- * -   collapsed
- * -   modals
- */
 export interface IMovingColumnScope extends angular.IScope {
-    // the controller with interfaces for alerts, modals, ...
-    ctrl : MovingColumnController;
-
     // an object that can be used to share data between different parts of the column.
     shared;
-
-    // key of the currently active modal or undefined
-    modal : string;
-
-    // private
-    _alerts : {[id : number]: {
-        message : string;
-        mode : string;
-    }};
 }
 
 export class MovingColumnController {
-    private lastId : number;
-
     constructor(
         protected adhTopLevelState : AdhTopLevelState.Service,
-        protected $timeout : angular.ITimeoutService,
         public $scope : IMovingColumnScope,
         protected $element : angular.IAugmentedJQuery
     ) {
-        $scope.ctrl = this;
-        $scope._alerts = {};
         $scope.shared = {};
-
-        this.lastId = 0;
     }
 
     public focus() : void {
         var index = this.$element.index();
         this.adhTopLevelState.set("focus", index);
-    }
-
-    public clear() : void {
-        this.$scope._alerts = {};
-        this.$scope.modal = undefined;
-    }
-
-    public alert(message : string, mode : string = "info", duration : number = 3000) : void {
-        var id = this.lastId++;
-        this.$timeout(() => this.removeAlert(id), duration);
-
-        this.$scope._alerts[id] = {
-            message: message,
-            mode: mode
-        };
-    }
-
-    public removeAlert(id : number) : void {
-        delete this.$scope._alerts[id];
-    }
-
-    public showModal(key : string) : void {
-        this.$scope.modal = key;
-    }
-
-    public hideModal(key? : string) : void {
-        if (typeof key === "undefined" || this.$scope.modal === key) {
-            this.$scope.modal = undefined;
-        }
-    }
-
-    public toggleModal(key : string, condition? : boolean) : void {
-        if (condition || (typeof condition === "undefined" && this.$scope.modal !== key)) {
-            this.$scope.modal = key;
-        } else if (this.$scope.modal === key) {
-            this.$scope.modal = undefined;
-        }
     }
 
     public $broadcast(name : string, ...args : any[]) {
@@ -259,20 +188,9 @@ export class MovingColumnController {
     public bindVariablesAndClear(scope, keys : string[]) : void {
         var self : MovingColumnController = this;
 
-        // NOTE: column directives are typically injected mutliple times
-        // with different transcludionIds. But we want to trigger clear() only once.
-        var clear = () => {
-            if (scope.transclusionId === "body") {
-                self.clear();
-            }
-        };
-
-        clear();
-
         keys.forEach((key : string) => {
             scope.$on("$destroy", self.adhTopLevelState.on(key, (value) => {
                 scope[key] = value;
-                clear();
             }));
         });
     }
@@ -286,6 +204,6 @@ export var movingColumnDirective = (adhConfig : AdhConfig.IService) => {
         replace: true,
         transclude: true,
         templateUrl: adhConfig.pkg_path + pkgLocation + "/MovingColumn.html",
-        controller: ["adhTopLevelState", "$timeout", "$scope", "$element", MovingColumnController]
+        controller: ["adhTopLevelState", "$scope", "$element", MovingColumnController]
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
@@ -26,7 +26,7 @@ export var register = (angular) => {
             "adhTopLevelState", "adhResourceUrlFilter", "$location", AdhResourceActions.moderateActionDirective])
         .directive("adhPrintAction", ["adhTopLevelState", "$window", AdhResourceActions.printActionDirective])
         .directive("adhCancelAction", ["adhTopLevelState", "adhResourceUrlFilter", AdhResourceActions.cancelActionDirective])
-        .animation(".action-bar-modal", () => {
+        .animation(".modal", () => {
             return {
                 enter: (element, done) => {
                     element.hide().slideDown(done);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -50,22 +50,22 @@
     </li>
 </ul>
 
-<div class="action-bar-modal" data-ng-if="modals.overlay">
+<div class="action-bar-modal" data-ng-if="modals.modal">
     <adh-report-abuse
-        data-ng-if="modals.overlay === 'abuse'"
+        data-ng-if="modals.modal === 'abuse'"
         data-modals="modals"
         class="report-abuse"
         data-url="{{ resourcePath | adhResourceUrl | adhCanonicalUrl }}">
     </adh-report-abuse>
 
     <adh-badge-assignment
-        data-ng-if="modals.overlay === 'badges'"
+        data-ng-if="modals.modal === 'badges'"
         data-modals="modals"
         data-path="{{resourcePath}}">
     </adh-badge-assignment>
 
-    <div data-ng-if="modals.overlay === 'share'">
+    <div data-ng-if="modals.modal === 'share'">
         <adh-social-share data-uri="{{ resourcePath | adhResourceUrl | adhCanonicalUrl }}"></adh-social-share>
-        <a href="" class="button" data-ng-click="modals.hideOverlay('share')">{{ "TR__CANCEL" | translate }}</a>
+        <a href="" class="button" data-ng-click="modals.hideModal('share')">{{ "TR__CANCEL" | translate }}</a>
     </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -44,8 +44,8 @@
         data-resource-path="{{resourcePath}}"></adh-cancel-action>
 </div>
 
-<ul class="moving-column-alerts">
-    <li data-ng-repeat="(id, alert) in modals.alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
+<ul class="alerts">
+    <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
         {{ alert.message | translate }}
     </li>
 </ul>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -50,7 +50,7 @@
     </li>
 </ul>
 
-<div class="action-bar-modal" data-ng-if="modals.modal">
+<div class="modal" data-ng-if="modals.modal">
     <adh-report-abuse
         data-ng-if="modals.modal === 'abuse'"
         data-modals="modals"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -13,7 +13,7 @@ var pkgLocation = "/ResourceActions";
 
 
 export class Modals {
-    public overlay : string;
+    public modal : string;
     public alerts : {[id : number]: {message : string, mode : string}};
     private lastId : number;
 
@@ -36,27 +36,27 @@ export class Modals {
         delete this.alerts[id];
     }
 
-    public showOverlay(key : string) : void {
-        this.overlay = key;
+    public showModal(key : string) : void {
+        this.modal = key;
     }
 
-    public hideOverlay(key? : string) : void {
-        if (typeof key === "undefined" || this.overlay === key) {
-            this.overlay = undefined;
+    public hideModal(key? : string) : void {
+        if (typeof key === "undefined" || this.modal === key) {
+            this.modal = undefined;
         }
     }
 
-    public toggleOverlay(key : string, condition? : boolean) : void {
-        if (condition || (typeof condition === "undefined" && this.overlay !== key)) {
-            this.overlay = key;
-        } else if (this.overlay === key) {
-            this.overlay = undefined;
+    public toggleModal(key : string, condition? : boolean) : void {
+        if (condition || (typeof condition === "undefined" && this.modal !== key)) {
+            this.modal = key;
+        } else if (this.modal === key) {
+            this.modal = undefined;
         }
     }
 
     public clear() : void {
         this.alerts = {};
-        this.overlay = undefined;
+        this.modal = undefined;
     }
 }
 
@@ -126,7 +126,7 @@ export var reportActionDirective = () => {
         },
         link: (scope) => {
             scope.report = () => {
-                scope.modals.toggleOverlay("abuse");
+                scope.modals.toggleModal("abuse");
             };
         }
     };
@@ -142,7 +142,7 @@ export var shareActionDirective = () => {
         },
         link: (scope) => {
             scope.share = () => {
-                scope.modals.toggleOverlay("share");
+                scope.modals.toggleModal("share");
             };
         }
     };
@@ -160,7 +160,7 @@ export var assignBadgesActionDirective = () => {
         },
         link: (scope) => {
             scope.assignBadges = () => {
-                scope.modals.toggleOverlay("badges");
+                scope.modals.toggleModal("badges");
             };
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -15,8 +15,8 @@
                 data-ng-click="modals.toggleModal('messaging')"
                 data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
         </div>
-        <ul class="moving-column-alerts">
-            <li data-ng-repeat="(id, alert) in modals.alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
+        <ul class="alerts">
+            <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
                 {{ alert.message | translate }}
             </li>
         </ul>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -20,7 +20,7 @@
                 {{ alert.message | translate }}
             </li>
         </ul>
-        <div class="action-bar-modal" data-ng-if="modals.modal">
+        <div class="modal" data-ng-if="modals.modal">
             <adh-user-message
                 data-ng-if="modals.modal === 'messaging'"
                 data-modals="modals"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -12,7 +12,7 @@
             <a
                 class="action-bar-item"
                 href=""
-                data-ng-click="modals.toggleOverlay('messaging')"
+                data-ng-click="modals.toggleModal('messaging')"
                 data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
         </div>
         <ul class="moving-column-alerts">
@@ -20,9 +20,9 @@
                 {{ alert.message | translate }}
             </li>
         </ul>
-        <div class="action-bar-modal" data-ng-if="modals.overlay">
+        <div class="action-bar-modal" data-ng-if="modals.modal">
             <adh-user-message
-                data-ng-if="modals.overlay === 'messaging'"
+                data-ng-if="modals.modal === 'messaging'"
                 data-modals="modals"
                 data-recipient-url="{{userUrl}}">
             </adh-user-message>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -667,7 +667,7 @@ export var userProfileDirective = (
 
             scope.showMessaging = () => {
                 if (scope.messageOptions.POST) {
-                    scope.modals.showOverlay("messaging");
+                    scope.modals.showModal("messaging");
                 } else if (!adhCredentials.loggedIn) {
                     adhTopLevelState.setCameFromAndGo("/login");
                 } else {
@@ -708,7 +708,7 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
                     title: scope.message.title,
                     text: scope.message.text
                 }).then(() => {
-                    scope.modals.hideOverlay();
+                    scope.modals.hideModal();
                     scope.modals.alert("TR__MESSAGE_STATUS_OK", "success");
                 }, () => {
                     // FIXME
@@ -716,7 +716,7 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
             };
 
             scope.cancel = () => {
-                scope.modals.hideOverlay();
+                scope.modals.hideModal();
             };
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -6,7 +6,6 @@ import * as _ from "lodash";
 import * as AdhBadge from "../Badge/Badge";
 import * as AdhConfig from "../Config/Config";
 import * as AdhHttp from "../Http/Http";
-import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhResourceActions from "../ResourceActions/ResourceActions";
 import * as AdhResourceArea from "../ResourceArea/ResourceArea";
@@ -732,8 +731,7 @@ export var userDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/UserDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("userUrl", scope));
             adhPermissions.bindScope(scope, adhConfig.rest_url + "/message_user", "messageOptions");
             scope.modals = new AdhResourceActions.Modals($timeout);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -724,8 +724,9 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
 
 
 export var userDetailColumnDirective = (
-    adhPermissions : AdhPermissions.Service,
     adhConfig : AdhConfig.IService,
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service,
     $timeout : angular.ITimeoutService
 ) => {
     return {
@@ -733,7 +734,7 @@ export var userDetailColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/UserDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["userUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("userUrl", scope));
             adhPermissions.bindScope(scope, adhConfig.rest_url + "/message_user", "messageOptions");
             scope.modals = new AdhResourceActions.Modals($timeout);
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/ViewsModule.ts
@@ -135,7 +135,8 @@ export var register = (angular) => {
             "adhConfig", "adhResourceArea", "adhTopLevelState", "adhPermissions", "$location", AdhUserViews.indicatorDirective])
         .directive("adhUserMeta", ["adhConfig", "adhResourceArea", "adhGetBadges", AdhUserViews.metaDirective])
         .directive("adhUserMessage", ["adhConfig", "adhHttp", AdhUserViews.userMessageDirective])
-        .directive("adhUserDetailColumn", ["adhPermissions", "adhConfig", "$timeout", AdhUserViews.userDetailColumnDirective])
+        .directive("adhUserDetailColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", "$timeout", AdhUserViews.userDetailColumnDirective])
         .directive("adhUserProfileImage", ["adhHttp", "adhConfig", AdhUserViews.adhUserProfileImageDirective])
         .directive("adhUserProfileImageEdit", ["adhHttp", "adhPermissions", "adhConfig", AdhUserViews.adhUserProfileImageEditDirective])
         .directive("adhUserActivityOverview", ["adhConfig", "adhHttp", AdhUserViews.adhUserActivityOverviewDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
@@ -12,8 +12,7 @@ It is typically located at the top of a larger widget, e.g. a proposal detail.
 Elements of the action bar are called action bar items (`action-bar-item`).
 They can have the `m-selected` modifier.
 
-An action can trigger showing a modal below the action bar
-(`action-bar-modal`).  Only one modal is visible at a time.
+An action can trigger showing a modal below the action bar.
 
 ```html_example
 <div class="action-bar">
@@ -21,7 +20,7 @@ An action can trigger showing a modal below the action bar
     <a class="action-bar-item m-selected">delete</a>
     <a class="action-bar-item">report</a>
 </div>
-<div class="action-bar-modal">
+<div class="modal">
     <form>
         <input type="text" />
         <input type="submit" class="button-cta" />
@@ -115,7 +114,34 @@ An action can trigger showing a modal below the action bar
     }
 }
 
-.action-bar-modal {
+/*doc
+---
+title: Modal
+name: modal
+category: Widgets
+---
+
+A modal contains optional interaction (e.g. a form) that is hidden by default
+and will only show up if triggered by an user action.
+
+Modals are displayed below the element where they were triggered. They should
+open/close with a sliding animation.
+
+```html_example
+<div class="action-bar">
+    <a class="action-bar-item">edit</a>
+    <a class="action-bar-item m-selected">delete</a>
+    <a class="action-bar-item">report</a>
+</div>
+<div class="modal">
+    <form>
+        <input type="text" />
+        <input type="submit" class="button-cta" />
+    </form>
+</div>
+```
+*/
+.modal {
     border-bottom: 2px solid $color-structure-normal;
     padding: 1em;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
@@ -6,7 +6,7 @@ category: Widgets
 ---
 
 A bar with items that trigger actions. Use this widget to provide a
-consistent interface for actions like edit, delete, report, print, and share. 
+consistent interface for actions like edit, delete, report, print, and share.
 It is typically located at the top of a larger widget, e.g. a proposal detail.
 
 Elements of the action bar are called action bar items (`action-bar-item`).
@@ -144,4 +144,51 @@ open/close with a sliding animation.
 .modal {
     border-bottom: 2px solid $color-structure-normal;
     padding: 1em;
+}
+
+/*doc
+---
+title: Alerts
+name: alerts
+parent: modal
+---
+
+A list of alert messages to notify users of the result of a modal action.
+
+The messages are informational by default, but can have the modifieres
+`m-error` and `m-success`.
+
+```html_example
+<ul class="alerts static-example">
+    <li class="alerts-message">Info</li>
+    <li class="alerts-message m-error">Error</li>
+    <li class="alerts-message m-success">Success</li>
+</ul>
+```
+*/
+.alerts {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    z-index: 3;
+
+    @media print {
+        display: none;
+    }
+}
+
+.alerts-message {
+    @include rem(padding, 1rem);
+    background: $color-function-neutral;
+    color: $color-text-normal;
+    text-align: center;
+
+    &.m-error {
+        background: $color-function-negative;
+        color: $color-text-inverted;
+    }
+
+    &.m-success {
+        background: $color-function-positive;
+    }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_action_bar.scss
@@ -182,6 +182,7 @@ The messages are informational by default, but can have the modifieres
     background: $color-function-neutral;
     color: $color-text-normal;
     text-align: center;
+    margin-bottom: 0.5em;
 
     &.m-error {
         background: $color-function-negative;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -148,24 +148,17 @@ The menu should always have the same state as its columns.
     }
 }
 
-.moving-column-body,
-.moving-column-modal,
-.moving-column-mask {
+.moving-column-body {
+    @include rem(border-width, 0 $moving-column-border-width $moving-column-border-width);
+    @include rem(font-size, $font-size-normal);
+
     position: absolute;
     top: $moving-column-menu-height;
     left: 0;
     right: 0;
-    overflow-y: auto;
-}
-
-.moving-column-body,
-.moving-column-mask {
     bottom: 0;
-}
+    overflow-y: auto;
 
-.moving-column-body {
-    @include rem(border-width, 0 $moving-column-border-width $moving-column-border-width);
-    @include rem(font-size, $font-size-normal);
     border-color: $color-structure-normal;
     border-style: solid;
 
@@ -308,16 +301,6 @@ States:
     }
 }
 
-.moving-column-mask {
-    @include opacity(0.5);
-    background-color: $color-background-mask;
-    z-index: 2;
-
-    @media print {
-        display: none;
-    }
-}
-
 /*doc
 ---
 title: Moving Column Alerts
@@ -359,40 +342,6 @@ A list of alert messages to notify users in the moving column
 
     &.m-success {
         background: $color-function-positive;
-    }
-}
-
-.moving-column-modal {
-    @include clearfix;
-    @include rem(padding, 1rem);
-    background: $color-structure-normal;
-    border-top: 1px solid $color-structure-introvert;
-    // .leaflet-top has 1000
-    z-index: 1000;
-    max-height: 80%;
-    overflow-y: auto;
-
-    textarea,
-    input[type="text"] {
-        background: $color-background-base;
-    }
-
-    &.ng-enter, &.ng-leave {
-        @include transition(opacity 0.5s);
-    }
-
-    &.ng-enter,
-    &.ng-leave.ng-leave-active {
-        @include opacity(0);
-    }
-
-    &.ng-leave,
-    &.ng-enter.ng-enter-active {
-        @include opacity(1);
-    }
-
-    @media print {
-        display: none;
     }
 }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -301,50 +301,6 @@ States:
     }
 }
 
-/*doc
----
-title: Moving Column Alerts
-name: moving-column-alerts
-parent: moving-columns
----
-
-A list of alert messages to notify users in the moving column
-
-```html_example
-<ul class="moving-column-alerts static-example">
-    <li class="moving-column-alert m-error">Error</li>
-    <li class="moving-column-alert m-info">Info</li>
-    <li class="moving-column-alert m-success">Success</li>
-</ul>
-```
-*/
-.moving-column-alerts {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    z-index: 3;
-
-    @media print {
-        display: none;
-    }
-}
-
-.moving-column-alert {
-    @include rem(padding, 1rem);
-    background: $color-function-neutral;
-    color: $color-text-normal;
-    text-align: center;
-
-    &.m-error {
-        background: $color-function-negative;
-        color: $color-text-inverted;
-    }
-
-    &.m-success {
-        background: $color-function-positive;
-    }
-}
-
 .moving-column-tab {
     float: left;
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -149,7 +149,7 @@ The menu should always have the same state as its columns.
 }
 
 .moving-column-body,
-.moving-column-overlay,
+.moving-column-modal,
 .moving-column-mask {
     position: absolute;
     top: $moving-column-menu-height;
@@ -362,7 +362,7 @@ A list of alert messages to notify users in the moving column
     }
 }
 
-.moving-column-overlay {
+.moving-column-modal {
     @include clearfix;
     @include rem(padding, 1rem);
     background: $color-structure-normal;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables_doc.scss
@@ -130,7 +130,7 @@ category: Variables
     <tr>
         <td><div class="example-color color-background-mask"></div></td>
         <td><code>color-background-mask</code></td>
-        <td>Mask behind an overlay</td>
+        <td>Mask behind an modal</td>
     </tr>
     <tr>
         <td colspan="3"><strong>Button colors</strong></td>

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Module.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Module.ts
@@ -39,10 +39,12 @@ export var register = (angular) => {
         .config(["adhResourceAreaProvider", Workbench.registerRoutes(RIEuthProcess)])
         .config(["adhResourceAreaProvider", Workbench.registerRoutes(RIEuthPrivateProcess)])
         .directive("adhPcompassWorkbench", ["adhTopLevelState", "adhConfig", "adhHttp", Workbench.workbenchDirective])
-        .directive("adhPcompassProposalDetailColumn", ["adhConfig", "adhHttp", "adhPermissions", Workbench.proposalDetailColumnDirective])
-        .directive("adhPcompassProposalCreateColumn", ["adhConfig", Workbench.proposalCreateColumnDirective])
-        .directive("adhPcompassProposalEditColumn", ["adhConfig", Workbench.proposalEditColumnDirective])
+        .directive("adhPcompassProposalDetailColumn", [
+            "adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", Workbench.proposalDetailColumnDirective])
+        .directive("adhPcompassProposalCreateColumn", ["adhConfig", "adhTopLevelState", Workbench.proposalCreateColumnDirective])
+        .directive("adhPcompassProposalEditColumn", ["adhConfig", "adhTopLevelState", Workbench.proposalEditColumnDirective])
         .directive("adhPcompassProposalImageColumn", [
             "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", "adhParentPathFilter", Workbench.proposalImageColumnDirective])
-        .directive("adhPcompassProcessDetailColumn", ["adhConfig", "adhPermissions", Workbench.processDetailColumnDirective]);
+        .directive("adhPcompassProcessDetailColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", Workbench.processDetailColumnDirective]);
 };

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -8,7 +8,7 @@
         <a
             class="moving-column-menu-button"
             data-ng-if="badgeAssignmentPoolOptions.POST"
-            data-ng-click="ctrl.toggleOverlay('badges')"
+            data-ng-click="ctrl.toggleModal('badges')"
             href="">{{ "TR__MANAGE_BADGE_ASSIGNMENTS" | translate }}</a>
 
         <div class="moving-column-menu-nav">

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.ts
@@ -36,14 +36,16 @@ export var workbenchDirective = (
 export var proposalDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
             scope.column = column;
@@ -61,27 +63,30 @@ export var proposalDetailColumnDirective = (
 };
 
 export var proposalCreateColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
 };
 
 export var proposalEditColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
     };
 };
@@ -97,7 +102,8 @@ export var proposalImageColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalImageColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             scope.goBack = () => {
                 var url = adhResourceUrl(adhParentPath(scope.proposalUrl));
                 adhTopLevelState.goToCameFrom(url);
@@ -108,14 +114,15 @@ export var proposalImageColumnDirective = (
 
 export var processDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProcessDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             scope.contentType = RIProposalVersion.content_type;
         }

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.ts
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/Workbench.ts
@@ -1,6 +1,5 @@
 import * as AdhConfig from "../../Config/Config";
 import * as AdhHttp from "../../Http/Http";
-import * as AdhMovingColumns from "../../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../../Permissions/Permissions";
 import * as AdhResourceArea from "../../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../TopLevelState/TopLevelState";
@@ -42,8 +41,7 @@ export var proposalDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
@@ -69,8 +67,7 @@ export var proposalCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
@@ -83,8 +80,7 @@ export var proposalEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
@@ -100,8 +96,7 @@ export var proposalImageColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalImageColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             scope.goBack = () => {
@@ -120,8 +115,7 @@ export var processDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProcessDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             scope.contentType = RIProposalVersion.content_type;

--- a/src/meinberlin/meinberlin/static/i18n/core_de.json
+++ b/src/meinberlin/meinberlin/static/i18n/core_de.json
@@ -149,7 +149,7 @@
     "TR__REPLY": "antworten",
     "TR__REPORT": "melden",
     "TR__REPORT_ABUSE_STATUS_OK": "Die Moderator*innen wurden benachrichtigt.",
-    "TR__REPORT_HELP": "Nutzen Sie dieses Fenster, um Verstöße gegen die [[linkNetiquette:Netiquette]] zu melden. Wenn Sie einem Kommentar inhaltlich widersprechen möchten, [[link:schließen Sie bitte das Overlay]] und benutzen Sie den Antworte-Button.",
+    "TR__REPORT_HELP": "Nutzen Sie dieses Fenster, um Verstöße gegen die [[linkNetiquette:Netiquette]] zu melden. Wenn Sie einem Kommentar inhaltlich widersprechen möchten, [[link:schließen Sie bitte den Modaldialog]] und benutzen Sie den Antworte-Button.",
     "TR__REPORT_PLACEHOLDER": "Bitte erklären Sie, wieso Sie diesen Beitrag melden möchten.",
     "TR__RESET": "Zurücksetzen",
     "TR__SAVE": "speichern",

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Module.ts
@@ -47,11 +47,15 @@ export var register = (angular) => {
         .directive("adhMeinberlinAlexanderplatzProcessColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", "adhHttp", Workbench.processDetailColumnDirective])
         .directive("adhMeinberlinAlexanderplatzDocumentDetailColumn", [
-            "adhConfig", "adhPermissions", Workbench.documentDetailColumnDirective])
+            "adhConfig", "adhPermissions", "adhTopLevelState", Workbench.documentDetailColumnDirective])
         .directive("adhMeinberlinAlexanderplatzProposalDetailColumn", [
-            "adhConfig", "adhPermissions", Workbench.proposalDetailColumnDirective])
-        .directive("adhMeinberlinAlexanderplatzDocumentCreateColumn", ["adhConfig", "adhHttp", Workbench.documentCreateColumnDirective])
-        .directive("adhMeinberlinAlexanderplatzProposalCreateColumn", ["adhConfig", Workbench.proposalCreateColumnDirective])
-        .directive("adhMeinberlinAlexanderplatzDocumentEditColumn", ["adhConfig", "adhHttp", Workbench.documentEditColumnDirective])
-        .directive("adhMeinberlinAlexanderplatzProposalEditColumn", ["adhConfig", Workbench.proposalEditColumnDirective]);
+            "adhConfig", "adhPermissions", "adhTopLevelState", Workbench.proposalDetailColumnDirective])
+        .directive("adhMeinberlinAlexanderplatzDocumentCreateColumn", [
+            "adhConfig", "adhHttp", "adhTopLevelState", Workbench.documentCreateColumnDirective])
+        .directive("adhMeinberlinAlexanderplatzProposalCreateColumn", [
+            "adhConfig", "adhTopLevelState", Workbench.proposalCreateColumnDirective])
+        .directive("adhMeinberlinAlexanderplatzDocumentEditColumn", [
+            "adhConfig", "adhHttp", "adhTopLevelState", Workbench.documentEditColumnDirective])
+        .directive("adhMeinberlinAlexanderplatzProposalEditColumn", [
+            "adhConfig", "adhTopLevelState", Workbench.proposalEditColumnDirective]);
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Workbench.ts
@@ -58,7 +58,7 @@ export var processDetailColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProcessDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("tab", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
 
@@ -88,14 +88,16 @@ export var processDetailColumnDirective = (
 
 export var documentDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "documentUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("documentUrl", scope));
             adhPermissions.bindScope(scope, () => AdhUtil.parentPath(scope.documentUrl), "documentItemOptions");
         }
     };
@@ -103,14 +105,16 @@ export var documentDetailColumnDirective = (
 
 export var proposalDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
         }
     };
@@ -118,14 +122,15 @@ export var proposalDetailColumnDirective = (
 
 export var documentCreateColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$watch("processUrl", (processUrl) => {
                 if (processUrl) {
                     getProcessPolygon(adhHttp)(processUrl).then((polygon) => {
@@ -139,14 +144,16 @@ export var documentCreateColumnDirective = (
 
 export var documentEditColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "documentUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("documentUrl", scope));
             scope.$watch("processUrl", (processUrl) => {
                 if (processUrl) {
                     getProcessPolygon(adhHttp)(processUrl).then((polygon) => {
@@ -159,27 +166,30 @@ export var documentEditColumnDirective = (
 };
 
 export var proposalCreateColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
 };
 
 export var proposalEditColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
     };
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Workbench.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Workbench.ts
@@ -2,7 +2,6 @@
 
 import * as AdhConfig from "../../../Config/Config";
 import * as AdhHttp from "../../../Http/Http";
-import * as AdhMovingColumns from "../../../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../../../Permissions/Permissions";
 import * as AdhResourceArea from "../../../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../../TopLevelState/TopLevelState";
@@ -56,8 +55,7 @@ export var processDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProcessDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("tab", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
@@ -94,8 +92,7 @@ export var documentDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("documentUrl", scope));
             adhPermissions.bindScope(scope, () => AdhUtil.parentPath(scope.documentUrl), "documentItemOptions");
@@ -111,8 +108,7 @@ export var proposalDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
@@ -128,8 +124,7 @@ export var documentCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$watch("processUrl", (processUrl) => {
                 if (processUrl) {
@@ -150,8 +145,7 @@ export var documentEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DocumentEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("documentUrl", scope));
             scope.$watch("processUrl", (processUrl) => {
@@ -172,8 +166,7 @@ export var proposalCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
@@ -186,8 +179,7 @@ export var proposalEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -2,7 +2,6 @@
 
 import * as AdhConfig from "../../Config/Config";
 import * as AdhHttp from "../../Http/Http";
-import * as AdhMovingColumns from "../../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../../Permissions/Permissions";
 import * as AdhResourceArea from "../../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../TopLevelState/TopLevelState";
@@ -97,8 +96,7 @@ export var proposalDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
@@ -112,8 +110,7 @@ export var proposalCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
@@ -126,8 +123,7 @@ export var proposalEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
@@ -141,8 +137,7 @@ export var detailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
@@ -155,8 +150,7 @@ export var editColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/EditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/IdeaCollection.ts
@@ -92,8 +92,6 @@ export var workbenchDirective = (
 
 export var proposalDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>,
-    adhPermissions : AdhPermissions.Service,
     adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
@@ -101,59 +99,65 @@ export var proposalDetailColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
     };
 };
 
 export var proposalCreateColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
 };
 
 export var proposalEditColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
     };
 };
 
 export var detailColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/DetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
 };
 
 export var editColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/EditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
 };

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
@@ -44,19 +44,13 @@ export var register = (angular) => {
         .directive("adhMeinberlinIdeaCollectionWorkbench", [
             "adhTopLevelState", "adhConfig", "adhHttp", IdeaCollection.workbenchDirective])
         .directive("adhMeinberlinIdeaCollectionProposalDetailColumn", [
-            "adhConfig",
-            "adhHttp",
-            "adhPermissions",
-            "adhTopLevelState",
-            "$location",
-            "$window",
-            "$translate",
-            IdeaCollection.proposalDetailColumnDirective])
+            "adhConfig", "adhTopLevelState", IdeaCollection.proposalDetailColumnDirective])
         .directive("adhMeinberlinIdeaCollectionProposalCreateColumn", [
-            "adhConfig", IdeaCollection.proposalCreateColumnDirective])
-        .directive("adhMeinberlinIdeaCollectionProposalEditColumn", ["adhConfig", IdeaCollection.proposalEditColumnDirective])
-        .directive("adhMeinberlinIdeaCollectionDetailColumn", ["adhConfig", IdeaCollection.detailColumnDirective])
-        .directive("adhMeinberlinIdeaCollectionEditColumn", ["adhConfig", IdeaCollection.editColumnDirective])
+            "adhConfig", "adhTopLevelState", IdeaCollection.proposalCreateColumnDirective])
+        .directive("adhMeinberlinIdeaCollectionProposalEditColumn", [
+            "adhConfig", "adhTopLevelState", IdeaCollection.proposalEditColumnDirective])
+        .directive("adhMeinberlinIdeaCollectionDetailColumn", ["adhConfig", "adhTopLevelState", IdeaCollection.detailColumnDirective])
+        .directive("adhMeinberlinIdeaCollectionEditColumn", ["adhConfig", "adhTopLevelState", IdeaCollection.editColumnDirective])
         .directive("adhMeinberlinIdeaCollectionAddProposalButton", [
             "adhConfig", "adhPermissions", "adhTopLevelState", IdeaCollection.addProposalButtonDirective])
         .config(["adhResourceAreaProvider", "adhConfig", (adhResourceAreaProvider: AdhResourceArea.Provider, adhConfig) => {

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Process.ts
@@ -6,7 +6,6 @@ import * as _ from "lodash";
 import * as AdhBadge from "../../../Badge/Badge";
 import * as AdhConfig from "../../../Config/Config";
 import * as AdhHttp from "../../../Http/Http";
-import * as AdhMovingColumns from "../../../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../../../Permissions/Permissions";
 import * as AdhProcess from "../../../Process/Process";
 import * as AdhUtil from "../../../Util/Util";
@@ -39,8 +38,7 @@ export var detailDirective = (
             isBuergerhaushalt: "=?",
             isKiezkasse: "=?"
         },
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             AdhBadge.getBadgeFacets(adhHttp, $q)(scope.path).then((facets) => {
                 scope.facets = facets;
             });
@@ -104,8 +102,7 @@ export var editDirective = (
         scope: {
             path: "@"
         },
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             var process;
             scope.data = {};
             scope.showError = adhShowError;

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Process.ts
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Process.ts
@@ -102,7 +102,7 @@ export var editDirective = (
         scope: {
             path: "@"
         },
-        link: (scope) => {
+        link: (scope, element) => {
             var process;
             scope.data = {};
             scope.showError = adhShowError;

--- a/src/mercator/mercator/static/js/Packages/Comment/Column.html
+++ b/src/mercator/mercator/static/js/Packages/Comment/Column.html
@@ -14,11 +14,4 @@
         data-path="{{commentableUrl}}"
         data-ng-switch-when="body">
     </adh-comment-listing>
-
-    <adh-report-abuse
-        data-ng-switch-when="overlays"
-        data-ng-if="overlay === 'abuse'"
-        data-modals="column"
-        data-url="{{ shared.abuseUrl | adhResourceUrl | adhCanonicalUrl }}">
-    </adh-report-abuse>
 </div>

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Module.ts
@@ -42,11 +42,11 @@ export var register = (angular) => {
         }])
         .directive("adhMercator2015Workbench", ["adhConfig", "adhTopLevelState", Workbench.workbenchDirective])
         .directive("adhMercator2015ProposalCreateColumn", [
-            "adhConfig", "adhResourceUrlFilter", "$location", Workbench.proposalCreateColumnDirective])
+            "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", "$location", Workbench.proposalCreateColumnDirective])
         .directive("adhMercator2015ProposalDetailColumn", [
             "adhTopLevelState", "adhPermissions", "adhConfig", Workbench.proposalDetailColumnDirective])
         .directive("adhMercator2015ProposalEditColumn", [
-            "adhConfig", "adhResourceUrlFilter", "$location", Workbench.proposalEditColumnDirective])
+            "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", "$location", Workbench.proposalEditColumnDirective])
         .directive("adhMercator2015ProposalListingColumn",
             ["adhConfig", "adhHttp", "adhTopLevelState", Workbench.proposalListingColumnDirective]);
 };

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Module.ts
@@ -44,7 +44,7 @@ export var register = (angular) => {
         .directive("adhMercator2015ProposalCreateColumn", [
             "adhConfig", "adhResourceUrlFilter", "$location", Workbench.proposalCreateColumnDirective])
         .directive("adhMercator2015ProposalDetailColumn", [
-            "$window", "adhTopLevelState", "adhPermissions", "adhConfig", Workbench.proposalDetailColumnDirective])
+            "adhTopLevelState", "adhPermissions", "adhConfig", Workbench.proposalDetailColumnDirective])
         .directive("adhMercator2015ProposalEditColumn", [
             "adhConfig", "adhResourceUrlFilter", "$location", Workbench.proposalEditColumnDirective])
         .directive("adhMercator2015ProposalListingColumn",

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
@@ -65,7 +65,6 @@ export var proposalCreateColumnDirective = (
 
 
 export var proposalDetailColumnDirective = (
-    $window : Window,
     adhTopLevelState : AdhTopLevelState.Service,
     adhPermissions : AdhPermissions.Service,
     adhConfig : AdhConfig.IService
@@ -80,12 +79,6 @@ export var proposalDetailColumnDirective = (
 
             scope.delete = () => {
                 column.$broadcast("triggerDelete", scope.proposalUrl);
-            };
-
-            scope.print = () => {
-                // only the focused column is printed
-                adhTopLevelState.set("focus", 1);
-                $window.print();
             };
         }
     };

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
@@ -49,6 +49,7 @@ var bindRedirectsToScope = (scope, adhConfig, adhResourceUrlFilter, $location) =
 
 export var proposalCreateColumnDirective = (
     adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service,
     adhResourceUrlFilter : (path : string) => string,
     $location : angular.ILocationService
 ) => {
@@ -57,7 +58,7 @@ export var proposalCreateColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["platformUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("platformUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
         }
     };
@@ -74,7 +75,8 @@ export var proposalDetailColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["platformUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("platformUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
             scope.delete = () => {
@@ -87,6 +89,7 @@ export var proposalDetailColumnDirective = (
 
 export var proposalEditColumnDirective = (
     adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service,
     adhResourceUrlFilter : (path : string) => string,
     $location : angular.ILocationService
 ) => {
@@ -95,7 +98,8 @@ export var proposalEditColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["platformUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("platformUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
         }
     };
@@ -112,7 +116,8 @@ export var proposalListingColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalListingColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["platformUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("platformUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             scope.contentType = RIMercatorProposalVersion.content_type;
 
             scope.sorts = [{

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
@@ -56,8 +56,7 @@ export var proposalCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("platformUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
         }
@@ -96,8 +95,7 @@ export var proposalEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("platformUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
@@ -114,8 +112,7 @@ export var proposalListingColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalListingColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("platformUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             scope.contentType = RIMercatorProposalVersion.content_type;

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Module.ts
@@ -45,13 +45,13 @@ export var register = (angular) => {
         }])
         .directive("adhMercator2016Workbench", ["adhConfig", "adhTopLevelState", Workbench.workbenchDirective])
         .directive("adhMercator2016ProposalCreateColumn", [
-            "adhConfig", "adhResourceUrlFilter", "$location", Workbench.proposalCreateColumnDirective])
+            "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", "$location", Workbench.proposalCreateColumnDirective])
         .directive("adhMercator2016ProposalDetailColumn", [
             "$window", "adhTopLevelState", "adhPermissions", "adhConfig", Workbench.proposalDetailColumnDirective])
         .directive("adhMercator2016ProposalModerateColumn", [
-            "adhConfig", "adhResourceUrlFilter", "$location", Workbench.proposalModerateColumnDirective])
+            "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", "$location", Workbench.proposalModerateColumnDirective])
         .directive("adhMercator2016ProposalEditColumn", [
-            "adhConfig", "adhResourceUrlFilter", "$location", Workbench.proposalEditColumnDirective])
+            "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", "$location", Workbench.proposalEditColumnDirective])
         .directive("adhMercator2016ProposalListingColumn",
             ["adhConfig", "adhHttp", "adhTopLevelState", Workbench.proposalListingColumnDirective])
         .directive("adhMercator2016AddProposalButton", [

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
@@ -61,8 +61,7 @@ export var proposalCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
         }
@@ -111,8 +110,7 @@ export var proposalEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
@@ -130,8 +128,7 @@ export var proposalModerateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalModerateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
@@ -148,8 +145,7 @@ export var proposalListingColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalListingColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             scope.contentType = RIProposal.content_type;

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
@@ -54,6 +54,7 @@ var bindRedirectsToScope = (scope, adhConfig, adhResourceUrlFilter, $location) =
 
 export var proposalCreateColumnDirective = (
     adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service,
     adhResourceUrlFilter : (path : string) => string,
     $location : angular.ILocationService
 ) => {
@@ -62,7 +63,7 @@ export var proposalCreateColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
         }
     };
@@ -80,7 +81,8 @@ export var proposalDetailColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
             adhPermissions.bindScope(scope, () => scope.proposalUrl, "proposalOptions");
 
@@ -102,6 +104,7 @@ export var proposalDetailColumnDirective = (
 
 export var proposalEditColumnDirective = (
     adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service,
     adhResourceUrlFilter : (path : string) => string,
     $location : angular.ILocationService
 ) => {
@@ -110,7 +113,8 @@ export var proposalEditColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
         }
     };
@@ -119,6 +123,7 @@ export var proposalEditColumnDirective = (
 
 export var proposalModerateColumnDirective = (
     adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service,
     adhResourceUrlFilter : (path : string) => string,
     $location : angular.ILocationService
 ) => {
@@ -127,7 +132,8 @@ export var proposalModerateColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalModerateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             bindRedirectsToScope(scope, adhConfig, adhResourceUrlFilter, $location);
         }
     };
@@ -144,7 +150,8 @@ export var proposalListingColumnDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalListingColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             scope.contentType = RIProposal.content_type;
 
             scope.sorts = [{

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/Module.ts
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/Module.ts
@@ -37,8 +37,10 @@ export var register = (angular) => {
                 "<adh-pcompass-workbench></adh-pcompass-workbench>";
         }])
         .directive("adhPcompassWorkbench", ["adhTopLevelState", "adhConfig", "adhHttp", Workbench.workbenchDirective])
-        .directive("adhPcompassProposalDetailColumn", ["adhConfig", "adhHttp", "adhPermissions", Workbench.proposalDetailColumnDirective])
-        .directive("adhPcompassProposalCreateColumn", ["adhConfig", Workbench.proposalCreateColumnDirective])
-        .directive("adhPcompassProposalEditColumn", ["adhConfig", Workbench.proposalEditColumnDirective])
-        .directive("adhPcompassProcessDetailColumn", ["adhConfig", "adhPermissions", Workbench.processDetailColumnDirective]);
+        .directive("adhPcompassProposalDetailColumn", [
+            "adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", Workbench.proposalDetailColumnDirective])
+        .directive("adhPcompassProposalCreateColumn", ["adhConfig", "adhTopLevelState", Workbench.proposalCreateColumnDirective])
+        .directive("adhPcompassProposalEditColumn", ["adhConfig", "adhTopLevelState", Workbench.proposalEditColumnDirective])
+        .directive("adhPcompassProcessDetailColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", Workbench.processDetailColumnDirective]);
 };

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalDetailColumn.html
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalDetailColumn.html
@@ -7,7 +7,7 @@
         <a
             class="moving-column-menu-button"
             data-ng-if="badgeAssignmentPoolOptions.POST"
-            data-ng-click="ctrl.toggleOverlay('badges')"
+            data-ng-click="ctrl.toggleModal('badges')"
             href="">{{ "TR__MANAGE_BADGE_ASSIGNMENTS" | translate }}</a>
 
         <div class="moving-column-menu-nav">

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/Workbench.ts
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/Workbench.ts
@@ -36,14 +36,16 @@ export var workbenchDirective = (
 export var proposalDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service<any>,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
 
             scope.column = column;
@@ -61,41 +63,45 @@ export var proposalDetailColumnDirective = (
 };
 
 export var proposalCreateColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
 };
 
 export var proposalEditColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
     };
 };
 
 export var processDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProcessDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             scope.contentType = RIProposalVersion.content_type;
         }

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/Workbench.ts
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/Workbench.ts
@@ -1,6 +1,5 @@
 import * as AdhConfig from "../../Config/Config";
 import * as AdhHttp from "../../Http/Http";
-import * as AdhMovingColumns from "../../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../../Permissions/Permissions";
 import * as AdhResourceArea from "../../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../TopLevelState/TopLevelState";
@@ -42,8 +41,7 @@ export var proposalDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
@@ -69,8 +67,7 @@ export var proposalCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
@@ -83,8 +80,7 @@ export var proposalEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
@@ -99,8 +95,7 @@ export var processDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProcessDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             scope.contentType = RIProposalVersion.content_type;

--- a/src/s1/s1/static/js/Packages/S1/Workbench/ArchiveColumn.html
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/ArchiveColumn.html
@@ -4,9 +4,8 @@
             data-ng-if="proposalState"
             data-state="{{proposalState}}"
             data-decision-date="{{decisionDate}}"
-            data-sort="shared.sort"
-            data-sorts="shared.sorts"
-            data-facets="shared.facets">
+            data-sorts="sorts"
+            data-facets="facets">
         </adh-s1-proposal-listing>
     </div>
 

--- a/src/s1/s1/static/js/Packages/S1/Workbench/CurrentColumn.html
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/CurrentColumn.html
@@ -4,9 +4,8 @@
             data-ng-if="proposalState"
             data-state="{{proposalState}}"
             data-decision-date="{{decisionDate}}"
-            data-sort="shared.sort"
-            data-sorts="shared.sorts"
-            data-facets="shared.facets">
+            data-sorts="sorts"
+            data-facets="facets">
         </adh-s1-proposal-listing>
     </div>
 

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Module.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Module.ts
@@ -28,10 +28,11 @@ export var register = (angular) => {
         }])
         .directive("adhS1Workbench", ["adhConfig", "adhTopLevelState", Workbench.s1WorkbenchDirective])
         .directive("adhS1Landing", ["$translate", "adhConfig", "adhTopLevelState", Workbench.s1LandingDirective])
-        .directive("adhS1CurrentColumn", ["adhConfig", "adhHttp", Workbench.s1CurrentColumnDirective])
-        .directive("adhS1NextColumn", ["adhConfig", "adhHttp", Workbench.s1NextColumnDirective])
-        .directive("adhS1ArchiveColumn", ["adhConfig", "adhHttp", Workbench.s1ArchiveColumnDirective])
-        .directive("adhS1ProposalDetailColumn", ["adhConfig", "adhPermissions", Workbench.s1ProposalDetailColumnDirective])
-        .directive("adhS1ProposalCreateColumn", ["adhConfig", Workbench.s1ProposalCreateColumnDirective])
-        .directive("adhS1ProposalEditColumn", ["adhConfig", Workbench.s1ProposalEditColumnDirective]);
+        .directive("adhS1CurrentColumn", ["adhConfig", "adhHttp", "adhTopLevelState", Workbench.s1CurrentColumnDirective])
+        .directive("adhS1NextColumn", ["adhConfig", "adhHttp", "adhTopLevelState", Workbench.s1NextColumnDirective])
+        .directive("adhS1ArchiveColumn", ["adhConfig", "adhHttp", "adhTopLevelState", Workbench.s1ArchiveColumnDirective])
+        .directive("adhS1ProposalDetailColumn", [
+            "adhConfig", "adhPermissions", "adhTopLevelState", Workbench.s1ProposalDetailColumnDirective])
+        .directive("adhS1ProposalCreateColumn", ["adhConfig", "adhTopLevelState", Workbench.s1ProposalCreateColumnDirective])
+        .directive("adhS1ProposalEditColumn", ["adhConfig", "adhTopLevelState", Workbench.s1ProposalEditColumnDirective]);
 };

--- a/src/s1/s1/static/js/Packages/S1/Workbench/NextColumn.html
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/NextColumn.html
@@ -8,9 +8,8 @@
             data-ng-if="proposalState"
             data-state="{{proposalState}}"
             data-decision-date="{{decisionDate}}"
-            data-sort="shared.sort"
-            data-sorts="shared.sorts"
-            data-facets="shared.facets">
+            data-sorts="sorts"
+            data-facets="facets">
         </adh-s1-proposal-listing>
     </div>
 

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
@@ -66,7 +66,7 @@ export var s1CurrentColumnDirective = (
                 });
             });
 
-            scope.shared.sorts = [{
+            scope.sorts = [{
                 key: "rates",
                 name: "TR__RATES",
                 index: "rates",
@@ -82,11 +82,6 @@ export var s1CurrentColumnDirective = (
                 index: "item_creation_date",
                 reverse: true
             }];
-
-            scope.shared.sort = "rates";
-            scope.shared.setSort = (sort : string) => {
-                scope.shared.sort = sort;
-            };
         }
     };
 };
@@ -116,7 +111,7 @@ export var s1NextColumnDirective = (
                 });
             });
 
-            scope.shared.sorts = [{
+            scope.sorts = [{
                 key: "rates",
                 name: "TR__RATES",
                 index: "rates",
@@ -127,11 +122,6 @@ export var s1NextColumnDirective = (
                 index: "item_creation_date",
                 reverse: true
             }];
-
-            scope.shared.sort = "rates";
-            scope.shared.setSort = (sort : string) => {
-                scope.shared.sort = sort;
-            };
         }
     };
 };
@@ -162,7 +152,7 @@ export var s1ArchiveColumnDirective = (
                 });
             });
 
-            scope.shared.facets = [{
+            scope.facets = [{
                 key: "workflow_state",
                 name: "TR__S1_FACET_STATE_HEADER",
                 items: [
@@ -171,7 +161,7 @@ export var s1ArchiveColumnDirective = (
                 ]
             }];
 
-            scope.shared.sorts = [{
+            scope.sorts = [{
                 key: "rates",
                 name: "TR__RATES",
                 index: "rates",
@@ -182,11 +172,6 @@ export var s1ArchiveColumnDirective = (
                 index: "item_creation_date",
                 reverse: true
             }];
-
-            scope.shared.sort = "rates";
-            scope.shared.setSort = (sort : string) => {
-                scope.shared.sort = sort;
-            };
         }
     };
 };

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
@@ -2,7 +2,6 @@
 
 import * as AdhConfig from "../../Config/Config";
 import * as AdhHttp from "../../Http/Http";
-import * as AdhMovingColumns from "../../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../../Permissions/Permissions";
 import * as AdhProcess from "../../Process/Process";
 import * as AdhResourceArea from "../../ResourceArea/ResourceArea";
@@ -45,8 +44,7 @@ export var s1CurrentColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/CurrentColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.contentType = RIProposalVersion.content_type;
 
@@ -96,8 +94,7 @@ export var s1NextColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/NextColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.contentType = RIProposalVersion.content_type;
 
@@ -137,8 +134,7 @@ export var s1ArchiveColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ArchiveColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.contentType = RIProposalVersion.content_type;
 
@@ -188,8 +184,7 @@ export var s1ProposalDetailColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("meeting", scope));
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
@@ -205,8 +200,7 @@ export var s1ProposalCreateColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
@@ -219,8 +213,7 @@ export var s1ProposalEditColumnDirective = (
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
-        require: "^adhMovingColumn",
-        link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
+        link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
@@ -39,14 +39,15 @@ export var s1WorkbenchDirective = (
 
 export var s1CurrentColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/CurrentColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.contentType = RIProposalVersion.content_type;
 
             scope.$watch("processUrl", (processUrl : string) => {
@@ -89,14 +90,15 @@ export var s1CurrentColumnDirective = (
 
 export var s1NextColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/NextColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.contentType = RIProposalVersion.content_type;
 
             scope.$watch("processUrl", (processUrl : string) => {
@@ -129,14 +131,15 @@ export var s1NextColumnDirective = (
 
 export var s1ArchiveColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhHttp : AdhHttp.Service<any>
+    adhHttp : AdhHttp.Service<any>,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ArchiveColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.contentType = RIProposalVersion.content_type;
 
             scope.$watch("processUrl", (processUrl : string) => {
@@ -179,41 +182,47 @@ export var s1ArchiveColumnDirective = (
 
 export var s1ProposalDetailColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalDetailColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["meeting", "processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("meeting", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
             adhPermissions.bindScope(scope, () => scope.proposalUrl && AdhUtil.parentPath(scope.proposalUrl), "proposalItemOptions");
         }
     };
 };
 
 export var s1ProposalCreateColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalCreateColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
         }
     };
 };
 
 export var s1ProposalEditColumnDirective = (
-    adhConfig : AdhConfig.IService
+    adhConfig : AdhConfig.IService,
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ProposalEditColumn.html",
         require: "^adhMovingColumn",
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
-            column.bindVariablesAndClear(scope, ["processUrl", "proposalUrl"]);
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("proposalUrl", scope));
         }
     };
 };

--- a/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
+++ b/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
@@ -15,8 +15,8 @@
                 data-ng-click="modals.toggleModal('messaging')"
                 data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
         </div>
-        <ul class="moving-column-alerts">
-            <li data-ng-repeat="(id, alert) in modals.alerts" class="moving-column-alert m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
+        <ul class="alerts">
+            <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">
                 {{ alert.message | translate }}
             </li>
         </ul>

--- a/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
+++ b/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
@@ -20,7 +20,7 @@
                 {{ alert.message | translate }}
             </li>
         </ul>
-        <div class="action-bar-modal" data-ng-if="modals.modal">
+        <div class="modal" data-ng-if="modals.modal">
             <adh-user-message
                 data-ng-if="modals.modal === 'messaging'"
                 data-modals="modals"

--- a/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
+++ b/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
@@ -12,7 +12,7 @@
             <a
                 class="action-bar-item"
                 href=""
-                data-ng-click="modals.toggleOverlay('messaging')"
+                data-ng-click="modals.toggleModal('messaging')"
                 data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
         </div>
         <ul class="moving-column-alerts">
@@ -20,9 +20,9 @@
                 {{ alert.message | translate }}
             </li>
         </ul>
-        <div class="action-bar-modal" data-ng-if="modals.overlay">
+        <div class="action-bar-modal" data-ng-if="modals.modal">
             <adh-user-message
-                data-ng-if="modals.overlay === 'messaging'"
+                data-ng-if="modals.modal === 'messaging'"
                 data-modals="modals"
                 data-recipient-url="{{userUrl}}">
             </adh-user-message>


### PR DESCRIPTION
For quite some pull requests (#2451, #2454, #2456, #2458, #2459, #2468) we have now been switch from the previous column based overlay concept to a new local modal concept. Now that everything is merged, this pull request does some overall refactoring.

I had originally planned to split this into more than one pull request, but I kept it together in order to avoid merge conflicts. If you prefer to review/merge in small steps, I will happily split this up.

-  b04adec, 6baf005, d39a720: cleaning up behind some of the previous pull requests
-  e78979c, 531ab05: change wording from "overlay" to "modal"
-  b76fc7e, 15fd00a, ae81d23, 838926b, 57e6b3a, dc5bbcb remove legacy functionality from moving columns (I know this is awefult for review, really sorry)
-  e8c6699, f4aa9a2: refactor CSS

Note that pcompass and euth are still using the legacy system. I ignored that for this pull request and trusted that we will do sensible merging.