### PR TITLE
add flag "autoupdated" to transaction changelog entries

### DIFF
--- a/src/adhocracy_core/adhocracy_core/changelog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/__init__.py
@@ -1,18 +1,7 @@
 """Transaction changelog for resources."""
 from collections import defaultdict
-from adhocracy_core.interfaces import ChangelogMetadata
-from adhocracy_core.interfaces import VisibilityChange
 
-changelog_meta = ChangelogMetadata(modified=False,
-                                   created=False,
-                                   autoupdated=False,
-                                   followed_by=None,
-                                   resource=None,
-                                   last_version=None,
-                                   changed_descendants=False,
-                                   changed_backrefs=False,
-                                   visibility=VisibilityChange.visible,
-                                   )
+from adhocracy_core.interfaces import changelog_meta
 
 
 class Changelog(defaultdict):

--- a/src/adhocracy_core/adhocracy_core/changelog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/__init__.py
@@ -5,6 +5,7 @@ from adhocracy_core.interfaces import VisibilityChange
 
 changelog_meta = ChangelogMetadata(modified=False,
                                    created=False,
+                                   autoupdated=False,
                                    followed_by=None,
                                    resource=None,
                                    last_version=None,

--- a/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
@@ -28,6 +28,7 @@ def add_changelog_created(event):
     parent = event.object.__parent__
     if parent is not None:
         _add_changelog(event.registry, parent, key='modified', value=True)
+        _add_changelog(event.registry, parent, key='autoupdated', value=True)
 
 
 def add_changelog_modified_and_descendants(event):

--- a/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
@@ -137,6 +137,8 @@ def includeme(config):
     """Register subscriber to update transaction changelog."""
     config.add_subscriber(add_changelog_created,
                           IResourceCreatedAndAdded)
+    config.add_subscriber(add_changelog_autoupdated,
+                          IResourceCreatedAndAdded)
     config.add_subscriber(add_changelog_modified_and_descendants,
                           IResourceSheetModified)
     config.add_subscriber(add_changelog_autoupdated,

--- a/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/subscriber.py
@@ -125,17 +125,28 @@ def _mark_referenced_resources_as_changed(resource: IResource,
             _add_changelog_backrefs_for_resource(ref.target, registry)
 
 
+def add_changelog_autoupdated(event):
+    """Add autoupdated message to the transaction_changelog."""
+    _add_changelog(event.registry, event.object,
+                   key='autoupdated',
+                   value=event.autoupdated)
+
+
 def includeme(config):
     """Register subscriber to update transaction changelog."""
     config.add_subscriber(add_changelog_created,
                           IResourceCreatedAndAdded)
     config.add_subscriber(add_changelog_modified_and_descendants,
                           IResourceSheetModified)
+    config.add_subscriber(add_changelog_autoupdated,
+                          IResourceSheetModified)
     config.add_subscriber(add_changelog_modified_and_descendants,
                           ACLModified)
     config.add_subscriber(add_changelog_backrefs,
                           ISheetBackReferenceModified)
     config.add_subscriber(add_changelog_followed,
+                          IItemVersionNewVersionAdded)
+    config.add_subscriber(add_changelog_autoupdated,
                           IItemVersionNewVersionAdded)
     config.add_subscriber(add_changelog_visibility,
                           IResourceSheetModified,

--- a/src/adhocracy_core/adhocracy_core/changelog/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/test_init.py
@@ -5,7 +5,7 @@ from pyramid import testing
 
 def test_changelog_create():
     from . import Changelog
-    from . import changelog_meta
+    from adhocracy_core.interfaces import changelog_meta
     inst = Changelog()
     assert inst['/path/'] == changelog_meta
 
@@ -52,7 +52,7 @@ def test_create_changelog():
 
 def test_create_changelog_mapping():
     from adhocracy_core.changelog import create_changelog
-    from adhocracy_core.changelog import changelog_meta
+    from adhocracy_core.interfaces import changelog_meta
     from collections import defaultdict
     changelog = create_changelog()
     assert changelog['/'] == changelog_meta

--- a/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
@@ -172,6 +172,20 @@ def test_add_changelog_visibility(event, changelog, mock_visibility):
     assert changelog['/'].visibility == 'consealed'
 
 
+def test_add_changelog_autoupaded_true(event, changelog):
+    from .subscriber import add_changelog_autoupdated
+    event.autoupdated = True
+    add_changelog_autoupdated(event)
+    assert changelog['/'].autoupdated
+
+
+def test_add_changelog_autoupaded_false(event, changelog):
+    from .subscriber import add_changelog_autoupdated
+    event.autoupdated = False
+    add_changelog_autoupdated(event)
+    assert not changelog['/'].autoupdated
+
+
 @fixture()
 def integration(config):
     config.include('adhocracy_core.events')
@@ -187,3 +201,4 @@ def test_register_subscriber(registry):
     assert subscriber.add_changelog_modified_and_descendants.__name__ in handlers
     assert subscriber.add_changelog_backrefs.__name__ in handlers
     assert subscriber.add_changelog_visibility.__name__ in handlers
+    assert subscriber.add_changelog_autoupdated.__name__ in handlers

--- a/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
@@ -34,6 +34,7 @@ def test_add_changelog_created_with_parent(event, pool, changelog):
     event.object.__parent__ = pool
     add_changelog_created(event)
     assert changelog['parent'].modified is True
+    assert changelog['parent'].autoupdated is True
 
 
 def test_add_changelog_followed_with_item_parent(event, item, changelog):

--- a/src/adhocracy_core/adhocracy_core/events/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/events/__init__.py
@@ -64,6 +64,7 @@ class ResourceSheetModified:
     :param registry: pyramid.registry.Registry
     :param old_appstruct: The old :term:`appstruct` data (dict)
     :param new_appstruct: The new :term:`appstruct` data (dict)
+    :param request: The current request or None
     :param: autoupdated(bool): The modification was caused by a modified
         referenced resource.
     """

--- a/src/adhocracy_core/adhocracy_core/events/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/events/__init__.py
@@ -64,7 +64,8 @@ class ResourceSheetModified:
     :param registry: pyramid.registry.Registry
     :param old_appstruct: The old :term:`appstruct` data (dict)
     :param new_appstruct: The new :term:`appstruct` data (dict)
-    :param request: The current request or None
+    :param: autoupdated(bool): The modification was caused by a modified
+        referenced resource.
     """
 
     def __init__(self,
@@ -73,7 +74,8 @@ class ResourceSheetModified:
                  registry,
                  old_appstruct,
                  new_appstruct,
-                 request: Request):
+                 request: Request,
+                 autoupdated: bool):
         """Initialize self."""
         self.object = object
         self.isheet = isheet
@@ -81,6 +83,7 @@ class ResourceSheetModified:
         self.old_appstruct = old_appstruct
         self.new_appstruct = new_appstruct
         self.request = request
+        self.autoupdated = autoupdated
 
 
 @implementer(IItemVersionNewVersionAdded)
@@ -91,14 +94,17 @@ class ItemVersionNewVersionAdded:
     :param new_version(adhocracy_core.interfaces.IItemVersion):
     :param registry(pyramid.registry.Registry):
     :param creator(adhocracy_core.resource.principal.IUser':
+    :param: autoupdated(bool): The modification was caused by a modified
+        referenced resource.
     """
 
-    def __init__(self, object, new_version, registry, creator):
+    def __init__(self, object, new_version, registry, creator, autoupdated):
         """Initialize self."""
         self.object = object
         self.new_version = new_version
         self.registry = registry
         self.creator = creator
+        self.autoupdated = autoupdated
 
 
 @implementer(ISheetReferenceNewVersion)

--- a/src/adhocracy_core/adhocracy_core/events/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/events/__init__.py
@@ -29,14 +29,18 @@ class ResourceCreatedAndAdded:
     :param parent(adhocracy_core.interfaces.IResource):
     :param registry(pyramid.registry.Registry):
     :param creator(adhocracy_core.resource.principal.IUser):
+    :param: autoupdated(bool): The creation was caused by the application,
+        for example :term:`service` resources or automatic updates of
+        referencing resources.
     """
 
-    def __init__(self, object, parent, registry, creator):
+    def __init__(self, object, parent, registry, creator, autoupdated):
         """Initialize self."""
         self.object = object
         self.parent = parent
         self.registry = registry
         self.creator = creator
+        self.autoupdated = autoupdated
 
 
 @implementer(IResourceWillBeDeleted)

--- a/src/adhocracy_core/adhocracy_core/events/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/events/test_init.py
@@ -16,8 +16,9 @@ class ResourceCreatedAndAddedUnitTest(unittest.TestCase):
         parent = testing.DummyResource()
         registry = testing.DummyResource()
         creator = testing.DummyResource()
+        autoupdated = True
 
-        inst = self.make_one(context, parent, registry, creator)
+        inst = self.make_one(context, parent, registry, creator, autoupdated)
 
         assert IResourceCreatedAndAdded.providedBy(inst)
         assert verifyObject(IResourceCreatedAndAdded, inst)

--- a/src/adhocracy_core/adhocracy_core/events/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/events/test_init.py
@@ -55,9 +55,10 @@ class ResourceSheetModifiedUnitTest(unittest.TestCase):
         request = testing.DummyResource()
         old_appstruct = {}
         new_appstruct = {}
+        autoupdated = True
 
         inst = self.make_one(context, parent, registry, old_appstruct,
-                              new_appstruct, request)
+                              new_appstruct, request, autoupdated)
 
         assert IResourceSheetModified.providedBy(inst)
         assert verifyObject(IResourceSheetModified, inst)
@@ -66,6 +67,7 @@ class ResourceSheetModifiedUnitTest(unittest.TestCase):
         assert inst.old_appstruct is old_appstruct
         assert inst.new_appstruct is new_appstruct
         assert inst.request is request
+        assert inst.autoupdated
 
 
 class ItemNewVersionAddedUnitTest(unittest.TestCase):
@@ -80,8 +82,10 @@ class ItemNewVersionAddedUnitTest(unittest.TestCase):
         new_version = testing.DummyResource()
         registry = testing.DummyResource()
         creator = testing.DummyResource()
+        autoupdated = True
 
-        inst = self.make_one(context, new_version, registry, creator)
+        inst = self.make_one(context, new_version, registry, creator,
+                             autoupdated)
 
         assert IItemVersionNewVersionAdded.providedBy(inst)
         assert verifyObject(IItemVersionNewVersionAdded, inst)

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -587,6 +587,7 @@ class VisibilityChange(Enum):
 class ChangelogMetadata(namedtuple('ChangelogMetadata',
                                    ['modified',
                                     'created',
+                                    'autoupdated',
                                     'followed_by',
                                     'resource',
                                     'last_version',
@@ -603,6 +604,9 @@ class ChangelogMetadata(namedtuple('ChangelogMetadata',
         modified.
     created (bool):
         This resource is created and added to a pool.
+    autoupdated (bool):
+        The modification/creation was caused by a modified referenced
+        resource. This means there is no real content change.
     followed_by (None or IResource):
         A new Version (:class:`adhocracy_core.interfaces.IItemVersion`) follows
         this resource

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -482,6 +482,7 @@ class IResourceCreatedAndAdded(IObjectEvent):
     parent = Attribute('The parent of the new resource')
     registry = Attribute('The pyramid registry')
     creator = Attribute('User resource object of the authenticated User')
+    autoupdated = Attribute('Creation was caused automatically by application')
 
 
 class IResourceWillBeDeleted(IObjectEvent):

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -594,6 +594,21 @@ class ChangelogMetadata(namedtuple('ChangelogMetadata',
                                     'changed_descendants',
                                     'changed_backrefs',
                                     'visibility'])):
+    def __new__(cls,
+                modified: bool=False,
+                created: bool=False,
+                autoupdated: bool=False,
+                followed_by: IResource=None,
+                resource: IResource=None,
+                last_version: IResource=None,
+                changed_descendants: bool=False,
+                changed_backrefs: bool=False,
+                visibility: str=VisibilityChange.visible,
+                ):
+        return super().__new__(cls, modified, created, autoupdated,
+                               followed_by, resource, last_version,
+                               changed_descendants, changed_backrefs,
+                               visibility)
     """Metadata to track modified resources during one transaction.
 
     Fields:
@@ -622,6 +637,9 @@ class ChangelogMetadata(namedtuple('ChangelogMetadata',
     visibility (VisibilityChange):
         Tracks the visibility of the resource and whether it has changed
     """
+
+
+changelog_meta = ChangelogMetadata()
 
 
 class AuditlogEntry(namedtuple('AuditlogEntry', ['name',

--- a/src/adhocracy_core/adhocracy_core/resources/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/resources/__init__.py
@@ -124,14 +124,16 @@ class ResourceFactory:
                    registry=registry)
 
     def _notify_new_resource_created_and_added(self, resource, registry,
-                                               creator):
+                                               creator, autoupdated):
         has_parent = resource.__parent__ is not None
         is_root = IRoot.providedBy(resource)
         if (has_parent or is_root) and registry is not None:
             event = ResourceCreatedAndAdded(object=resource,
                                             parent=resource.__parent__,
                                             registry=registry,
-                                            creator=creator)
+                                            creator=creator,
+                                            autoupdated=autoupdated,
+                                            )
             registry.notify(event)
 
     def __call__(self,
@@ -240,7 +242,9 @@ class ResourceFactory:
         if send_event:
             self._notify_new_resource_created_and_added(resource,
                                                         registry,
-                                                        creator)
+                                                        creator,
+                                                        autoupdated,
+                                                        )
 
         return resource
 

--- a/src/adhocracy_core/adhocracy_core/resources/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/resources/__init__.py
@@ -142,6 +142,7 @@ class ResourceFactory:
                  registry=None,
                  request=None,
                  send_event=True,
+                 autoupdated=False,
                  **kwargs
                  ):
         """Triggered when a ResourceFactory instance is called.
@@ -168,9 +169,12 @@ class ResourceFactory:
             send_event (bool): send
                 :class:`adhocracy_core.interfaces.IResourceCreatedAndAdded`
                 event. Default is True.
+            autoupdated (bool): The creation is caused by a modified
+                referenced resource, no real content is modified.
+                Default is False.
             **kwargs: Arbitary keyword arguments. Will be passed along with
-                       'creator' to the `after_creation` hook as 3rd argument
-                      `options`.
+-               `creator` and  `autoupdated` to the `after_creation` hook as
+                3rd argument `options`.
 
         Returns:
             object (IResource): the newly created resource
@@ -228,6 +232,7 @@ class ResourceFactory:
         if run_after_creation:
             for call in self.meta.after_creation:
                 kwargs['creator'] = creator
+                kwargs['autoupdated'] = autoupdated
                 call(resource, registry, options=kwargs)
 
         if send_event:

--- a/src/adhocracy_core/adhocracy_core/resources/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/resources/__init__.py
@@ -206,7 +206,7 @@ class ResourceFactory:
             sheet = registry.content.get_sheet(resource, isheet,
                                                request=request)
             if sheet.meta.creatable:
-                sheet.set(struct, send_event=False)
+                sheet.set(struct, send_event=False, autoupdated=autoupdated)
 
         # Fixme: Sideffect. We change here the passed creator because the
         # creator of user resources should always be the created user.
@@ -227,7 +227,9 @@ class ResourceFactory:
                                                request=request)
             sheet.set(metadata,
                       send_event=False,
-                      omit_readonly=False)
+                      omit_readonly=False,
+                      autoupdated=autoupdated
+                      )
 
         if run_after_creation:
             for call in self.meta.after_creation:

--- a/src/adhocracy_core/adhocracy_core/resources/asset.py
+++ b/src/adhocracy_core/adhocracy_core/resources/asset.py
@@ -109,8 +109,10 @@ deprecated('IPoolWithAssets', 'Backward compatible code, use process instead')
 
 def add_assets_service(context: IPool, registry: Registry, options: dict):
     """Add `assets` service to context."""
-    registry.content.create(IAssetsService.__identifier__, parent=context,
-                            registry=registry)
+    registry.content.create(IAssetsService.__identifier__,
+                            parent=context,
+                            registry=registry,
+                            autoupdated=True)
 
 
 pool_with_assets_meta = pool_meta._replace(

--- a/src/adhocracy_core/adhocracy_core/resources/badge.py
+++ b/src/adhocracy_core/adhocracy_core/resources/badge.py
@@ -78,8 +78,11 @@ badges_service_meta = service_meta._replace(
 def add_badges_service(context: IPool, registry: Registry, options: dict):
     """Add `badge` service to context."""
     creator = options.get('creator')
-    registry.content.create(IBadgesService.__identifier__, parent=context,
-                            registry=registry, creator=creator)
+    registry.content.create(IBadgesService.__identifier__,
+                            parent=context,
+                            registry=registry,
+                            creator=creator,
+                            autoupdated=True)
 
 
 class IBadgeAssignment(ISimple):

--- a/src/adhocracy_core/adhocracy_core/resources/comment.py
+++ b/src/adhocracy_core/adhocracy_core/resources/comment.py
@@ -60,7 +60,9 @@ comments_meta = service_meta._replace(
 
 def add_commentsservice(context: IPool, registry: Registry, options: dict):
     """Add `comments` service to context."""
-    registry.content.create(ICommentsService.__identifier__, parent=context)
+    registry.content.create(ICommentsService.__identifier__,
+                            parent=context,
+                            autoupdated=True)
 
 
 def includeme(config):

--- a/src/adhocracy_core/adhocracy_core/resources/item.py
+++ b/src/adhocracy_core/adhocracy_core/resources/item.py
@@ -25,7 +25,8 @@ def create_initial_content_for_item(context, registry, options):
                                             request=request,
                                             )
     tags_sheet.set({'FIRST': first_version,
-                    'LAST': first_version})
+                    'LAST': first_version},
+                   autoupdated=True)
 
 
 item_meta = pool_meta._replace(

--- a/src/adhocracy_core/adhocracy_core/resources/itemversion.py
+++ b/src/adhocracy_core/adhocracy_core/resources/itemversion.py
@@ -30,7 +30,7 @@ def update_last_tag(version, registry, options):
     tags_sheet = registry.content.get_sheet(item,
                                             adhocracy_core.sheets.tags.ITags,
                                             request=request)
-    tags_sheet.set({'LAST': version})
+    tags_sheet.set({'LAST': version}, autoupdated=True)
 
 
 def notify_new_itemversion_created(context, registry, options):

--- a/src/adhocracy_core/adhocracy_core/resources/itemversion.py
+++ b/src/adhocracy_core/adhocracy_core/resources/itemversion.py
@@ -46,7 +46,8 @@ def notify_new_itemversion_created(context, registry, options):
             decide whether they should update themselfes.
         creator:
             User resource that passed to the creation events.
-
+        autupdated:
+            Flag passed to the creation events
     :return: None
 
     """
@@ -54,13 +55,14 @@ def notify_new_itemversion_created(context, registry, options):
     root_versions = options.get('root_versions', [])
     creator = options.get('creator', None)
     is_batchmode = options.get('is_batchmode', False)
+    autoupdated = options['autoupdated']
     old_versions = []
     versionable = registry.content.get_sheet(context, IVersionable)
     follows = versionable.get()['follows']
     for old_version in follows:
         old_versions.append(old_version)
         _notify_itemversion_has_new_version(old_version, new_version, registry,
-                                            creator)
+                                            creator, autoupdated)
         _notify_referencing_resources_about_new_version(old_version,
                                                         new_version,
                                                         root_versions,
@@ -69,13 +71,13 @@ def notify_new_itemversion_created(context, registry, options):
                                                         is_batchmode)
     if follows == []:
         _notify_itemversion_has_new_version(None, new_version, registry,
-                                            creator)
+                                            creator, autoupdated)
 
 
 def _notify_itemversion_has_new_version(old_version, new_version, registry,
-                                        creator):
+                                        creator, autoupdated):
     event = ItemVersionNewVersionAdded(old_version, new_version, registry,
-                                       creator)
+                                       creator, autoupdated)
     registry.notify(event)
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/logbook.py
+++ b/src/adhocracy_core/adhocracy_core/resources/logbook.py
@@ -24,6 +24,7 @@ def add_logbook_service(context: IPool, registry: Registry, options: dict):
     creator = options.get('creator')
     registry.content.create(ILogbookService.__identifier__,
                             parent=context,
+                            autoupdated=True,
                             creator=creator)
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/rate.py
+++ b/src/adhocracy_core/adhocracy_core/resources/rate.py
@@ -51,7 +51,9 @@ rates_meta = service_meta._replace(
 
 def add_ratesservice(context: IPool, registry: Registry, options: dict):
     """Add `rates` service to context."""
-    registry.content.create(IRatesService.__identifier__, parent=context)
+    registry.content.create(IRatesService.__identifier__,
+                            autoupdated=True,
+                            parent=context)
 
 
 def includeme(config):

--- a/src/adhocracy_core/adhocracy_core/resources/relation.py
+++ b/src/adhocracy_core/adhocracy_core/resources/relation.py
@@ -68,6 +68,7 @@ def add_relationsservice(context: IPool,
                          options: dict):
     """Add `relations` service to context."""
     registry.content.create(IRelationsService.__identifier__,
+                            autoupdated=True,
                             parent=context)
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/resources/subscriber.py
@@ -225,6 +225,7 @@ def _create_new_version(event, appstruct) -> IResource:
                                           registry=event.registry,
                                           root_versions=event.root_versions,
                                           is_batchmode=event.is_batchmode,
+                                          autoupdated=True,
                                           )
     return new_version
 
@@ -248,7 +249,7 @@ def autoupdate_non_versionable_has_new_version(event):
     if not sheet.meta.editable:
         return
     appstruct = _get_updated_appstruct(event, sheet)
-    sheet.set(appstruct)
+    sheet.set(appstruct, autoupdated=True)
 
 
 def send_password_reset_mail(event):

--- a/src/adhocracy_core/adhocracy_core/resources/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_init.py
@@ -130,7 +130,9 @@ class TestResourceFactory:
 
         inst = self.make_one(meta)(creator=None, kwarg1=True)
 
-        assert inst._options == {'kwarg1': True, 'creator': None}
+        assert inst._options == {'kwarg1': True,
+                                 'creator': None,
+                                 'autoupdated': False}
         assert inst._registry is registry
 
     def test_call_without_run_after_create(self, resource_meta):

--- a/src/adhocracy_core/adhocracy_core/resources/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_init.py
@@ -368,11 +368,13 @@ class TestResourceFactory:
         meta = resource_meta._replace(iresource=IResource, use_autonaming=True)
         user = testing.DummyResource()
 
-        resource = self.make_one(meta)(parent=pool, creator=user)
+        resource = self.make_one(meta)(parent=pool, creator=user,
+                                       autoupdated=True)
 
         assert IResourceCreatedAndAdded.providedBy(events[0])
         assert events[0].object == resource
         assert events[0].parent == pool
+        assert events[0].autoupdated is True
 
     def test_notify_new_resource_created_and_added_ignore_if_not_send_event(
             self, resource_meta, config, pool):

--- a/src/adhocracy_core/adhocracy_core/resources/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_init.py
@@ -128,12 +128,21 @@ class TestResourceFactory:
         meta = resource_meta._replace(iresource=IResource,
                                       after_creation=(dummy_after_create,))
 
-        inst = self.make_one(meta)(creator=None, kwarg1=True)
+        inst = self.make_one(meta)(kwarg1=True)
 
-        assert inst._options == {'kwarg1': True,
-                                 'creator': None,
-                                 'autoupdated': False}
+        assert inst._options['kwarg1']
+        assert inst._options['creator'] is None
+        assert not inst._options['autoupdated']
         assert inst._registry is registry
+
+    def test_call_with_after_create_and_autoupdate(self, resource_meta,
+                                                   registry):
+        def dummy_after_create(context, registry, options):
+            context._options = options
+        meta = resource_meta._replace(iresource=IResource,
+                                      after_creation=(dummy_after_create,))
+        inst = self.make_one(meta)(autoupdated=True)
+        assert inst._options['autoupdated']
 
     def test_call_without_run_after_create(self, resource_meta):
         def dummy_after_create(context, registry, options):

--- a/src/adhocracy_core/adhocracy_core/rest/schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/schemas.py
@@ -466,8 +466,9 @@ def create_validate_activation_path(context,
             # TODO we should use a sheet to activate the user.
             user.activate()
             user.activation_path = None
+            autoupdated = False
             event = ResourceSheetModified(user, IUserBasic, request.registry, {},
-                                          {}, request)
+                                          {}, request, autoupdated)
             registry.notify(event)  # trigger reindex activation_path index
     return validate_activation_path
 

--- a/src/adhocracy_core/adhocracy_core/sheets/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/__init__.py
@@ -175,7 +175,9 @@ class BaseResourceSheet:
             omit=(),
             send_event=True,
             send_reference_event=True,
-            omit_readonly: bool=True) -> bool:
+            omit_readonly: bool=True,
+            autoupdated=False,
+            ) -> bool:
         """Store appstruct.
 
         Read :func:`adhocracy_core.interfaces.IResourceSheet.set`
@@ -195,7 +197,9 @@ class BaseResourceSheet:
                                           self.registry,
                                           appstruct_old,
                                           appstruct,
-                                          self.request)
+                                          self.request,
+                                          autoupdated,
+                                          )
             self.registry.notify(event)
         return bool(appstruct)
 

--- a/src/adhocracy_core/adhocracy_core/sheets/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_init.py
@@ -323,6 +323,14 @@ class TestBaseResourceSheet:
         assert events[0].registry == config.registry
         assert events[0].old_appstruct == {'count': 0}
         assert events[0].new_appstruct == {'count': 2}
+        assert events[0].autoupdated is False
+
+    def test_notify_resource_sheet_modified_autoupdated(self, inst, config):
+        from adhocracy_core.interfaces import IResourceSheetModified
+        from adhocracy_core.testing import create_event_listener
+        events = create_event_listener(config, IResourceSheetModified)
+        inst.set({'count': 2}, autoupdated=True)
+        assert events[0].autoupdated
 
     def test_serialize(self, inst, request_):
         from . import BaseResourceSheet

--- a/src/adhocracy_core/adhocracy_core/utils/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/utils/test_init.py
@@ -196,7 +196,9 @@ class TestGetVisibilityChange:
                                       registry=None,
                                       old_appstruct={},
                                       new_appstruct={},
-                                      request=None)
+                                      request=None,
+                                      autoupdated=False,
+                                      )
         return event
 
     def call_fut(self, event):

--- a/src/adhocracy_core/adhocracy_core/websockets/test_client.py
+++ b/src/adhocracy_core/adhocracy_core/websockets/test_client.py
@@ -50,7 +50,7 @@ class SendMessageAfterCommitUnitTests(unittest.TestCase):
 
     def setUp(self):
         from pyramid.testing import DummyResource
-        from adhocracy_core.changelog import changelog_meta
+        from adhocracy_core.interfaces import changelog_meta
         self._client = DummyClient()
         self._registry = DummyResource()
         self._registry.ws_client = self._client


### PR DESCRIPTION
Internal changes:

- add flag 'autoupdated' to ChangeLogMetadata tuples (transaction changelog) and IResourceModified/IItemNewVersionAdded events. 
  It is True if the resource creation or modification was caused by autoupdateing versionable resources. This allows us to filter entries without changed content (For example  new rate versions triggerd by a new proposal version).