### PR TITLE
abstract resource actions

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
@@ -15,8 +15,7 @@ export var register = (angular) => {
         ])
         .directive("adhResourceActions", [
             "$timeout", "adhConfig", "adhPermissions", AdhResourceActions.resourceActionsDirective])
-        .directive("adhReportAction", [AdhResourceActions.reportActionDirective])
-        .directive("adhShareAction", [AdhResourceActions.shareActionDirective])
+        .directive("adhModalAction", [AdhResourceActions.modalActionDirective])
         .directive("adhHideAction", [
             "adhHttp", "adhTopLevelState", "adhResourceUrlFilter", "$translate", "$window", AdhResourceActions.hideActionDirective])
         .directive("adhAssignBadgesAction", ["adhConfig", "adhHttp", "adhPermissions", AdhResourceActions.assignBadgesActionDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/Module.ts
@@ -21,9 +21,7 @@ export var register = (angular) => {
             "adhHttp", "adhTopLevelState", "adhResourceUrlFilter", "$translate", "$window", AdhResourceActions.hideActionDirective])
         .directive("adhAssignBadgesAction", ["adhConfig", "adhHttp", "adhPermissions", AdhResourceActions.assignBadgesActionDirective])
         .directive("adhResourceWidgetDeleteAction", [AdhResourceActions.resourceWidgetDeleteActionDirective])
-        .directive("adhEditAction", ["adhTopLevelState", "adhResourceUrlFilter", "$location", AdhResourceActions.editActionDirective])
-        .directive("adhModerateAction", [
-            "adhTopLevelState", "adhResourceUrlFilter", "$location", AdhResourceActions.moderateActionDirective])
+        .directive("adhViewAction", ["adhTopLevelState", "adhResourceUrlFilter", "$location", AdhResourceActions.viewActionDirective])
         .directive("adhPrintAction", ["adhTopLevelState", "$window", AdhResourceActions.printActionDirective])
         .directive("adhCancelAction", ["adhTopLevelState", "adhResourceUrlFilter", AdhResourceActions.cancelActionDirective])
         .animation(".modal", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -19,14 +19,18 @@
         data-class="action-bar-item"
         data-resource-with-badges-url="{{resourceWithBadgesUrl}}"
         data-resource-path="{{resourcePath}}"></adh-assign-badges-action>
-    <adh-report-action
+    <adh-modal-action
         data-ng-if="report"
         data-modals="modals"
-        data-class="action-bar-item"></adh-report-action>
-    <adh-share-action
+        data-modal="abuse"
+        data-label="TR__REPORT"
+        data-class="action-bar-item"></adh-modal-action>
+    <adh-modal-action
         data-ng-if="share"
         data-modals="modals"
-        data-class="action-bar-item"></adh-share-action>
+        data-modal="share"
+        data-label="TR__SHARE"
+        data-class="action-bar-item"></adh-modal-action>
     <adh-hide-action
         data-ng-if="hide && resourcePath && options.hide"
         data-class="action-bar-item"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -1,14 +1,12 @@
 <div class="action-bar">
     <adh-view-action
         data-ng-if="edit && resourcePath && options.PUT"
-        data-class="action-bar-item"
         data-view="edit"
         data-label="TR__EDIT"
         data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-view-action>
     <adh-view-action
         data-ng-if="moderate && resourcePath"
-        data-class="action-bar-item"
         data-view="moderate"
         data-label="TR__MODERATE"
         data-parent-path="parentPath"
@@ -16,38 +14,31 @@
     <adh-assign-badges-action
         data-ng-if="assignBadges && resourcePath"
         data-modals="modals"
-        data-class="action-bar-item"
         data-resource-with-badges-url="{{resourceWithBadgesUrl}}"
         data-resource-path="{{resourcePath}}"></adh-assign-badges-action>
     <adh-modal-action
         data-ng-if="report"
         data-modals="modals"
         data-modal="abuse"
-        data-label="TR__REPORT"
-        data-class="action-bar-item"></adh-modal-action>
+        data-label="TR__REPORT"></adh-modal-action>
     <adh-modal-action
         data-ng-if="share"
         data-modals="modals"
         data-modal="share"
-        data-label="TR__SHARE"
-        data-class="action-bar-item"></adh-modal-action>
+        data-label="TR__SHARE"></adh-modal-action>
     <adh-hide-action
         data-ng-if="hide && resourcePath && options.hide"
-        data-class="action-bar-item"
         data-parent-path="parentPath"
         data-redirect-url="{{deleteRedirectUrl}}"
         data-resource-path="{{resourcePath}}"></adh-hide-action>
     <adh-resource-widget-delete-action
         data-ng-if="resourceWidgetDelete && resourcePath && options.hide"
-        data-class="action-bar-item"
         data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-resource-widget-delete-action>
     <adh-print-action
-        data-ng-if="print"
-        data-class="action-bar-item"></adh-print-action>
+        data-ng-if="print"></adh-print-action>
     <adh-cancel-action
         data-ng-if="cancel && resourcePath"
-        data-class="action-bar-item"
         data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-cancel-action>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -1,40 +1,50 @@
 <div class="action-bar">
     <adh-view-action
         data-ng-if="edit && resourcePath && options.PUT"
+        data-class="action-bar-item"
         data-view="edit"
         data-label="TR__EDIT"
         data-resource-path="{{resourcePath}}"></adh-view-action>
     <adh-view-action
         data-ng-if="moderate && resourcePath"
+        data-class="action-bar-item"
         data-view="moderate"
         data-label="TR__MODERATE"
         data-resource-path="{{resourcePath}}"></adh-view-action>
     <adh-assign-badges-action
         data-ng-if="assignBadges && resourcePath"
         data-modals="modals"
+        data-class="action-bar-item"
         data-resource-with-badges-url="{{resourceWithBadgesUrl}}"
         data-resource-path="{{resourcePath}}"></adh-assign-badges-action>
     <adh-modal-action
         data-ng-if="report"
         data-modals="modals"
         data-modal="abuse"
-        data-label="TR__REPORT"></adh-modal-action>
+        data-label="TR__REPORT"
+        data-class="action-bar-item"></adh-modal-action>
     <adh-modal-action
         data-ng-if="share"
         data-modals="modals"
         data-modal="share"
-        data-label="TR__SHARE"></adh-modal-action>
+        data-label="TR__SHARE"
+        data-class="action-bar-item"></adh-modal-action>
     <adh-hide-action
         data-ng-if="hide && resourcePath && options.hide"
+        data-class="action-bar-item"
         data-redirect-url="{{deleteRedirectUrl}}"
         data-resource-path="{{resourcePath}}"></adh-hide-action>
     <adh-resource-widget-delete-action
         data-ng-if="resourceWidgetDelete && resourcePath && options.hide"
+        data-class="action-bar-item"
+        data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-resource-widget-delete-action>
     <adh-print-action
-        data-ng-if="print"></adh-print-action>
+        data-ng-if="print"
+        data-class="action-bar-item"></adh-print-action>
     <adh-cancel-action
         data-ng-if="cancel && resourcePath"
+        data-class="action-bar-item"
         data-resource-path="{{resourcePath}}"></adh-cancel-action>
 </div>
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -1,14 +1,18 @@
 <div class="action-bar">
-    <adh-edit-action
+    <adh-view-action
         data-ng-if="edit && resourcePath && options.PUT"
         data-class="action-bar-item"
+        data-view="edit"
+        data-label="TR__EDIT"
         data-parent-path="parentPath"
-        data-resource-path="{{resourcePath}}"></adh-edit-action>
-    <adh-moderate-action
+        data-resource-path="{{resourcePath}}"></adh-view-action>
+    <adh-view-action
         data-ng-if="moderate && resourcePath"
         data-class="action-bar-item"
+        data-view="moderate"
+        data-label="TR__MODERATE"
         data-parent-path="parentPath"
-        data-resource-path="{{resourcePath}}"></adh-moderate-action>
+        data-resource-path="{{resourcePath}}"></adh-view-action>
     <adh-assign-badges-action
         data-ng-if="assignBadges && resourcePath"
         data-modals="modals"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -3,13 +3,11 @@
         data-ng-if="edit && resourcePath && options.PUT"
         data-view="edit"
         data-label="TR__EDIT"
-        data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-view-action>
     <adh-view-action
         data-ng-if="moderate && resourcePath"
         data-view="moderate"
         data-label="TR__MODERATE"
-        data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-view-action>
     <adh-assign-badges-action
         data-ng-if="assignBadges && resourcePath"
@@ -28,18 +26,15 @@
         data-label="TR__SHARE"></adh-modal-action>
     <adh-hide-action
         data-ng-if="hide && resourcePath && options.hide"
-        data-parent-path="parentPath"
         data-redirect-url="{{deleteRedirectUrl}}"
         data-resource-path="{{resourcePath}}"></adh-hide-action>
     <adh-resource-widget-delete-action
         data-ng-if="resourceWidgetDelete && resourcePath && options.hide"
-        data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-resource-widget-delete-action>
     <adh-print-action
         data-ng-if="print"></adh-print-action>
     <adh-cancel-action
         data-ng-if="cancel && resourcePath"
-        data-parent-path="parentPath"
         data-resource-path="{{resourcePath}}"></adh-cancel-action>
 </div>
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -96,33 +96,19 @@ export var resourceActionsDirective = (
     };
 };
 
-export var reportActionDirective = () => {
+export var modalActionDirective = () => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"report();\">{{ 'TR__REPORT' | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"toggle();\">{{ label | translate }}</a>",
         scope: {
             class: "@",
             modals: "=",
+            modal: "@",
+            label: "@",
         },
         link: (scope) => {
-            scope.report = () => {
-                scope.modals.toggleModal("abuse");
-            };
-        }
-    };
-};
-
-export var shareActionDirective = () => {
-    return {
-        restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"share();\">{{ 'TR__SHARE' | translate }}</a>",
-        scope: {
-            class: "@",
-            modals: "=",
-        },
-        link: (scope) => {
-            scope.share = () => {
-                scope.modals.toggleModal("share");
+            scope.toggle = () => {
+                scope.modals.toggleModal(scope.modal);
             };
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -245,47 +245,26 @@ export var printActionDirective = (
     };
 };
 
-export var editActionDirective = (
+export var viewActionDirective = (
     adhTopLevelState : AdhTopLevelState.Service,
     adhResourceUrl,
     $location : angular.ILocationService
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"edit();\">{{ 'TR__EDIT' | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"link();\">{{ label | translate }}</a>",
         scope: {
             resourcePath: "@",
             parentPath: "=?",
-            class: "@"
+            class: "@",
+            label: "@",
+            view: "@",
         },
         link: (scope) => {
-            scope.edit = () => {
+            scope.link = () => {
                 adhTopLevelState.setCameFrom();
                 var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
-                var url = adhResourceUrl(path, "edit");
-                $location.url(url);
-            };
-        }
-    };
-};
-
-export var moderateActionDirective = (
-    adhTopLevelState : AdhTopLevelState.Service,
-    adhResourceUrl,
-    $location : angular.ILocationService
-) => {
-    return {
-        restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"moderate();\">{{ 'TR__MODERATE' | translate }}</a>",
-        scope: {
-            resourcePath: "@",
-            parentPath: "=?",
-            class: "@"
-        },
-        link: (scope) => {
-            scope.moderate = () => {
-                var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
-                var url = adhResourceUrl(path, "moderate");
+                var url = adhResourceUrl(path, scope.view);
                 $location.url(url);
             };
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -96,7 +96,7 @@ export var resourceActionsDirective = (
 export var modalActionDirective = () => {
     return {
         restrict: "E",
-        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"toggle();\">{{ label | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"toggle();\">{{ label | translate }}</a>",
         scope: {
             class: "@",
             modals: "=",
@@ -118,7 +118,7 @@ export var assignBadgesActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a data-ng-if=\"badgesExist && badgeAssignmentPoolOptions.PUT\" class=\"action-bar-item {{class}}\""
+        template: "<a data-ng-if=\"badgesExist && badgeAssignmentPoolOptions.PUT\" class=\"{{class}}\""
             + "href=\"\" data-ng-click=\"assignBadges();\">{{ 'TR__MANAGE_BADGE_ASSIGNMENTS' | translate }}</a>",
         scope: {
             resourcePath: "@",
@@ -160,7 +160,7 @@ export var hideActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"hide();\">{{ 'TR__HIDE' | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"hide();\">{{ 'TR__HIDE' | translate }}</a>",
         scope: {
             resourcePath: "@",
             class: "@",
@@ -188,7 +188,7 @@ export var hideActionDirective = (
 export var resourceWidgetDeleteActionDirective = () => {
     return {
         restrict: "E",
-        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"delete();\">{{ 'TR__DELETE' | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"delete();\">{{ 'TR__DELETE' | translate }}</a>",
         require: "^adhMovingColumn",
         scope: {
             resourcePath: "@",
@@ -208,7 +208,7 @@ export var printActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"print();\">{{ 'TR__PRINT' | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"print();\">{{ 'TR__PRINT' | translate }}</a>",
         require: "?^adhMovingColumn",
         scope: {
             class: "@"
@@ -232,7 +232,7 @@ export var viewActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"link();\">{{ label | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"link();\">{{ label | translate }}</a>",
         scope: {
             resourcePath: "@",
             class: "@",
@@ -255,7 +255,7 @@ export var cancelActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"cancel();\">{{ 'TR__CANCEL' | translate }}</a>",
+        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"cancel();\">{{ 'TR__CANCEL' | translate }}</a>",
         scope: {
             resourcePath: "@",
             class: "@"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -3,7 +3,6 @@ import * as AdhHttp from "../Http/Http";
 import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
-import * as AdhUtil from "../Util/Util";
 
 import * as SIBadge from "../../Resources_/adhocracy_core/sheets/badge/IBadge";
 import * as SIBadgeable from "../../Resources_/adhocracy_core/sheets/badge/IBadgeable";
@@ -69,7 +68,6 @@ export var resourceActionsDirective = (
         restrict: "E",
         scope: {
             resourcePath: "@",
-            parentPath: "=?",
             resourceWithBadgesUrl: "@?",
             deleteRedirectUrl: "@?",
             assignBadges: "=?",
@@ -85,9 +83,8 @@ export var resourceActionsDirective = (
         },
         templateUrl: adhConfig.pkg_path + pkgLocation + "/ResourceActions.html",
         link: (scope, element) => {
-            var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
             scope.modals = new Modals($timeout);
-            adhPermissions.bindScope(scope, path, "options");
+            adhPermissions.bindScope(scope, scope.resourcePath, "options");
 
             scope.$watch("resourcePath", () => {
                 scope.modals.clear();
@@ -166,16 +163,14 @@ export var hideActionDirective = (
         template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"hide();\">{{ 'TR__HIDE' | translate }}</a>",
         scope: {
             resourcePath: "@",
-            parentPath: "=?",
             class: "@",
             redirectUrl: "@?",
         },
         link: (scope, element) => {
             scope.hide = () => {
                 return $translate("TR__ASK_TO_CONFIRM_HIDE_ACTION").then((question) => {
-                    var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
                     if ($window.confirm(question)) {
-                        return adhHttp.hide(path).then(() => {
+                        return adhHttp.hide(scope.resourcePath).then(() => {
                             var url = scope.redirectUrl;
                             if (!url) {
                                 var processUrl = adhTopLevelState.get("processUrl");
@@ -197,7 +192,6 @@ export var resourceWidgetDeleteActionDirective = () => {
         require: "^adhMovingColumn",
         scope: {
             resourcePath: "@",
-            parentPath: "=?",
             class: "@"
         },
         link: (scope, element, attrs, column : AdhMovingColumns.MovingColumnController) => {
@@ -241,7 +235,6 @@ export var viewActionDirective = (
         template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"link();\">{{ label | translate }}</a>",
         scope: {
             resourcePath: "@",
-            parentPath: "=?",
             class: "@",
             label: "@",
             view: "@",
@@ -249,8 +242,7 @@ export var viewActionDirective = (
         link: (scope) => {
             scope.link = () => {
                 adhTopLevelState.setCameFrom();
-                var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
-                var url = adhResourceUrl(path, scope.view);
+                var url = adhResourceUrl(scope.resourcePath, scope.view);
                 $location.url(url);
             };
         }
@@ -266,7 +258,6 @@ export var cancelActionDirective = (
         template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"cancel();\">{{ 'TR__CANCEL' | translate }}</a>",
         scope: {
             resourcePath: "@",
-            parentPath: "=?",
             class: "@"
         },
         link: (scope) => {
@@ -274,8 +265,7 @@ export var cancelActionDirective = (
                 if (!scope.resourcePath) {
                     scope.resourcePath = adhTopLevelState.get("processUrl");
                 }
-                var path = scope.parentPath ? AdhUtil.parentPath(scope.resourcePath) : scope.resourcePath;
-                var url = adhResourceUrl(path);
+                var url = adhResourceUrl(scope.resourcePath);
                 adhTopLevelState.goToCameFrom(url);
             };
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -99,7 +99,7 @@ export var resourceActionsDirective = (
 export var modalActionDirective = () => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"toggle();\">{{ label | translate }}</a>",
+        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"toggle();\">{{ label | translate }}</a>",
         scope: {
             class: "@",
             modals: "=",
@@ -121,7 +121,7 @@ export var assignBadgesActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a data-ng-if=\"badgesExist && badgeAssignmentPoolOptions.PUT\" class=\"{{class}}\""
+        template: "<a data-ng-if=\"badgesExist && badgeAssignmentPoolOptions.PUT\" class=\"action-bar-item {{class}}\""
             + "href=\"\" data-ng-click=\"assignBadges();\">{{ 'TR__MANAGE_BADGE_ASSIGNMENTS' | translate }}</a>",
         scope: {
             resourcePath: "@",
@@ -163,7 +163,7 @@ export var hideActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"hide();\">{{ 'TR__HIDE' | translate }}</a>",
+        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"hide();\">{{ 'TR__HIDE' | translate }}</a>",
         scope: {
             resourcePath: "@",
             parentPath: "=?",
@@ -193,7 +193,7 @@ export var hideActionDirective = (
 export var resourceWidgetDeleteActionDirective = () => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"delete();\">{{ 'TR__DELETE' | translate }}</a>",
+        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"delete();\">{{ 'TR__DELETE' | translate }}</a>",
         require: "^adhMovingColumn",
         scope: {
             resourcePath: "@",
@@ -214,7 +214,7 @@ export var printActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"print();\">{{ 'TR__PRINT' | translate }}</a>",
+        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"print();\">{{ 'TR__PRINT' | translate }}</a>",
         require: "?^adhMovingColumn",
         scope: {
             class: "@"
@@ -238,7 +238,7 @@ export var viewActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"link();\">{{ label | translate }}</a>",
+        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"link();\">{{ label | translate }}</a>",
         scope: {
             resourcePath: "@",
             parentPath: "=?",
@@ -263,7 +263,7 @@ export var cancelActionDirective = (
 ) => {
     return {
         restrict: "E",
-        template: "<a class=\"{{class}}\" href=\"\" data-ng-click=\"cancel();\">{{ 'TR__CANCEL' | translate }}</a>",
+        template: "<a class=\"action-bar-item {{class}}\" href=\"\" data-ng-click=\"cancel();\">{{ 'TR__CANCEL' | translate }}</a>",
         scope: {
             resourcePath: "@",
             parentPath: "=?",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -12,8 +12,7 @@
             <adh-modal-action
                 data-modals="modals"
                 data-modal="messaging"
-                data-label="TR__MESSAGING"
-                data-class="action-bar-item"></adh-modal-action>
+                data-label="TR__MESSAGING"></adh-modal-action>
         </div>
         <ul class="alerts">
             <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -9,11 +9,11 @@
         data-ng-switch-when="body"
         data-value="{{userUrl}}">
         <div class="action-bar">
-            <a
-                class="action-bar-item"
-                href=""
-                data-ng-click="modals.toggleModal('messaging')"
-                data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
+            <adh-modal-action
+                data-modals="modals"
+                data-modal="messaging"
+                data-label="TR__MESSAGING"
+                data-class="action-bar-item"></adh-modal-action>
         </div>
         <ul class="alerts">
             <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/UserDetailColumn.html
@@ -12,7 +12,8 @@
             <adh-modal-action
                 data-modals="modals"
                 data-modal="messaging"
-                data-label="TR__MESSAGING"></adh-modal-action>
+                data-label="TR__MESSAGING"
+                data-class="action-bar-item"></adh-modal-action>
         </div>
         <ul class="alerts">
             <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -24,8 +24,13 @@
                 data-view="edit"
                 data-label="TR__EDIT"
                 data-resource-path="{{proposalUrl}}">
+            <adh-view-action data-ng-if="proposalItemOptions.PUT"
+                data-class="action-bar-item"
+                data-parent-path="true"
+                data-view="image"
+                data-label="TR__IMAGE_UPLOAD"
+                data-resource-path="{{proposalUrl}}">
             </adh-view-action>
-            <a class="action-bar-item" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'image' }}">{{ "TR__IMAGE_UPLOAD" | translate }}</a>
             <adh-assign-badges-action
                 data-class="action-bar-item"
                 data-modals="modals"

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -18,11 +18,13 @@
         data-ng-switch-when="body"
         data-value="{{proposalUrl}}">
         <div class="action-bar">
-            <adh-edit-action data-ng-if="proposalItemOptions.PUT"
+            <adh-view-action data-ng-if="proposalItemOptions.PUT"
                 data-class="action-bar-item"
                 data-parent-path="true"
+                data-view="edit"
+                data-label="TR__EDIT"
                 data-resource-path="{{proposalUrl}}">
-            </adh-edit-action>
+            </adh-view-action>
             <a class="action-bar-item" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl:'image' }}">{{ "TR__IMAGE_UPLOAD" | translate }}</a>
             <adh-assign-badges-action
                 data-class="action-bar-item"

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -19,20 +19,17 @@
         data-value="{{proposalUrl}}">
         <div class="action-bar">
             <adh-view-action data-ng-if="proposalItemOptions.PUT"
-                data-class="action-bar-item"
                 data-parent-path="true"
                 data-view="edit"
                 data-label="TR__EDIT"
                 data-resource-path="{{proposalUrl}}">
             <adh-view-action data-ng-if="proposalItemOptions.PUT"
-                data-class="action-bar-item"
                 data-parent-path="true"
                 data-view="image"
                 data-label="TR__IMAGE_UPLOAD"
                 data-resource-path="{{proposalUrl}}">
             </adh-view-action>
             <adh-assign-badges-action
-                data-class="action-bar-item"
                 data-modals="modals"
                 data-resource-with-badges-url="{{processUrl}}"
                 data-resource-path="{{proposalUrl}}">

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -19,15 +19,13 @@
         data-value="{{proposalUrl}}">
         <div class="action-bar">
             <adh-view-action data-ng-if="proposalItemOptions.PUT"
-                data-parent-path="true"
                 data-view="edit"
                 data-label="TR__EDIT"
-                data-resource-path="{{proposalUrl}}">
+                data-resource-path="{{proposalUrl | adhParentPath}}">
             <adh-view-action data-ng-if="proposalItemOptions.PUT"
-                data-parent-path="true"
                 data-view="image"
                 data-label="TR__IMAGE_UPLOAD"
-                data-resource-path="{{proposalUrl}}">
+                data-resource-path="{{proposalUrl | adhParentPath}}">
             </adh-view-action>
             <adh-assign-badges-action
                 data-modals="modals"

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -19,15 +19,18 @@
         data-value="{{proposalUrl}}">
         <div class="action-bar">
             <adh-view-action data-ng-if="proposalItemOptions.PUT"
+                data-class="action-bar-item"
                 data-view="edit"
                 data-label="TR__EDIT"
                 data-resource-path="{{proposalUrl | adhParentPath}}">
             <adh-view-action data-ng-if="proposalItemOptions.PUT"
+                data-class="action-bar-item"
                 data-view="image"
                 data-label="TR__IMAGE_UPLOAD"
                 data-resource-path="{{proposalUrl | adhParentPath}}">
             </adh-view-action>
             <adh-assign-badges-action
+                data-class="action-bar-item"
                 data-modals="modals"
                 data-resource-with-badges-url="{{processUrl}}"
                 data-resource-path="{{proposalUrl | adhParentPath}}">

--- a/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
+++ b/src/euth/euth/static/js/Packages/Euth/IdeaCollection/Workbench/ProposalDetailColumn.html
@@ -30,7 +30,7 @@
             <adh-assign-badges-action
                 data-modals="modals"
                 data-resource-with-badges-url="{{processUrl}}"
-                data-resource-path="{{proposalUrl}}">
+                data-resource-path="{{proposalUrl | adhParentPath}}">
             </adh-assign-badges-action>
         </div>
         <ul class="alerts">

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentDetailColumn.html
@@ -17,8 +17,7 @@
 
     <div data-ng-switch-when="body">
         <adh-resource-actions
-            data-resource-path="{{documentUrl}}"
-            data-parent-path="true"
+            data-resource-path="{{documentUrl | adhParentPath}}"
             data-edit="true"
             data-hide="true">
         </adh-resource-actions>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentEditColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentEditColumn.html
@@ -17,8 +17,7 @@
 
     <div data-ng-switch-when="body">
         <adh-resource-actions
-            data-resource-path="{{documentUrl}}"
-            data-parent-path="true"
+            data-resource-path="{{documentUrl | adhParentPath}}"
             data-cancel="true">
         </adh-resource-actions>
         <adh-document-edit data-path="{{documentUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon"></adh-document-edit>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalDetailColumn.html
@@ -22,8 +22,7 @@
         data-ng-switch-when="body"
         data-value="{{proposalUrl}}">
         <adh-resource-actions
-            data-resource-path="{{proposalUrl}}"
-            data-parent-path="true"
+            data-resource-path="{{proposalUrl | adhParentPath}}"
             data-edit="true">
         </adh-resource-actions>
         <adh-meinberlin-proposal-detail

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalEditColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalEditColumn.html
@@ -17,8 +17,7 @@
         data-ng-switch-when="body"
         data-value="{{proposalUrl}}">
         <adh-resource-actions
-            data-resource-path="{{proposalUrl}}"
-            data-parent-path="true"
+            data-resource-path="{{proposalUrl | adhParentPath}}"
             data-cancel="true">
         </adh-resource-actions>
         <adh-meinberlin-proposal-edit

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Detail.html
@@ -1,6 +1,6 @@
 <div class="meinberlin-idea-collection-detail">
     <div class="action-bar">
-        <adh-print-action data-class="action-bar-item"></adh-print-action>
+        <adh-print-action></adh-print-action>
         <adh-map-switch data-model="isShowMap"></adh-map-switch>
     </div>
     <div data-ng-switch="currentPhase.name">

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Detail.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/Process/Detail.html
@@ -1,6 +1,6 @@
 <div class="meinberlin-idea-collection-detail">
     <div class="action-bar">
-        <adh-print-action></adh-print-action>
+        <adh-print-action data-class="action-bar-item"></adh-print-action>
         <adh-map-switch data-model="isShowMap"></adh-map-switch>
     </div>
     <div data-ng-switch="currentPhase.name">

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/IdeaCollection/ProposalDetailColumn.html
@@ -19,10 +19,9 @@
         <adh-recompile-on-change
             data-value="{{proposalUrl}}">
             <adh-resource-actions
-                data-resource-path="{{proposalUrl}}"
+                data-resource-path="{{proposalUrl | adhParentPath}}"
                 data-resource-with-badges-url="{{processUrl}}"
                 data-ng-if="proposalUrl"
-                data-parent-path="true"
                 data-edit="true"
                 data-assign-badges="true"
                 data-report="true"

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalDetailColumn.html
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalDetailColumn.html
@@ -18,10 +18,9 @@
         data-ng-switch-when="body"
         data-value="{{proposalUrl}}">
         <adh-resource-actions
-            data-resource-path="{{proposalUrl}}"
+            data-resource-path="{{proposalUrl | adhParentPath}}"
             data-resource-with-badges-url="{{processUrl}}"
             data-ng-if="proposalUrl"
-            data-parent-path="true"
             data-edit="true"
             data-assign-badges="true">
         </adh-resource-actions>

--- a/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
+++ b/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
@@ -12,8 +12,7 @@
             <adh-modal-action
                 data-modals="modals"
                 data-modal="messaging"
-                data-label="TR__MESSAGING"
-                data-class="action-bar-item"></adh-modal-action>
+                data-label="TR__MESSAGING"></adh-modal-action>
         </div>
         <ul class="alerts">
             <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">

--- a/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
+++ b/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
@@ -9,11 +9,11 @@
         data-ng-switch-when="body"
         data-value="{{userUrl}}">
         <div class="action-bar">
-            <a
-                class="action-bar-item"
-                href=""
-                data-ng-click="modals.toggleModal('messaging')"
-                data-ng-if="messageOptions.POST">{{ "TR__MESSAGING" | translate }}</a>
+            <adh-modal-action
+                data-modals="modals"
+                data-modal="messaging"
+                data-label="TR__MESSAGING"
+                data-class="action-bar-item"></adh-modal-action>
         </div>
         <ul class="alerts">
             <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">

--- a/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
+++ b/src/s1/s1/static/js/Packages/User/UserDetailColumn.html
@@ -12,7 +12,8 @@
             <adh-modal-action
                 data-modals="modals"
                 data-modal="messaging"
-                data-label="TR__MESSAGING"></adh-modal-action>
+                data-label="TR__MESSAGING"
+                data-class="action-bar-item"></adh-modal-action>
         </div>
         <ul class="alerts">
             <li data-ng-repeat="(id, alert) in modals.alerts" class="alerts-message m-{{alert.mode}}" data-ng-click="modals.removeAlert(id)">


### PR DESCRIPTION
I propose three changes to resource actions:

- convert some similar actions into parameterized/generic actions
- make the `action-bar-item` class implicit
- remove `parentPath` parameter

With neither of them I am completely sure, so this is a proposal rather than a request.