### PR TITLE
Switch to sass-planifolia 0.3.0

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -217,7 +217,7 @@ packages =
     webfont-opensans#0.0.2
     roboto-fontface#0.4.3
     merriweather-fontface#f5fee770c034a92a3a551d52fcd34f210acf23d2
-    xi/sass-planifolia#7ad24e9942c3eca601b5406da22f7b1eb341376f
+    xi/sass-planifolia#0.3.0
 
 executable = ${buildout:bin-directory}/node ${buildout:directory}/node_modules/.bin/bower --config.interactive=false
 base-directory = ${adhocracy:frontend.static_dir}/lib


### PR DESCRIPTION
I just released a new version, so we can switch to a stable release now.

Note: I did not test this as I do not currently have a adhocracy development setup