### PR TITLE
Remove underline text decoration of s1 logo in ie

### DIFF
--- a/src/s1/s1/static/stylesheets/scss/components/_s1_header.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_s1_header.scss
@@ -11,6 +11,8 @@
     color: $color-text-introvert;
     position: absolute;
     left: 0;
+    // IE 10 renders the image only logo with an underline otherwise
+    text-decoration: none;
 
     &:hover, &:focus {
         color: $color-text-normal;


### PR DESCRIPTION
teste in 10, 11 and edge. The bug is possibly also visible in older versions, but those I haven't tested.