### PR TITLE
Fix landing and login alignment (centered!) in IE

### DIFF
--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.html
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.html
@@ -1,6 +1,4 @@
-<div class="l-center" data-ng-if="landingPage ==='true'">
-    <adh-s1-landing></adh-s1-landing>
-</div>
+<adh-s1-landing data-ng-if="landingPage ==='true'"></adh-s1-landing>
 <div data-ng-if="landingPage !== 'true'" data-adh-moving-columns="" data-max-width="64" data-spacing="0" class="moving-columns">
     <adh-moving-column data-ng-switch="meeting">
         <div class="s1-proposal-list">

--- a/src/s1/s1/static/stylesheets/scss/_layout_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/_layout_theme.scss
@@ -1,16 +1,5 @@
 .l-center {
     background-color: $color-background-base;
-    max-width: $moving-column-single-width-max;
-    padding: 0;
-
-    // get it scrolling and centered
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    margin: 0 auto;
-    overflow-y: auto;
 }
 
 // Need more space for the header so the second line (process progress indicator) fits

--- a/src/s1/s1/static/stylesheets/scss/components/_s1_landing.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_s1_landing.scss
@@ -1,6 +1,9 @@
 .s1-landing {
     @include container;
     background: $color-background-base-introvert;
+    margin: 0 auto;
+    min-width: $moving-column-single-width-min;
+    max-width: $moving-column-single-width-max;
 }
 
 .s1-landing-row,


### PR DESCRIPTION
Rework how the landing page is centered and make it work in IE. Also take of custom styling of the .l-center class as it is reused for login (which also didn't center correctly in IE 10+).