### PR TITLE
resource actions everywhere

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentDetailColumn.html
@@ -1,8 +1,8 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
-        <i class="icon-document moving-column-icon"></i>
-        <a class="moving-column-menu-button" data-ng-if="proposalItemOptions.POST" data-ng-href="{{ documentUrl | adhParentPath | adhResourceUrl:'edit' }}">{{ "TR__EDIT" | translate }}</a>
-
+        <adh-resource-actions
+            data-resource-path="{{documentUrl | adhParentPath}}"
+            data-edit="true"></adh-resource-actions>
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentDetailColumn.html
@@ -1,8 +1,6 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
-        <adh-resource-actions
-            data-resource-path="{{documentUrl | adhParentPath}}"
-            data-edit="true"></adh-resource-actions>
+        <i class="icon-document moving-column-icon"></i>
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
@@ -17,6 +15,9 @@
     <adh-recompile-on-change
             data-ng-switch-when="body"
             data-value="{{documentUrl}}">
+        <adh-resource-actions
+            data-resource-path="{{documentUrl | adhParentPath}}"
+            data-edit="true"></adh-resource-actions>
         <adh-document-detail
             data-ng-if="documentUrl"
             data-path="{{documentUrl}}">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentEditColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentEditColumn.html
@@ -1,10 +1,6 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
         <i class="icon-document moving-column-icon"></i>
-        <adh-resource-actions
-            data-resource-path="{{documentUrl | adhParentPath}}"
-            data-cancel="true">
-        </adh-resource-actions>
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
@@ -17,6 +13,10 @@
     <adh-recompile-on-change
             data-ng-switch-when="body"
             data-value="{{documentUrl}}">
+        <adh-resource-actions
+            data-resource-path="{{documentUrl | adhParentPath}}"
+            data-cancel="true">
+        </adh-resource-actions>
         <adh-document-edit
             data-ng-if="documentUrl"
             data-path="{{documentUrl}}">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentEditColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentEditColumn.html
@@ -1,8 +1,10 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
         <i class="icon-document moving-column-icon"></i>
-        <a class="moving-column-menu-button" data-ng-href="{{ documentUrl | adhParentPath | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
-
+        <adh-resource-actions
+            data-resource-path="{{documentUrl | adhParentPath}}"
+            data-cancel="true">
+        </adh-resource-actions>
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
@@ -4,6 +4,7 @@ import * as AdhDocumentModule from "../Document/Module";
 import * as AdhHttpModule from "../Http/Module";
 import * as AdhMovingColumnsModule from "../MovingColumns/Module";
 import * as AdhPermissionsModule from "../Permissions/Module";
+import * as AdhResourceActionsModule from "../ResourceActions/Module";
 import * as AdhResourceAreaModule from "../ResourceArea/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 
@@ -23,6 +24,7 @@ export var register = (angular) => {
             AdhHttpModule.moduleName,
             AdhMovingColumnsModule.moduleName,
             AdhPermissionsModule.moduleName,
+            AdhResourceActionsModule.moduleName,
             AdhResourceAreaModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/ProcessDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/ProcessDetailColumn.html
@@ -1,9 +1,9 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
         <i class="icon-list moving-column-icon"></i>
-        <a class="moving-column-menu-button"
-            data-ng-if="processOptions.POST"
-            data-ng-href="{{ processUrl | adhResourceUrl:'create_document' }}">{{ "TR__CREATE_DOCUMENT" | translate }}</a>
+        <adh-resource-actions
+            data-resource-path="{{processUrl | adhParentPath}}"
+            data-create-document="true"></adh-resource-actions>
     </div>
 
     <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ processUrl | adhResourceUrl }}">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/ProcessDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/ProcessDetailColumn.html
@@ -1,9 +1,6 @@
 <div data-ng-switch="transclusionId">
     <div data-ng-switch-when="menu">
         <i class="icon-list moving-column-icon"></i>
-        <adh-resource-actions
-            data-resource-path="{{processUrl | adhParentPath}}"
-            data-create-document="true"></adh-resource-actions>
     </div>
 
     <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ processUrl | adhResourceUrl }}">
@@ -12,9 +9,13 @@
         </div>
     </a>
 
-    <adh-document-listing
-        data-ng-switch-when="body"
-        data-ng-if="processUrl"
-        data-path="{{processUrl}}">
-    </adh-document-listing>
+    <div data-ng-switch-when="body">
+        <adh-resource-actions
+            data-resource-path="{{processUrl}}"
+            data-create-document="true"></adh-resource-actions>
+        <adh-document-listing
+            data-ng-if="processUrl"
+            data-path="{{processUrl}}">
+        </adh-document-listing>
+    </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalEditColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalEditColumn.html
@@ -3,10 +3,6 @@
         <div class="moving-column-tab">
             <i class="icon-document moving-column-icon"></i>
         </div>
-        <adh-resource-actions
-            data-resource-path="{{proposalUrl | adhParentPath}}"
-            data-cancel="true">
-        </adh-resource-actions>
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
@@ -19,6 +15,10 @@
     <adh-recompile-on-change
             data-ng-switch-when="body"
             data-value="{{proposalUrl}}">
+        <adh-resource-actions
+            data-resource-path="{{proposalUrl | adhParentPath}}"
+            data-cancel="true">
+        </adh-resource-actions>
         <adh-idea-collection-proposal-edit
             data-ng-if="proposalUrl"
             data-process-options="processOptions"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalEditColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalEditColumn.html
@@ -3,8 +3,10 @@
         <div class="moving-column-tab">
             <i class="icon-document moving-column-icon"></i>
         </div>
-        <a class="moving-column-menu-button" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
-
+        <adh-resource-actions
+            data-resource-path="{{proposalUrl | adhParentPath}}"
+            data-cancel="true">
+        </adh-resource-actions>
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalImageColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalImageColumn.html
@@ -3,8 +3,10 @@
         <div class="moving-column-tab">
             <i class="icon-document moving-column-icon"></i>
         </div>
-        <a class="moving-column-menu-button" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
-
+        <adh-resource-actions
+            data-resource-path="{{documentUrl | adhParentPath}}"
+            data-cancel="true">
+        </adh-resource-actions>
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalImageColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalImageColumn.html
@@ -3,10 +3,6 @@
         <div class="moving-column-tab">
             <i class="icon-document moving-column-icon"></i>
         </div>
-        <adh-resource-actions
-            data-resource-path="{{documentUrl | adhParentPath}}"
-            data-cancel="true">
-        </adh-resource-actions>
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
@@ -16,11 +12,16 @@
         <i class="icon-document moving-column-icon"></i>
     </a>
 
-    <adh-upload-image
-        data-ng-switch-when="body"
-        data-ng-if="proposalUrl"
-        data-path="{{proposalUrl}}"
-        data-pool-path="{{processUrl}}"
-        data-did-complete-upload="goBack()"
-    ></adh-upload-image>
+    <div data-ng-switch-when="body">
+        <adh-resource-actions
+            data-resource-path="{{documentUrl | adhParentPath}}"
+            data-cancel="true">
+        </adh-resource-actions>
+        <adh-upload-image
+            data-ng-if="proposalUrl"
+            data-path="{{proposalUrl}}"
+            data-pool-path="{{processUrl}}"
+            data-did-complete-upload="goBack()"
+        ></adh-upload-image>
+    </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -1,5 +1,11 @@
 <div class="action-bar">
     <adh-view-action
+        data-ng-if="createDocument && resourcePath && options.POST"
+        data-class="action-bar-item"
+        data-view="create_document"
+        data-label="TR__CREATE_DOCUMENT"
+        data-resource-path="{{resourcePath}}"></adh-view-action>
+    <adh-view-action
         data-ng-if="edit && resourcePath && options.PUT"
         data-class="action-bar-item"
         data-view="edit"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -71,6 +71,7 @@ export var resourceActionsDirective = (
             resourceWithBadgesUrl: "@?",
             deleteRedirectUrl: "@?",
             assignBadges: "=?",
+            createDocument: "=?",
             share: "=?",
             hide: "=?",
             resourceWidgetDelete: "=?",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_moving_columns.scss
@@ -209,24 +209,6 @@ States:
     @include rem(padding, 0 0 0 $padding-small);
     background: $color-structure-normal;
 
-    .moving-column-menu-button {
-        @include rem(font-size, $font-size-small);
-        @include rem(margin-right, 30px);
-        display: inline-block;
-        color: $color-text-highlight-introvert;
-        font-weight: $font-weight-introvert;
-        float: left;
-        text-decoration: none;
-
-        &:hover, &:focus {
-            color: $color-text-highlight-extrovert;
-        }
-
-        &:active, &.is-active {
-            color: $color-text-highlight-normal;
-         }
-    }
-
     @media print {
         display: none;
     }

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProcessDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProcessDetailColumn.html
@@ -6,11 +6,6 @@
         <div class="moving-column-tab" data-ng-if="data.isShowMap">
             <i class="icon-map-filled moving-column-icon"></i>
         </div>
-        <adh-resource-actions
-            data-ng-if="processOptions.canPost(documentItemType) && tab === 'documents'"
-            data-ng-click="setCameFrom()"
-            data-resource-path="{{processUrl | adhParentPath}}"
-            data-create-document="true"></adh-resource-actions>
     </div>
 
     <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ processUrl | adhResourceUrl }}">
@@ -74,6 +69,10 @@
         </div>
 
         <div data-ng-if="tab === 'documents'">
+            <adh-resource-actions
+                data-ng-if="processOptions.canPost(documentItemType)"
+                data-resource-path="{{processUrl}}"
+                data-create-document="true"></adh-resource-actions>
             <div
                 class="map-info-persistent"
                 data-ng-if="data.isShowMap"

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProcessDetailColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProcessDetailColumn.html
@@ -6,12 +6,11 @@
         <div class="moving-column-tab" data-ng-if="data.isShowMap">
             <i class="icon-map-filled moving-column-icon"></i>
         </div>
-
-        <a
-            class="moving-column-menu-button"
+        <adh-resource-actions
+            data-ng-if="processOptions.canPost(documentItemType) && tab === 'documents'"
             data-ng-click="setCameFrom()"
-            href="{{ processUrl | adhResourceUrl:'create_document'}}"
-            data-ng-if="processOptions.canPost(documentItemType) && tab === 'documents'">{{ "TR__CREATE_DOCUMENT" | translate }}</a>
+            data-resource-path="{{processUrl | adhParentPath}}"
+            data-create-document="true"></adh-resource-actions>
     </div>
 
     <a class="moving-column-expand" data-ng-switch-when="collapsed" data-ng-href="{{ processUrl | adhResourceUrl }}">

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalEditColumn.html
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalEditColumn.html
@@ -3,9 +3,6 @@
         <div class="moving-column-tab">
             <i class="icon-document moving-column-icon"></i>
         </div>
-        <adh-resource-actions
-            data-resource-path="{{proposalUrl | adhParentPath}}"
-            data-cancel="true">
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>
@@ -18,6 +15,9 @@
     <adh-recompile-on-change
             data-ng-switch-when="body"
             data-value="{{proposalUrl}}">
+        <adh-resource-actions
+            data-resource-path="{{proposalUrl | adhParentPath}}"
+            data-cancel="true"></adh-resource-actions>
         <adh-pcompass-proposal-edit
             data-ng-if="proposalUrl"
             data-path="{{proposalUrl}}">

--- a/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalEditColumn.html
+++ b/src/pcompass/pcompass/static/js/Packages/Pcompass/Workbench/ProposalEditColumn.html
@@ -3,8 +3,9 @@
         <div class="moving-column-tab">
             <i class="icon-document moving-column-icon"></i>
         </div>
-        <a class="moving-column-menu-button" data-ng-href="{{ proposalUrl | adhParentPath | adhResourceUrl }}">{{ "TR__CANCEL" | translate }}</a>
-
+        <adh-resource-actions
+            data-resource-path="{{proposalUrl | adhParentPath}}"
+            data-cancel="true">
         <div class="moving-column-menu-nav">
             <a class="moving-column-menu-nav-button" data-ng-href="{{ processUrl | adhResourceUrl }}" title="{{ 'TR__CLOSE' | translate }}"><i class="icon-x moving-column-menu-nav-icon"></i></a>
         </div>

--- a/src/s1/s1/static/stylesheets/scss/components/_moving_columns_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_moving_columns_theme.scss
@@ -30,10 +30,6 @@
         line-height: inherit;
         padding-left: 0;
 
-        .moving-column-menu-button {
-            color: $color-brand-one-normal;
-        }
-
         .button {
             margin-right: 17px;
         }

--- a/src/spd/spd/static/js/Adhocracy.ts
+++ b/src/spd/spd/static/js/Adhocracy.ts
@@ -47,6 +47,7 @@ import * as AdhPermissionsModule from "./Packages/Permissions/Module";
 import * as AdhPreliminaryNamesModule from "./Packages/PreliminaryNames/Module";
 import * as AdhProcessModule from "./Packages/Process/Module";
 import * as AdhRateModule from "./Packages/Rate/Module";
+import * as AdhResourceActionsModule from "./Packages/ResourceActions/Module";
 import * as AdhResourceAreaModule from "./Packages/ResourceArea/Module";
 import * as AdhResourceWidgetsModule from "./Packages/ResourceWidgets/Module";
 import * as AdhShareSocialModule from "./Packages/ShareSocial/Module";
@@ -102,6 +103,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
         AdhDebateWorkbenchModule.moduleName,
         AdhEmbedModule.moduleName,
         AdhProcessModule.moduleName,
+        AdhResourceActionsModule.moduleName,
         AdhResourceAreaModule.moduleName,
         AdhTrackingModule.moduleName,
         AdhUserViewsModule.moduleName
@@ -199,6 +201,7 @@ export var init = (config : AdhConfig.IService, metaApi) => {
     AdhProcessModule.register(angular);
     AdhRateModule.register(angular);
     AdhAngularHelpersModule.register(angular);
+    AdhResourceActionsModule.register(angular);
     AdhResourceAreaModule.register(angular);
     AdhResourceWidgetsModule.register(angular);
     AdhShareSocialModule.register(angular);


### PR DESCRIPTION
This replaces the last few usages of `moving-column-menu-button` with resourceActions. It's necessary for implementing resource headers.

Unfortunately, none of this is tested due to backend bug #2513.