### PR TITLE
Allow multiple S1 processes

### DIFF
--- a/etc/frontend_development.ini.in
+++ b/etc/frontend_development.ini.in
@@ -84,12 +84,11 @@ adhocracy.trusted_domains =
 #     http://localhost:9000
 #     http://localhost:9001
 
-adhocracy.custom = mercator_platform_path financial_plan_url_de financial_plan_url_en show_add_button allow_rate embed_only hide_header s1_process_url
+adhocracy.custom = mercator_platform_path financial_plan_url_de financial_plan_url_en show_add_button allow_rate embed_only hide_header
 adhocracy.custom.mercator_platform_path = /mercator/
 adhocracy.custom.show_add_button = true
 adhocracy.custom.allow_rate = true
 adhocracy.custom.embed_only = false
-adhocracy.custom.s1_process_url = http://localhost:6541/s1/
 
 # if set to true the hader is not shown
 #adhocracy.custom.hide_header = true

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Module.ts
@@ -14,5 +14,6 @@ export var register = (angular) => {
         .directive("adhWorkflowSwitch", ["adhConfig", "adhHttp", "adhPermissions", "$window", AdhProcess.workflowSwitchDirective])
         .directive("adhProcessView", ["adhTopLevelState", "adhProcess", "$compile", AdhProcess.processViewDirective])
         .directive("adhProcessListItem", AdhProcess.listItemDirective)
-        .directive("adhProcessListing", ["adhConfig", AdhProcess.listingDirective]);
+        .directive("adhProcessListing", ["adhConfig", AdhProcess.listingDirective])
+        .directive("adhCurrentProcessTitle", ["adhTopLevelState", "adhHttp", AdhProcess.currentProcessTitleDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
@@ -9,6 +9,7 @@ import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as SIName from "../../Resources_/adhocracy_core/sheets/name/IName";
 import * as SIWorkflow from "../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
 import RIProcess from "../../Resources_/adhocracy_core/resources/process/IProcess";
+import * as SITitle from "../../Resources_/adhocracy_core/sheets/title/ITitle";
 
 var pkgLocation = "/Process";
 
@@ -170,3 +171,23 @@ export var listingDirective = (adhConfig : AdhConfig.IService) => {
         }
     };
 };
+
+export var currentProcessTitleDirective = (
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhHttp: AdhHttp.Service
+) => {
+    return {
+        restrict: "E",
+        scope: {},
+        template: "<a class=\"current-process-title\" data-ng-href=\"{{processUrl | adhResourceUrl}}\">{{processTitle}}</a>",
+        link: (scope) => {
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.on("processUrl", (processUrl) => {
+                adhHttp.get(processUrl).then((process) => {
+                    scope.processTitle = process.data[SITitle.nick].title;
+                });
+            }));
+        }
+    };
+};
+

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_workflow_switch.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_workflow_switch.scss
@@ -2,20 +2,14 @@ $state-height: 15px;
 
 .workflow-switch {
     @include clearfix;
-    @include rem(margin, 0 auto 27px);
-    width: $moving-column-single-width-max;
-}
+    @include rem(margin, 0 auto);
+    text-align: center;
 
-.workflow-switch.has-switch .workflow-switch-transcluded {
-    @include grid-span(9, 0);
+    > * {
+        display: inline-block;
+    }
 }
 
 .workflow-switch-container {
-    @include grid-span(3, 9);
-    text-align: center;
-
-    .button {
-        @include rem(line-height, $state-height);
-        height: auto;
-    }
+    margin-left: 20px;
 }

--- a/src/s1/s1/static/js/Packages/S1/Context/Context.ts
+++ b/src/s1/s1/static/js/Packages/S1/Context/Context.ts
@@ -18,7 +18,7 @@ export var headerDirective = (
         restrict: "E",
         templateUrl: adhConfig.pkg_path + pkgLocation + "/header.html",
         link: (scope) => {
-            scope.processUrl = adhConfig.custom["s1_process_url"];
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.bind("meeting", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
         }

--- a/src/s1/s1/static/js/Packages/S1/Context/header.html
+++ b/src/s1/s1/static/js/Packages/S1/Context/header.html
@@ -1,12 +1,7 @@
 <div class="s1-header">
-    <a class="s1-header-logo-link" data-ng-href="{{ processUrl | adhResourceUrl }}">
-        <i class="icon-partou-logo s1-header-logo" title="PARTOU."></i>
-    </a>
-
     <div class="s1-header-menu">
         <a class="s1-header-link button-cta-secondary" data-ng-class="{'is-active': meeting == 'archive'}" data-ng-href="{{ processUrl | adhResourceUrl:'archive' }}">{{ "TR__ARCHIVE" | translate }}</a>
         <adh-s1-meeting-selector data-process-url="{{ processUrl }}"></adh-s1-meeting-selector>
-        <adh-user-indicator data-separator="/"></adh-user-indicator>
     </div>
 </div>
 <adh-workflow-switch ng-if="'current' === meeting || 'next' === meeting" data-path="{{ processUrl }}">

--- a/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
+++ b/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
@@ -306,7 +306,7 @@ export var listingDirective = (
         },
         link: (scope) => {
             scope.contentType = RIProposalVersion.content_type;
-            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope)); // REFACT is this even neccessary?
             scope.params = {};
 
             if (scope.creator) {

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Landing.html
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Landing.html
@@ -1,5 +1,11 @@
 <div class="s1-landing">
 
+    <section class="s1-landing-section" data-ng-if="processTitle">
+        <h1 class="s1-landing-section-header">{{ processTitle }}</h1>
+        <adh-parse-markdown data-parsetext="processShortDescription"></adh-parse-markdown>
+        <adh-parse-markdown data-parsetext="processDescription"></adh-parse-markdown>
+    </section>
+
     <section class="s1-landing-section">
         <h1 class="s1-landing-section-header">{{ "TR__S1_INTRODUCTION_HEADER" | translate }}</h1>
         <p>{{ "TR__S1_INTRODUCTION_TEXT" | translate }}</p>

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Module.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Module.ts
@@ -14,6 +14,8 @@ import * as Workbench from "./Workbench";
 export var moduleName = "adhS1Workbench";
 
 export var register = (angular) => {
+    var processType = RIS1Process.content_type;
+
     angular
         .module(moduleName, [
             AdhCommentModule.moduleName,
@@ -22,7 +24,14 @@ export var register = (angular) => {
             AdhResourceAreaModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
-        .config(["adhResourceAreaProvider", Workbench.registerRoutes(RIS1Process.content_type)])
+        .config(["adhResourceAreaProvider", "adhConfig", (
+            adhResourceAreaProvider,
+            adhConfig
+        ) => {
+            var processHeaderSlot = adhConfig.pkg_path + Workbench.pkgLocation + "/ProcessHeaderSlot.html";
+            adhResourceAreaProvider.processHeaderSlots[processType] = processHeaderSlot;
+            Workbench.registerRoutes(processType)(adhResourceAreaProvider);
+        }])
         .config(["adhProcessProvider", (adhProcessProvider : AdhProcess.Provider) => {
             adhProcessProvider.templates[RIS1Process.content_type] = "<adh-s1-workbench></adh-s1-workbench>";
         }])

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Module.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Module.ts
@@ -1,5 +1,6 @@
 import * as AdhCommentModule from "../../Comment/Module";
 import * as AdhHttpModule from "../../Http/Module";
+import * as AdhMarkdownModule from "../../Markdown/Module";
 import * as AdhProcessModule from "../../Process/Module";
 import * as AdhResourceAreaModule from "../../ResourceArea/Module";
 import * as AdhTopLevelStateModule from "../../TopLevelState/Module";
@@ -20,6 +21,7 @@ export var register = (angular) => {
         .module(moduleName, [
             AdhCommentModule.moduleName,
             AdhHttpModule.moduleName,
+            AdhMarkdownModule.moduleName,
             AdhProcessModule.moduleName,
             AdhResourceAreaModule.moduleName,
             AdhTopLevelStateModule.moduleName
@@ -36,7 +38,7 @@ export var register = (angular) => {
             adhProcessProvider.templates[RIS1Process.content_type] = "<adh-s1-workbench></adh-s1-workbench>";
         }])
         .directive("adhS1Workbench", ["adhConfig", "adhTopLevelState", Workbench.s1WorkbenchDirective])
-        .directive("adhS1Landing", ["$translate", "adhConfig", "adhTopLevelState", Workbench.s1LandingDirective])
+        .directive("adhS1Landing", ["$translate", "adhConfig", "adhHttp", "adhTopLevelState", Workbench.s1LandingDirective])
         .directive("adhS1CurrentColumn", ["adhConfig", "adhHttp", "adhTopLevelState", Workbench.s1CurrentColumnDirective])
         .directive("adhS1NextColumn", ["adhConfig", "adhHttp", "adhTopLevelState", Workbench.s1NextColumnDirective])
         .directive("adhS1ArchiveColumn", ["adhConfig", "adhHttp", "adhTopLevelState", Workbench.s1ArchiveColumnDirective])

--- a/src/s1/s1/static/js/Packages/S1/Workbench/ProcessHeaderSlot.html
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/ProcessHeaderSlot.html
@@ -1,0 +1,1 @@
+<adh-s1-context-header data-ng-hide="hideHeader"></adh-s1-context-header>

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
@@ -16,7 +16,7 @@ import RIProposalVersion from "../../../Resources_/adhocracy_s1/resources/s1/IPr
 import * as SIComment from "../../../Resources_/adhocracy_core/sheets/comment/IComment";
 import * as SIWorkflowAssignment from "../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
 
-var pkgLocation = "/S1/Workbench";
+export var pkgLocation = "/S1/Workbench";
 
 
 export var s1WorkbenchDirective = (

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
@@ -14,6 +14,8 @@ import RIS1Process from "../../../Resources_/adhocracy_s1/resources/s1/IProcess"
 import RIProposal from "../../../Resources_/adhocracy_s1/resources/s1/IProposal";
 import RIProposalVersion from "../../../Resources_/adhocracy_s1/resources/s1/IProposalVersion";
 import * as SIComment from "../../../Resources_/adhocracy_core/sheets/comment/IComment";
+import * as SIDescription from "../../../Resources_/adhocracy_core/sheets/description/IDescription";
+import * as SITitle from "../../../Resources_/adhocracy_core/sheets/title/ITitle";
 import * as SIWorkflowAssignment from "../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
 
 export var pkgLocation = "/S1/Workbench";
@@ -248,6 +250,7 @@ export var s1ProposalEditColumnDirective = (
 export var s1LandingDirective = (
     $translate: any,
     adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service,
     adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
@@ -255,6 +258,13 @@ export var s1LandingDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Landing.html",
         link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            scope.$on("$destroy", adhTopLevelState.on("processUrl", (processUrl) => {
+                adhHttp.get(processUrl).then((process) => {
+                    scope.processTitle = process.data[SITitle.nick].title;
+                    scope.processShortDescription = process.data[SIDescription.nick].short_description;
+                    scope.processDescription = process.data[SIDescription.nick].description;
+                });
+            }));
             $translate("TR__S1_ABOUT_TEXT").then((translated) => {
                 scope.aboutText = translated;
             });

--- a/src/s1/s1/static/js/Packages/TopLevelState/templates/defaultHeader.html
+++ b/src/s1/s1/static/js/Packages/TopLevelState/templates/defaultHeader.html
@@ -1,1 +1,7 @@
-<adh-s1-context-header data-ng-hide="hideHeader"></adh-s1-context-header>
+<header>
+    <a class="s1-header-logo-link" data-ng-href="/">
+        <i class="icon-partou-logo s1-header-logo" title="PARTOU."></i>
+    </a>
+    <ng-include data-ng-if="areaHeaderSlot" src="areaHeaderSlot"></ng-include>
+    <adh-user-indicator data-separator="/"></adh-user-indicator>
+</header>

--- a/src/s1/s1/static/js/Packages/TopLevelState/templates/defaultHeader.html
+++ b/src/s1/s1/static/js/Packages/TopLevelState/templates/defaultHeader.html
@@ -2,6 +2,7 @@
     <a class="s1-header-logo-link" data-ng-href="/">
         <i class="icon-partou-logo s1-header-logo" title="PARTOU."></i>
     </a>
+    <adh-current-process-title></adh-current-process-title>
     <ng-include data-ng-if="areaHeaderSlot" src="areaHeaderSlot"></ng-include>
     <adh-user-indicator data-separator="/"></adh-user-indicator>
 </header>

--- a/src/s1/s1/static/stylesheets/scss/components/_s1_header.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_s1_header.scss
@@ -1,5 +1,21 @@
+.current-process-title {
+    top: rem(0px);
+    left: rem(170px);
+    position: absolute;
+    display: block;
+    line-height: rem(52px);
+
+    font-size: $font-size-large;
+    text-decoration: none;
+
+    &:hover, &:focus {
+        text-decoration: underline;
+    }
+}
+
 .s1-header {
-    @include rem(padding, 10px 0 17px);
+    margin-top: rem(50px);
+    margin-bottom: rem(10px);
 
     position: relative;
 }
@@ -25,8 +41,6 @@
 }
 
 .s1-header-menu {
-    // space for logo
-    @include rem(margin-left, 140px);
     white-space: nowrap;
     text-align: center;
 

--- a/src/s1/s1/static/stylesheets/scss/components/_s1_header.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_s1_header.scss
@@ -1,5 +1,5 @@
 .current-process-title {
-    top: rem(0px);
+    top: rem(0);
     left: rem(170px);
     position: absolute;
     display: block;

--- a/src/s1/s1/static/stylesheets/scss/components/_s1_landing.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_s1_landing.scss
@@ -1,9 +1,17 @@
 .s1-landing {
     @include container;
     background: $color-background-base-introvert;
+    min-width: rem($moving-column-single-width-min);
+    max-width: rem($moving-column-single-width-max);
+
+    // center and make scrollable
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
     margin: 0 auto;
-    min-width: $moving-column-single-width-min;
-    max-width: $moving-column-single-width-max;
+    overflow: auto;
 }
 
 .s1-landing-row,

--- a/src/s1/s1/static/stylesheets/scss/components/_s1_workflow_indicator.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_s1_workflow_indicator.scss
@@ -6,6 +6,7 @@ $state-height: 15px;
     border-radius: $state-height / 2;
     border: 1px solid $color-brand-one-normal;
     list-style: none;
+    width: 573px;
     padding: 0;
     margin: 0;
 }

--- a/src/s1/s1/static/stylesheets/scss/components/_user_indicator_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_user_indicator_theme.scss
@@ -1,3 +1,6 @@
 .user-indicator {
-    @include rem(padding, 10px);
+    padding: rem(10px);
+    position: absolute;
+    right: rem(10px);
+    top: 0;
 }

--- a/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
@@ -38,4 +38,4 @@ $color-button-cta-active-text: $color-text-inverted;
 
 $moving-column-menu-height: 30px / $font-size-normal * 1em;
 // REFACT consider pushing this into the standard variables
-$s1-header-height: 100px;
+$s1-header-height: 110px;

--- a/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/general/_variables_theme.scss
@@ -37,6 +37,5 @@ $color-button-cta-active-background: $color-brand-one-extrovert;
 $color-button-cta-active-text: $color-text-inverted;
 
 $moving-column-menu-height: 30px / $font-size-normal * 1em;
-$s1-header-width: 80%;
 // REFACT consider pushing this into the standard variables
 $s1-header-height: 100px;


### PR DESCRIPTION
* Don't use hardcoded `s1_process_url` for S1 header buttons
* Show meaningful process information in header and landing page

Note that this makes use of the header slot concept, so that other processes can also inject their `ProcessHeaderSlot` into the S1 platform header.