### PR TITLE
Allow everyone to view image files

### DIFF
--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -855,6 +855,17 @@ def add_localroles_sheet_to_pools(root, registry):  # pragma: no cover
     migrate_new_sheet(root, IPool, ILocalRoles)
 
 
+@log_migration
+def allow_image_download_view_for_everyone(root, registry):  # pragma: no cover
+    """Add acls to image downloads to allow view for everyone."""
+    from adhocracy_core.resources.image import IImageDownload
+    from adhocracy_core.resources.image import allow_view_eveyone
+    catalogs = find_service(root, 'catalogs')
+    image_downloads = _search_for_interfaces(catalogs, IImageDownload)
+    for image_download in image_downloads:
+        allow_view_eveyone(image_download, registry, {})
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -904,3 +915,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(add_localroles_sheet_to_pools)
     config.add_evolution_step(remove_comment_count_data)
     config.add_evolution_step(reindex_comments)
+    config.add_evolution_step(allow_image_download_view_for_everyone)

--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -158,6 +158,8 @@ image_meta = asset_meta._replace(
     iresource=IImage,
     is_implicit_addable=True,
     extended_sheets=(adhocracy_core.sheets.image.IImageMetadata,),
+    use_autonaming=False,
+    use_autonaming_random=True,
 )._add(after_creation=(add_image_size_downloads,))
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -1,6 +1,8 @@
 """image resource type."""
 import io
 
+from pyramid.authentication import Everyone
+from pyramid.authorization import Allow
 from pyramid.response import FileResponse
 from pyramid.registry import Registry
 from substanced.file import File
@@ -8,7 +10,9 @@ from PIL import Image
 from ZODB.blob import BlobError
 import transaction
 
+from adhocracy_core.authorization import set_acl
 from adhocracy_core.interfaces import Dimensions
+from adhocracy_core.interfaces import IResource
 from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources.asset import IAsset
 from adhocracy_core.resources.asset import IAssetDownload
@@ -17,6 +21,13 @@ from adhocracy_core.resources.asset import asset_download_meta
 from adhocracy_core.resources.asset import asset_meta
 from adhocracy_core.utils import get_matching_isheet
 import adhocracy_core.sheets.image
+
+
+def allow_view_eveyone(context: IResource, registry: Registry,
+                       options: dict):
+    """Add view permission for everyone for `context`."""
+    acl = [(Allow, Everyone, 'view')]
+    set_acl(context, acl, registry=registry)
 
 
 class IImageDownload(IAssetDownload):
@@ -120,7 +131,7 @@ image_download_meta = asset_download_meta._replace(
     iresource=IImageDownload,
     use_autonaming=True,
     content_class=ImageDownload,
-)
+)._add(after_creation=(allow_view_eveyone,))
 
 
 class IImage(IAsset):

--- a/src/adhocracy_core/adhocracy_core/resources/test_image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_image.py
@@ -45,6 +45,8 @@ class TestImageDownload:
         assert issubclass(meta.content_class, asset.AssetDownload)
         assert meta.permission_create == 'create_asset_download'
         assert meta.use_autonaming
+        assert meta.after_creation == (image.allow_view_eveyone,
+                                       )
 
     def test_get_response_return_asset_parent_data(self, inst, registry,
                                                    mock_sheet, asset):
@@ -98,6 +100,15 @@ class TestImageDownload:
         response = inst.get_response(registry)
         assert response is inst._get_response.return_value
         inst._upload_crop_and_resize.assert_called_with(original)
+
+    def test_allow_view_everyone(context, registry, mocker):
+        from . import image
+        from .image import allow_view_eveyone
+        set_acl = mocker.spy(image, 'set_acl')
+        allow_view_eveyone(context, registry, {})
+        set_acl.assert_called_with(context,
+                                   [('Allow', 'system.Everyone', 'view')],
+                                   registry=registry)
 
     @fixture
     def mock_file(self, mock_open):
@@ -246,4 +257,3 @@ class TestImage:
         assert meta['detail'].dimensions == Dimensions(height=800, width=800)
         assert meta['thumbnail'] == res['0000001']
         assert meta['thumbnail'].dimensions == Dimensions(height=100, width=100)
-

--- a/src/adhocracy_core/adhocracy_core/resources/test_image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_image.py
@@ -232,6 +232,8 @@ class TestImage:
         assert meta.iresource is image.IImage
         assert meta.is_implicit_addable is True
         assert meta.content_name == 'Image'
+        assert not meta.use_autonaming
+        assert meta.use_autonaming_random
         assert meta.extended_sheets ==\
                (adhocracy_core.sheets.image.IImageMetadata,)
         assert meta.after_creation == (asset.add_metadata,

--- a/src/adhocracy_core/docs/assets_and_images.rst
+++ b/src/adhocracy_core/docs/assets_and_images.rst
@@ -142,13 +142,14 @@ Now we can upload a sample picture::
     ...                        upload_files=upload_files).json
 
 In response, the backend sends a JSON document with the resource type and
-path of the new resource (just as with other resource types)::
+path of the new resource (just as with other resource types). The resource
+name is generated randomly::
 
     >>> resp_data["content_type"]
     'adhocracy_core.resources.image.IImage'
     >>> pic_path = resp_data["path"]
     >>> pic_path
-    'http://localhost/process/assets/0000000/'
+    'http://localhost/process/assets/.../'
 
 If the frontend tries to upload an asset that is overly large (more than 16
 MB), the backend responds with an error. Stricter size limits may be
@@ -175,11 +176,11 @@ the asset::
     >>> resp_image_meta = resp_data['data']['adhocracy_core.sheets.image.IImageMetadata']
     >>> pprint(resp_image_meta)
     {'attached_to': [],
-     'detail': 'http://localhost/process/assets/0000000/0000000/',
+     'detail': 'http://localhost/process/assets/.../0000000/',
      'filename': 'python.jpg',
      'mime_type': 'image/jpeg',
      'size': '159041',
-     'thumbnail': 'http://localhost/process/assets/0000000/0000001/'}
+     'thumbnail': 'http://localhost/process/assets/.../0000001/'}
 
 The actual binary data is *not* part of that JSON document::
 
@@ -275,7 +276,7 @@ As usual, the response lists the resources affected by the transaction::
     >>> sorted(updated_resources)
     ['changed_descendants', 'created', 'modified', 'removed']
     >>> resp_data['updated_resources']['modified']
-    ['http://localhost/process/assets/0000000/']
+    ['http://localhost/process/assets/.../']
     >>> 'http://localhost/process/' in updated_resources['changed_descendants']
     True
 
@@ -310,7 +311,7 @@ The image reference sheet also allows to refer to an external image url.
 
     >>> resp = admin.get(prop_v1_path).json
     >>> resp['data']['adhocracy_core.sheets.image.IImageReference']['picture']
-    '.../process/assets/0000000/'
+    '.../process/assets/.../'
     >>> resp['data']['adhocracy_core.sheets.image.IImageReference']['external_picture_url']
     ''
 
@@ -331,4 +332,4 @@ the backend downloads and references the given image url. The old picture
 reference is replaced with the newly created image.
 
     >>> resp['data']['adhocracy_core.sheets.image.IImageReference']['picture']
-    '.../process/assets/0000001/'
+    '.../process/assets/.../'


### PR DESCRIPTION
Fixes #1973 

To make it more difficult to view all images through the API, image resource names are now randomly generated.