### PR TITLE
use breadcrumbs instead of cancel links

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DebateWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DebateWorkbench.ts
@@ -53,7 +53,8 @@ export var documentDetailColumnDirective = (
 
 export var documentCreateColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhTopLevelState : AdhTopLevelState.Service
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhResourceUrl
 ) => {
     return {
         restrict: "E",
@@ -66,7 +67,8 @@ export var documentCreateColumnDirective = (
 
 export var documentEditColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhTopLevelState : AdhTopLevelState.Service
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhResourceUrl
 ) => {
     return {
         restrict: "E",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DebateWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DebateWorkbench.ts
@@ -53,8 +53,7 @@ export var documentDetailColumnDirective = (
 
 export var documentCreateColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhTopLevelState : AdhTopLevelState.Service,
-    adhResourceUrl
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",
@@ -67,8 +66,7 @@ export var documentCreateColumnDirective = (
 
 export var documentEditColumnDirective = (
     adhConfig : AdhConfig.IService,
-    adhTopLevelState : AdhTopLevelState.Service,
-    adhResourceUrl
+    adhTopLevelState : AdhTopLevelState.Service
 ) => {
     return {
         restrict: "E",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentCreateColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentCreateColumn.html
@@ -3,6 +3,9 @@
         <i class="icon-document moving-column-icon"></i>
     </div>
 
-    <adh-document-create data-ng-switch-when="body" data-path="{{processUrl}}" data-cancel-url="processUrl | adhResourceUrl">
+    <adh-document-create
+        data-ng-switch-when="body"
+        data-path="{{processUrl}}"
+        data-cancel-url="processUrl | adhResourceUrl">
     </adh-document-create>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentCreateColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentCreateColumn.html
@@ -3,6 +3,6 @@
         <i class="icon-document moving-column-icon"></i>
     </div>
 
-    <adh-document-create data-ng-switch-when="body" data-path="{{processUrl}}">
+    <adh-document-create data-ng-switch-when="body" data-path="{{processUrl}}" data-cancel-url="processUrl | adhResourceUrl">
     </adh-document-create>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentEditColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/DocumentEditColumn.html
@@ -13,13 +13,10 @@
     <adh-recompile-on-change
             data-ng-switch-when="body"
             data-value="{{documentUrl}}">
-        <adh-resource-actions
-            data-resource-path="{{documentUrl | adhParentPath}}"
-            data-cancel="true">
-        </adh-resource-actions>
         <adh-document-edit
             data-ng-if="documentUrl"
-            data-path="{{documentUrl}}">
+            data-path="{{documentUrl}}"
+            data-cancel-url="documentUrl | adhParentPath | adhResourceUrl">
         </adh-document-edit>
     </adh-recompile-on-change>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
@@ -36,9 +36,9 @@ export var register = (angular) => {
         .directive("adhDocumentDetailColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", DebateWorkbench.documentDetailColumnDirective])
         .directive("adhDocumentCreateColumn", [
-            "adhConfig", "adhTopLevelState", "adhResourceUrl", DebateWorkbench.documentCreateColumnDirective])
+            "adhConfig", "adhTopLevelState", DebateWorkbench.documentCreateColumnDirective])
         .directive("adhDocumentEditColumn", [
-            "adhConfig", "adhTopLevelState", "adhResourceUrl", DebateWorkbench.documentEditColumnDirective])
+            "adhConfig", "adhTopLevelState", DebateWorkbench.documentEditColumnDirective])
         .directive("adhDebateProcessDetailColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", DebateWorkbench.processDetailColumnDirective])
         .directive("adhDebateProcessDetailAnnounceColumn", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/DebateWorkbench/Module.ts
@@ -35,8 +35,10 @@ export var register = (angular) => {
         .directive("adhDebateWorkbench", ["adhConfig", "adhTopLevelState", DebateWorkbench.debateWorkbenchDirective])
         .directive("adhDocumentDetailColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", DebateWorkbench.documentDetailColumnDirective])
-        .directive("adhDocumentCreateColumn", ["adhConfig", "adhTopLevelState", DebateWorkbench.documentCreateColumnDirective])
-        .directive("adhDocumentEditColumn", ["adhConfig", "adhTopLevelState", DebateWorkbench.documentEditColumnDirective])
+        .directive("adhDocumentCreateColumn", [
+            "adhConfig", "adhTopLevelState", "adhResourceUrl", DebateWorkbench.documentCreateColumnDirective])
+        .directive("adhDocumentEditColumn", [
+            "adhConfig", "adhTopLevelState", "adhResourceUrl", DebateWorkbench.documentEditColumnDirective])
         .directive("adhDebateProcessDetailColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", DebateWorkbench.processDetailColumnDirective])
         .directive("adhDebateProcessDetailAnnounceColumn", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
@@ -1,7 +1,5 @@
 <div class="resource-navigation">
-    <div class="resource-navigation-breadcrumbs">
-        <a data-ng-href="{{cancelUrl}}">{{"TR__CANCEL" | translate}}</a>
-    </div>
+    <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
 </div>
 <form
     novalidate="novalidate"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
@@ -1,3 +1,8 @@
+<div class="resource-navigation">
+    <div class="resource-navigation-breadcrumbs">
+        <a data-ng-href="{{cancelUrl}}">← {{"TR__CANCEL" | translate}}</a>
+    </div>
+</div>
 <form
     novalidate="novalidate"
     data-ng-submit="submit()"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
@@ -1,6 +1,6 @@
 <div class="resource-navigation">
     <div class="resource-navigation-breadcrumbs">
-        <a data-ng-href="{{cancelUrl}}">← {{"TR__CANCEL" | translate}}</a>
+        <a data-ng-href="{{cancelUrl}}">{{"TR__CANCEL" | translate}}</a>
     </div>
 </div>
 <form

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Create.html
@@ -1,5 +1,7 @@
 <div class="resource-navigation">
-    <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
+    <div class="resource-navigation-breadcrumbs">
+        <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
+    </div>
 </div>
 <form
     novalidate="novalidate"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Detail.html
@@ -9,24 +9,20 @@
             data-print="true">
         </adh-resource-dropdown>
     </div>
-    <header class="resource-header" data-ng-class="{'m-image': data.picture}">
-        <adh-background-image
-            data-css-path="document-detail-image"
-            data-no-fallback="true"
-            data-path="{{data.picture}}">
-            <div class="resource-header-main-wrapper">
-                <div class="resource-header-main">
-                    <h1 class="resource-header-title">{{ data.title }}</h1>
+    <adh-background-image
+        data-css-path="document-detail-image"
+        data-no-fallback="true"
+        data-path="{{data.picture}}">
+        <header class="resource-header" data-ng-class="{'m-image': data.picture}">
+            <h1 class="resource-header-title">{{ data.title }}</h1>
 
-                    <ul class="resource-header-meta">
-                        <li>
-                            <i class="icon-speechbubble"></i> {{ data.commentCountTotal }} {{ "TR__COMMENTS_TOTAL" | translate }}
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </adh-background-image>
-    </header>
+            <ul class="resource-header-meta">
+                <li>
+                    <i class="icon-speechbubble"></i> {{ data.commentCountTotal }} {{ "TR__COMMENTS_TOTAL" | translate }}
+                </li>
+            </ul>
+        </header>
+    </adh-background-image>
 
     <div class="jump-navigation-wrapper m-narrow">
         <nav class="jump-navigation m-unnumbered" data-adh-sticky="" data-ng-if="data.paragraphs.length > 1">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Detail.html
@@ -1,15 +1,15 @@
 <article class="document-detail">
+    <div class="resource-navigation">
+        <adh-resource-dropdown
+            data-resource-path="{{path | adhParentPath}}"
+            data-ng-if="path"
+            data-edit="true"
+            data-report="true"
+            data-hide="true"
+            data-print="true">
+        </adh-resource-dropdown>
+    </div>
     <header class="resource-header" data-ng-class="{'m-image': data.picture}">
-        <div class="resource-navigation">
-            <adh-resource-dropdown
-                data-resource-path="{{path | adhParentPath}}"
-                data-ng-if="path"
-                data-edit="true"
-                data-report="true"
-                data-hide="true"
-                data-print="true">
-            </adh-resource-dropdown>
-        </div>
         <adh-background-image
             data-css-path="document-detail-image"
             data-no-fallback="true"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Detail.html
@@ -1,6 +1,6 @@
 <article class="document-detail">
     <header class="resource-header" data-ng-class="{'m-image': data.picture}">
-        <div class="resource-header-navigation">
+        <div class="resource-navigation">
             <adh-resource-dropdown
                 data-resource-path="{{path | adhParentPath}}"
                 data-ng-if="path"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Document.ts
@@ -455,7 +455,8 @@ export var createDirective = (
             path: "@",
             hasMap: "=?",
             hasImage: "=?",
-            polygon: "=?"
+            polygon: "=?",
+            cancelUrl: "=?"
         },
         link: (scope : IFormScope, element) => {
             scope.errors = [];
@@ -525,7 +526,8 @@ export var editDirective = (
             hasMap: "=?",
             hasBadges: "=?",
             hasImage: "=?",
-            polygon: "=?"
+            polygon: "=?",
+            cancelUrl: "=?"
         },
         link: (scope : IFormScope, element) => {
             scope.errors = [];

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Create.html
@@ -1,7 +1,5 @@
 <div class="resource-navigation">
-    <div class="resource-navigation-breadcrumbs">
-        <a data-ng-href="{{cancelUrl}}">{{"TR__CANCEL" | translate}}</a>
-    </div>
+    <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
 </div>
 <form
     novalidate="novalidate"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Create.html
@@ -1,3 +1,8 @@
+<div class="resource-navigation">
+    <div class="resource-navigation-breadcrumbs">
+        <a data-ng-href="{{cancelUrl}}">← {{"TR__CANCEL" | translate}}</a>
+    </div>
+</div>
 <form
     novalidate="novalidate"
     data-ng-submit="submit()"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Create.html
@@ -1,6 +1,6 @@
 <div class="resource-navigation">
     <div class="resource-navigation-breadcrumbs">
-        <a data-ng-href="{{cancelUrl}}">← {{"TR__CANCEL" | translate}}</a>
+        <a data-ng-href="{{cancelUrl}}">{{"TR__CANCEL" | translate}}</a>
     </div>
 </div>
 <form

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Create.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Create.html
@@ -1,5 +1,7 @@
 <div class="resource-navigation">
-    <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
+    <div class="resource-navigation-breadcrumbs">
+        <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
+    </div>
 </div>
 <form
     novalidate="novalidate"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
@@ -12,51 +12,47 @@
             data-print="true">
         </adh-resource-dropdown>
     </div>
-    <header class="resource-header" data-ng-class="{'m-image': data.picture}">
-        <adh-background-image
-            data-no-fallback="true"
-            data-path="{{data.picture}}">
-            <div class="resource-header-main-wrapper">
-                <div class="resource-header-main">
-                    <div class="resource-header-meta">
-                        <span
-                            data-ng-repeat="assignment in data.assignments"
-                            class="badge"
-                            data-ng-class="{
-                                'm-is-realized': assignment.name === 'going_to_be_realized',
-                                'm-is-not-realized': assignment.name === 'not_realizeable',
-                                'm-on-test': assignment.name === 'on_test'
-                            }">{{ assignment.title | translate }}</span>
-                    </div>
-
-                    <h1 class="resource-header-title">{{ data.title }}</h1>
-
-                    <ul class="resource-header-meta">
-                        <li data-ng-if="processProperties.hasLocationText">
-                            <i class="icon-pin-detail"></i> {{data.locationText}}
-                        </li>
-                        <li data-ng-if="processProperties.maxBudget">
-                            <i class="icon-budget"></i> {{data.budget | numberOrDash}} &euro;
-                        </li>
-                        <li>
-                            {{ "TR__BY" | translate }} <adh-user-meta data-path="{{data.creator}}" data-ng-if="data.creator"></adh-user-meta>
-                        </li>
-                        <li>
-                            {{ "TR__ON" | translate }} <adh-time data-datetime="data.creationDate" data-format="L"></adh-time>
-                        </li>
-                        <li>
-                            <a href="{{ path | adhParentPath | adhResourceUrl:'comments' }}"
-                                ><i class="icon-speechbubble"></i> {{ data.commentCount }} {{ "TR__COMMENTS" | translate }}</a>
-                        </li>
-                    </ul>
-
-                    <div class="resource-header-action">
-                        <adh-rate data-refers-to="{{path}}"></adh-rate>
-                    </div>
-                </div>
+    <adh-background-image
+        data-no-fallback="true"
+        data-path="{{data.picture}}">
+        <header class="resource-header" data-ng-class="{'m-image': data.picture}">
+            <div class="resource-header-meta">
+                <span
+                    data-ng-repeat="assignment in data.assignments"
+                    class="badge"
+                    data-ng-class="{
+                        'm-is-realized': assignment.name === 'going_to_be_realized',
+                        'm-is-not-realized': assignment.name === 'not_realizeable',
+                        'm-on-test': assignment.name === 'on_test'
+                    }">{{ assignment.title | translate }}</span>
             </div>
-        </adh-background-image>
-    </header>
+
+            <h1 class="resource-header-title">{{ data.title }}</h1>
+
+            <ul class="resource-header-meta">
+                <li data-ng-if="processProperties.hasLocationText">
+                    <i class="icon-pin-detail"></i> {{data.locationText}}
+                </li>
+                <li data-ng-if="processProperties.maxBudget">
+                    <i class="icon-budget"></i> {{data.budget | numberOrDash}} &euro;
+                </li>
+                <li>
+                    {{ "TR__BY" | translate }} <adh-user-meta data-path="{{data.creator}}" data-ng-if="data.creator"></adh-user-meta>
+                </li>
+                <li>
+                    {{ "TR__ON" | translate }} <adh-time data-datetime="data.creationDate" data-format="L"></adh-time>
+                </li>
+                <li>
+                    <a href="{{ path | adhParentPath | adhResourceUrl:'comments' }}"
+                        ><i class="icon-speechbubble"></i> {{ data.commentCount }} {{ "TR__COMMENTS" | translate }}</a>
+                </li>
+            </ul>
+
+            <div class="resource-header-action">
+                <adh-rate data-refers-to="{{path}}"></adh-rate>
+            </div>
+        </header>
+    </adh-background-image>
 
 
     <section class="action-section">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
@@ -1,6 +1,6 @@
 <article>
     <header class="resource-header" data-ng-class="{'m-image': data.picture}">
-        <div class="resource-header-navigation">
+        <div class="resource-navigation">
             <adh-resource-dropdown
                 data-resource-path="{{path | adhParentPath}}"
                 data-resource-with-badges-url="{{processUrl}}"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
@@ -1,18 +1,18 @@
 <article>
+    <div class="resource-navigation">
+        <adh-resource-dropdown
+            data-resource-path="{{path | adhParentPath}}"
+            data-resource-with-badges-url="{{processUrl}}"
+            data-ng-if="path"
+            data-edit="true"
+            data-image="processProperties.hasImage"
+            data-assign-badges="true"
+            data-report="true"
+            data-hide="true"
+            data-print="true">
+        </adh-resource-dropdown>
+    </div>
     <header class="resource-header" data-ng-class="{'m-image': data.picture}">
-        <div class="resource-navigation">
-            <adh-resource-dropdown
-                data-resource-path="{{path | adhParentPath}}"
-                data-resource-with-badges-url="{{processUrl}}"
-                data-ng-if="path"
-                data-edit="true"
-                data-image="processProperties.hasImage"
-                data-assign-badges="true"
-                data-report="true"
-                data-hide="true"
-                data-print="true">
-            </adh-resource-dropdown>
-        </div>
         <adh-background-image
             data-no-fallback="true"
             data-path="{{data.picture}}">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Proposal.ts
@@ -330,7 +330,8 @@ export var createDirective = (
         restrict: "E",
         scope: {
             poolPath: "@",
-            processProperties: "="
+            processProperties: "=",
+            cancelUrl: "=?"
         },
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
         link: (scope, element) => {
@@ -388,7 +389,8 @@ export var editDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
         scope: {
             path: "@",
-            processProperties: "="
+            processProperties: "=",
+            cancelUrl: "=?"
         },
         link: (scope, element) => {
             scope.errors = [];

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalCreateColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalCreateColumn.html
@@ -12,6 +12,7 @@
     <adh-idea-collection-proposal-create
         data-ng-switch-when="body"
         data-pool-path="{{processUrl}}"
-        data-process-properties="processProperties">
+        data-process-properties="processProperties"
+        data-cancel-url="processUrl | adhResourceUrl">
     </adh-idea-collection-proposal-create>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalEditColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalEditColumn.html
@@ -15,14 +15,11 @@
     <adh-recompile-on-change
             data-ng-switch-when="body"
             data-value="{{proposalUrl}}">
-        <adh-resource-actions
-            data-resource-path="{{proposalUrl | adhParentPath}}"
-            data-cancel="true">
-        </adh-resource-actions>
         <adh-idea-collection-proposal-edit
             data-ng-if="proposalUrl"
             data-process-properties="processProperties"
-            data-path="{{proposalUrl}}">
+            data-path="{{proposalUrl}}"
+            data-cancel-url="proposalUrl | adhParentPath | adhResourceUrl">
         </adh-idea-collection-proposal-edit>
     </adh-recompile-on-change>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalImageColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/ProposalImageColumn.html
@@ -13,15 +13,12 @@
     </a>
 
     <div data-ng-switch-when="body">
-        <adh-resource-actions
-            data-resource-path="{{documentUrl | adhParentPath}}"
-            data-cancel="true">
-        </adh-resource-actions>
         <adh-upload-image
             data-ng-if="proposalUrl"
             data-path="{{proposalUrl}}"
             data-pool-path="{{processUrl}}"
             data-did-complete-upload="goBack()"
-        ></adh-upload-image>
+            data-cancel-url="proposalUrl | adhParentPath | adhResourceUrl">
+        </adh-upload-image>
     </div>
 </div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Image.ts
@@ -107,7 +107,8 @@ export var uploadImageDirective = (
             poolPath: "@",
             path: "@",
             didCompleteUpload: "&?",
-            didCancelUpload: "&?"
+            didCancelUpload: "&?",
+            cancelUrl: "=?"
         },
         link: (scope) => {
             scope.$flow = flowFactory.create();

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
@@ -1,7 +1,5 @@
-<div class="resource-navigation">
-    <div class="resource-navigation-breadcrumbs">
-        <a data-ng-href="{{cancelUrl}}">{{"TR__CANCEL" | translate}}</a>
-    </div>
+<div class="resource-navigation" data-ng-if="cancelUrl">
+    <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
 </div>
 <form name="imageUpload" data-ng-submit="submit()" data-ng-if="$flow.support" class="image-upload m-standalone">
     <span class="label-text">{{ "TR__IMAGE_UPLOAD" | translate }}</span>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
@@ -1,5 +1,7 @@
 <div class="resource-navigation" data-ng-if="cancelUrl">
-    <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
+    <div class="resource-navigation-breadcrumbs">
+        <adh-go-to-came-from data-default="cancelUrl"></adh-go-to-came-from>
+    </div>
 </div>
 <form name="imageUpload" data-ng-submit="submit()" data-ng-if="$flow.support" class="image-upload m-standalone">
     <span class="label-text">{{ "TR__IMAGE_UPLOAD" | translate }}</span>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
@@ -1,6 +1,6 @@
 <div class="resource-navigation">
     <div class="resource-navigation-breadcrumbs">
-        <a data-ng-href="{{cancelUrl}}">← {{"TR__CANCEL" | translate}}</a>
+        <a data-ng-href="{{cancelUrl}}">{{"TR__CANCEL" | translate}}</a>
     </div>
 </div>
 <form name="imageUpload" data-ng-submit="submit()" data-ng-if="$flow.support" class="image-upload m-standalone">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Image/Upload.html
@@ -1,3 +1,8 @@
+<div class="resource-navigation">
+    <div class="resource-navigation-breadcrumbs">
+        <a data-ng-href="{{cancelUrl}}">← {{"TR__CANCEL" | translate}}</a>
+    </div>
+</div>
 <form name="imageUpload" data-ng-submit="submit()" data-ng-if="$flow.support" class="image-upload m-standalone">
     <span class="label-text">{{ "TR__IMAGE_UPLOAD" | translate }}</span>
     <div

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -114,6 +114,7 @@ export var resourceDropdownDirective = (
             report: "=?",
             cancel: "=?",
             edit: "=?",
+            image: "=?",
             moderate: "=?",
             modals: "=?"
         },
@@ -131,6 +132,7 @@ export var resourceDropdownDirective = (
                 report: scope.report,
                 cancel: scope.cancel,
                 edit: scope.edit,
+                image: scope.image,
                 moderate: scope.moderate,
                 modals: scope.modals
             };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceDropdown.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceDropdown.html
@@ -1,4 +1,4 @@
-<div class="dropdown m-right resource-header-actions" data-ng-if="!data.modals.modal && data.isShowDropdownMenu">
+<div class="dropdown m-right resource-navigation-actions" data-ng-if="!data.modals.modal && data.isShowDropdownMenu">
     <a class="dropdown-button" href="" aria-haspopup="true" aria-expanded="{{isShowDropdown}}" data-ng-click="data.toggleDropdown()" id="{{id}}">
         <i class="icon-three-dots"></i>
     </a>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/Module.ts
@@ -18,5 +18,6 @@ export var register = (angular) => {
         .directive("adhDefaultHeader", ["adhConfig", "adhTopLevelState", AdhTopLevelState.defaultHeaderDirective])
         .directive("adhRoutingError", ["adhConfig", AdhTopLevelState.routingErrorDirective])
         .directive("adhSpace", ["adhTopLevelState", AdhTopLevelState.spaceDirective])
-        .directive("adhView", ["adhTopLevelState", "$compile", AdhTopLevelState.viewFactory]);
+        .directive("adhView", ["adhTopLevelState", "$compile", AdhTopLevelState.viewFactory])
+        .directive("adhGoToCameFrom", ["adhTopLevelState", AdhTopLevelState.goToCameFromDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -496,12 +496,12 @@ export var goToCameFromDirective = (adhTopLevelState : Service) => {
         template: "<div class=\"resource-navigation-breadcrumbs\"><a href=\"\" data-ng-click=\"cancel()\">" +
             "{{\"TR__CANCEL\" | translate}}</a></div>",
         scope: {
-			default: "="
-		},
+            default: "="
+        },
         link: (scope) => {
             scope.cancel = () => {
-				adhTopLevelState.goToCameFrom(scope.default);
-			};
+                adhTopLevelState.goToCameFrom(scope.default);
+            };
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -493,8 +493,7 @@ export var routingErrorDirective = (adhConfig  : AdhConfig.IService) => {
 export var goToCameFromDirective = (adhTopLevelState : Service) => {
     return {
         restrict: "E",
-        template: "<div class=\"resource-navigation-breadcrumbs\"><a href=\"\" data-ng-click=\"cancel()\">" +
-            "{{\"TR__CANCEL\" | translate}}</a></div>",
+        template: "<a href=\"\" data-ng-click=\"cancel()\">{{\"TR__CANCEL\" | translate}}</a>",
         scope: {
             default: "="
         },

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/TopLevelState/TopLevelState.ts
@@ -488,3 +488,20 @@ export var routingErrorDirective = (adhConfig  : AdhConfig.IService) => {
         }]
     };
 };
+
+
+export var goToCameFromDirective = (adhTopLevelState : Service) => {
+    return {
+        restrict: "E",
+        template: "<div class=\"resource-navigation-breadcrumbs\"><a href=\"\" data-ng-click=\"cancel()\">" +
+            "{{\"TR__CANCEL\" | translate}}</a></div>",
+        scope: {
+			default: "="
+		},
+        link: (scope) => {
+            scope.cancel = () => {
+				adhTopLevelState.goToCameFrom(scope.default);
+			};
+        }
+    };
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -7,16 +7,9 @@ category: Widgets
 
 The resource header should be used as a consistent header for resources such as
 processes, proposals or documents. It contains a title, some meta-information,
-a primary action (e.g. create proposal or like) and a dropdown with resource
-actions (edit, share, report, print, ...).
+and a primary action (e.g. create proposal or like).
 
 ```html_example
-<div class="resource-navigation">
-    <div class="resource-navigation-breadcrumbs">
-        <a href="#">← to process</a>
-    </div>
-    <a href="#" class="resource-navigation-actions">…</a>
-</div>
 <header class="resource-header">
     <div class="resource-header-main-wrapper">
         <div class="resource-header-main">
@@ -83,26 +76,6 @@ actions (edit, share, report, print, ...).
     }
 }
 
-.resource-navigation {
-    padding: $padding;
-}
-
-.resource-navigation-actions {
-    position: absolute;
-    right: 0;
-    top: 0;
-}
-
-.resource-navigation-breadcrumbs {
-    a {
-        color: inherit;
-        text-transform: uppercase;
-        text-decoration: none;
-        font-size: $font-size-small;
-        font-weight: bold;
-    }
-}
-
 /*doc
 ---
 title: image modifier
@@ -113,12 +86,6 @@ parent: resource-header
 Resource headers can have a background image.
 
 ```html_example
-<div class="resource-navigation">
-    <div class="resource-navigation-breadcrumbs">
-        <a href="#">← to process</a>
-    </div>
-    <a href="#" class="resource-navigation-actions">…</a>
-</div>
 <header class="resource-header m-image">
     <div class="image-background" style="background-image: url('/static/images/sample.jpg')">
         <div class="resource-header-main-wrapper">
@@ -145,5 +112,50 @@ Resource headers can have a background image.
     .resource-header-title,
     .resource-header-meta {
         color: inherit;
+    }
+}
+
+/*doc
+---
+title: Resource Navigation
+name: resource-navigation
+parent: resource-header
+---
+
+The resource navigation is usually displayed above the resource header, but it
+may also be used on its own. It contains breadcrumbs and a dropdown with
+resource actions (edit, share, report, print, ...).
+
+```html_example
+<div class="resource-navigation">
+    <nav class="resource-navigation-breadcrumbs">
+        <a href="#">← to process</a>
+        <a href="#">← to propoposal</a>
+    </nav>
+    <div class="dropdown m-right resource-navigation-actions">
+        <a href="#" class="dropdown-button">
+            <i class="icon-three-dots"></i>
+        </a>
+    </div>
+</div>
+```
+*/
+.resource-navigation {
+    padding: $padding;
+}
+
+.resource-navigation-actions {
+    position: absolute;
+    right: 0;
+    top: 0;
+}
+
+.resource-navigation-breadcrumbs {
+    a {
+        color: inherit;
+        text-transform: uppercase;
+        text-decoration: none;
+        font-size: $font-size-small;
+        font-weight: bold;
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -157,6 +157,7 @@ resource actions (edit, share, report, print, ...).
         text-decoration: none;
         font-size: $font-size-small;
         font-weight: bold;
+        margin-right: 1em;
 
         &:before {
             content: "← ";

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -12,11 +12,11 @@ actions (edit, share, report, print, ...).
 
 ```html_example
 <header class="resource-header">
-    <div class="resource-header-navigation">
-        <div class="resource-header-breadcrumbs">
+    <div class="resource-navigation">
+        <div class="resource-navigation-breadcrumbs">
             <a href="#">← to process</a>
         </div>
-        <a href="#" class="resource-header-actions">…</a>
+        <a href="#" class="resource-navigation-actions">…</a>
     </div>
     <div class="resource-header-main-wrapper">
         <div class="resource-header-main">
@@ -83,13 +83,13 @@ actions (edit, share, report, print, ...).
     }
 }
 
-.resource-header-actions {
+.resource-navigation-actions {
     position: absolute;
     right: 0;
     top: 0;
 }
 
-.resource-header-breadcrumbs {
+.resource-navigation-breadcrumbs {
     a {
         color: inherit;
         text-transform: uppercase;
@@ -109,11 +109,11 @@ Resource headers can have a background image.
 
 ```html_example
 <header class="resource-header m-image">
-    <div class="resource-header-navigation">
-        <div class="resource-header-breadcrumbs">
+    <div class="resource-navigation">
+        <div class="resource-navigation-breadcrumbs">
             <a href="#">← to process</a>
         </div>
-        <a href="#" class="resource-header-actions">…</a>
+        <a href="#" class="resource-navigation-actions">…</a>
     </div>
     <div class="image-background" style="background-image: url('/static/images/sample.jpg')">
         <div class="resource-header-main-wrapper">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -45,6 +45,7 @@ and a primary action (e.g. create proposal or like).
     color: $color-text-introvert;
     font-weight: bold;
     list-style: none;
+    padding: 0;
 
     li {
         display: inline;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -11,13 +11,13 @@ a primary action (e.g. create proposal or like) and a dropdown with resource
 actions (edit, share, report, print, ...).
 
 ```html_example
-<header class="resource-header">
-    <div class="resource-navigation">
-        <div class="resource-navigation-breadcrumbs">
-            <a href="#">← to process</a>
-        </div>
-        <a href="#" class="resource-navigation-actions">…</a>
+<div class="resource-navigation">
+    <div class="resource-navigation-breadcrumbs">
+        <a href="#">← to process</a>
     </div>
+    <a href="#" class="resource-navigation-actions">…</a>
+</div>
+<header class="resource-header">
     <div class="resource-header-main-wrapper">
         <div class="resource-header-main">
             <h1 class="resource-header-title">Johannisthal</h1>
@@ -83,6 +83,10 @@ actions (edit, share, report, print, ...).
     }
 }
 
+.resource-navigation {
+    padding: $padding;
+}
+
 .resource-navigation-actions {
     position: absolute;
     right: 0;
@@ -109,13 +113,13 @@ parent: resource-header
 Resource headers can have a background image.
 
 ```html_example
-<header class="resource-header m-image">
-    <div class="resource-navigation">
-        <div class="resource-navigation-breadcrumbs">
-            <a href="#">← to process</a>
-        </div>
-        <a href="#" class="resource-navigation-actions">…</a>
+<div class="resource-navigation">
+    <div class="resource-navigation-breadcrumbs">
+        <a href="#">← to process</a>
     </div>
+    <a href="#" class="resource-navigation-actions">…</a>
+</div>
+<header class="resource-header m-image">
     <div class="image-background" style="background-image: url('/static/images/sample.jpg')">
         <div class="resource-header-main-wrapper">
             <div class="resource-header-main">

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -129,8 +129,8 @@ resource actions (edit, share, report, print, ...).
 ```html_example
 <div class="resource-navigation">
     <nav class="resource-navigation-breadcrumbs">
-        <a href="#">← to process</a>
-        <a href="#">← to propoposal</a>
+        <a href="#">to process</a>
+        <a href="#">to propoposal</a>
     </nav>
     <div class="dropdown m-right resource-navigation-actions">
         <a href="#" class="dropdown-button">
@@ -157,5 +157,9 @@ resource actions (edit, share, report, print, ...).
         text-decoration: none;
         font-size: $font-size-small;
         font-weight: bold;
+
+        &:before {
+            content: "← ";
+        }
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -141,16 +141,17 @@ resource actions (edit, share, report, print, ...).
 ```
 */
 .resource-navigation {
+    @include pie-clearfix;
     padding: $padding;
 }
 
 .resource-navigation-actions {
-    position: absolute;
-    right: 0;
-    top: 0;
+    float: right;
 }
 
 .resource-navigation-breadcrumbs {
+    float: left;
+
     a {
         color: inherit;
         text-transform: uppercase;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -11,34 +11,21 @@ and a primary action (e.g. create proposal or like).
 
 ```html_example
 <header class="resource-header">
-    <div class="resource-header-main-wrapper">
-        <div class="resource-header-main">
-            <h1 class="resource-header-title">Johannisthal</h1>
-            <ul class="resource-header-meta">
-                <li>Bebauungsplanverfahren 184a</li>
-                <li>Öffentliche auslegung</li>
-                <li>22.9.-22.10.15</li>
-            </ul>
-            <div class="resource-header-action"><a href="#" class="button-cta">Create proposal</a></div>
-        </div>
-    </div>
+    <h1 class="resource-header-title">Johannisthal</h1>
+    <ul class="resource-header-meta">
+        <li>Bebauungsplanverfahren 184a</li>
+        <li>Öffentliche auslegung</li>
+        <li>22.9.-22.10.15</li>
+    </ul>
+    <div class="resource-header-action"><a href="#" class="button-cta">Create proposal</a></div>
 </header>
 ```
 */
 .resource-header {
+    @include rem(padding, 3rem 4rem 4rem);
     position: relative;
-    padding: $padding;
     margin-bottom: $padding;
     z-index: 0;
-}
-
-.resource-header-main-wrapper {
-    padding: 1px;  // clear margins
-}
-
-.resource-header-main {
-    @include rem(margin, 3em auto 4rem);
-    max-width: 40em;
     text-align: center;
 }
 
@@ -86,28 +73,22 @@ parent: resource-header
 Resource headers can have a background image.
 
 ```html_example
-<header class="resource-header m-image">
-    <div class="image-background" style="background-image: url('/static/images/sample.jpg')">
-        <div class="resource-header-main-wrapper">
-            <div class="resource-header-main">
-                <h1 class="resource-header-title">Johannisthal</h1>
-                <ul class="resource-header-meta">
-                    <li>Bebauungsplanverfahren 184a</li>
-                    <li>Öffentliche auslegung</li>
-                    <li>22.9.-22.10.15</li>
-                </ul>
-                <div class="resource-header-action"><a href="#" class="button-cta">Create proposal</a></div>
-            </div>
-        </div>
-    </div>
-</header>
+<div class="image-background" style="background-image: url('/static/images/sample.jpg')">
+    <header class="resource-header m-image">
+        <h1 class="resource-header-title">Johannisthal</h1>
+        <ul class="resource-header-meta">
+            <li>Bebauungsplanverfahren 184a</li>
+            <li>Öffentliche auslegung</li>
+            <li>22.9.-22.10.15</li>
+        </ul>
+        <div class="resource-header-action"><a href="#" class="button-cta">Create proposal</a></div>
+    </header>
+</div>
 ```
 */
 .resource-header.m-image {
-    .resource-header-main-wrapper {
-        color: $color-text-inverted;
-        background: rgba($color-brand-one-introvert, 0.8);
-    }
+    color: $color-text-inverted;
+    background: rgba($color-brand-one-introvert, 0.8);
 
     .resource-header-title,
     .resource-header-meta {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_resource_header.scss
@@ -93,6 +93,7 @@ actions (edit, share, report, print, ...).
     a {
         color: inherit;
         text-transform: uppercase;
+        text-decoration: none;
         font-size: $font-size-small;
         font-weight: bold;
     }

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
@@ -11,7 +11,7 @@
         </div>
     </a>
 
-    <div class="tabs" data-ng-switch-when="body">
+    <div data-ng-switch-when="body">
         <adh-document-create data-path="{{processUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon" data-cancel-url="processUrl | adhResourceUrl"></adh-document-create>
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
@@ -12,6 +12,12 @@
     </a>
 
     <div data-ng-switch-when="body">
-        <adh-document-create data-path="{{processUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon" data-cancel-url="processUrl | adhResourceUrl"></adh-document-create>
+        <adh-document-create
+            data-path="{{processUrl}}"
+            data-has-map="true"
+            data-has-image="true"
+            data-polygon="polygon"
+            data-cancel-url="processUrl | adhResourceUrl">
+        </adh-document-create>
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentCreateColumn.html
@@ -11,11 +11,7 @@
         </div>
     </a>
 
-    <div data-ng-switch-when="body">
-        <adh-resource-actions
-            data-resource-path="{{processUrl}}"
-            data-cancel="true">
-        </adh-resource-actions>
-        <adh-document-create data-path="{{processUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon"></adh-document-create>
+    <div class="tabs" data-ng-switch-when="body">
+        <adh-document-create data-path="{{processUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon" data-cancel-url="processUrl | adhResourceUrl"></adh-document-create>
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentEditColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentEditColumn.html
@@ -16,10 +16,6 @@
     </a>
 
     <div data-ng-switch-when="body">
-        <adh-resource-actions
-            data-resource-path="{{documentUrl | adhParentPath}}"
-            data-cancel="true">
-        </adh-resource-actions>
-        <adh-document-edit data-path="{{documentUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon"></adh-document-edit>
+        <adh-document-edit data-path="{{documentUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon" data-cancel-url="documentUrl | adhParentPath | adhResourceUrl"></adh-document-edit>
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentEditColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/DocumentEditColumn.html
@@ -16,6 +16,12 @@
     </a>
 
     <div data-ng-switch-when="body">
-        <adh-document-edit data-path="{{documentUrl}}" data-has-map="true" data-has-image="true" data-polygon="polygon" data-cancel-url="documentUrl | adhParentPath | adhResourceUrl"></adh-document-edit>
+        <adh-document-edit
+            data-path="{{documentUrl}}"
+            data-has-map="true"
+            data-has-image="true"
+            data-polygon="polygon"
+            data-cancel-url="documentUrl | adhParentPath | adhResourceUrl">
+        </adh-document-edit>
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalCreateColumn.html
@@ -11,14 +11,11 @@
         </div>
     </a>
 
-    <div data-ng-switch-when="body">
-        <adh-resource-actions
-            data-resource-path="{{processUrl}}"
-            data-cancel="true">
-        </adh-resource-actions>
+    <div class="tabs" data-ng-switch-when="body">
         <adh-idea-collection-proposal-create
             data-pool-path="{{processUrl}}"
-            data-process-properties="processProperties">
+            data-process-properties="processProperties"
+            data-cancel-url="processUrl | adhResourceUrl:'proposals'">
         </adh-idea-collection-proposal-create>
     </div>
 </div>

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalCreateColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalCreateColumn.html
@@ -11,7 +11,7 @@
         </div>
     </a>
 
-    <div class="tabs" data-ng-switch-when="body">
+    <div data-ng-switch-when="body">
         <adh-idea-collection-proposal-create
             data-pool-path="{{processUrl}}"
             data-process-properties="processProperties"

--- a/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalEditColumn.html
+++ b/src/meinberlin/meinberlin/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/ProposalEditColumn.html
@@ -16,14 +16,11 @@
     <adh-recompile-on-change
         data-ng-switch-when="body"
         data-value="{{proposalUrl}}">
-        <adh-resource-actions
-            data-resource-path="{{proposalUrl | adhParentPath}}"
-            data-cancel="true">
-        </adh-resource-actions>
         <adh-idea-collection-proposal-edit
             data-ng-if="proposalUrl"
             data-path="{{proposalUrl}}"
-            data-process-properties="processProperties">
+            data-process-properties="processProperties"
+            data-cancel-url="proposalUrl | adhParentPath | adhResourceUrl">
         </adh-idea-collection-proposal-edit>
     </adh-recompile-on-change>
 </div>


### PR DESCRIPTION
(replaces #2571.) This is part of the redesign. Breadcrumbs get introduced - in this PR, (solitary) cancel actions everywhere outside of Mercator get replaced by such 'cancel' breadcrumbs.

Besides this: breadcrumbs plus dropdown now constitute the `resource-navigation` and have moved outside of the `resource-header`.