### PR TITLE
Fix decision date in S1

### DIFF
--- a/src/adhocracy_s1/adhocracy_s1/workflows/s1.py
+++ b/src/adhocracy_s1/adhocracy_s1/workflows/s1.py
@@ -19,11 +19,6 @@ from adhocracy_core.sheets.principal import IUserBasic
 from adhocracy_core.sheets.tags import ITags
 
 
-def do_transition_to_propose(context: IPool, request: Request, **kwargs):
-    """Do various tasks to complete transition to propose state."""
-    _remove_state_data(context, 'result', 'start_date', request)
-
-
 def do_transition_to_voteable(context: IPool, request: Request, **kwargs):
     """Do transition from state proposed to voteable for all children."""
     for child in context.values():
@@ -71,20 +66,6 @@ def _store_state_data(context: IWorkflowAssignment, state_name: str,
     else:
         data = datas[0]
     data.update(**kwargs)
-    sheet.set({'state_data': state_data})
-
-
-def _remove_state_data(context: IWorkflowAssignment, state_name: str,
-                       key: str, request: Request):
-    sheet = request.registry.content.get_sheet(context, IWorkflowAssignment,
-                                               request=request)
-    state_data = sheet.get()['state_data']
-    datas = [x for x in state_data if x['name'] == state_name]
-    if datas == []:
-        return
-    data = datas[0]
-    if key in data:
-        del data[key]
     sheet.set({'state_data': state_data})
 
 

--- a/src/adhocracy_s1/adhocracy_s1/workflows/s1.yaml
+++ b/src/adhocracy_s1/adhocracy_s1/workflows/s1.yaml
@@ -43,4 +43,3 @@ transitions:
   to_propose:
     from_state: result
     to_state: propose
-    callback: adhocracy_s1.workflows.s1.do_transition_to_propose

--- a/src/adhocracy_s1/adhocracy_s1/workflows/test_s1.py
+++ b/src/adhocracy_s1/adhocracy_s1/workflows/test_s1.py
@@ -8,31 +8,6 @@ from adhocracy_core.testing import do_transition_to
 from adhocracy_core.testing import get_next_states
 
 
-class TestDoTransitionToPropose:
-
-    @fixture
-    def registry(self, registry_with_content, mock_sheet):
-        mock_sheet.get.return_value = {'state_data': []}
-        registry_with_content.content.get_sheet.return_value = mock_sheet
-        return registry_with_content
-
-    def call_fut(self, *args, **kwargs):
-        from .s1 import do_transition_to_propose
-        return do_transition_to_propose(*args, **kwargs)
-
-    def test_ignore_if_no_result_state_data(self, context, request_, registry,
-                                            mock_sheet):
-        self.call_fut(context, request_)
-        assert not mock_sheet.set.called
-
-    def test_remove_result_state_data_start_date(
-            self, context, request_, registry, mock_sheet):
-        mock_sheet.get.return_value = {'state_data': [{'name': 'result',
-                                                       'start_date': '2015'}]}
-        self.call_fut(context, request_)
-        mock_sheet.set.assert_called_with({'state_data': [{'name': 'result'}]})
-
-
 class TestDoTransitionToVotable:
 
     @fixture
@@ -375,13 +350,13 @@ class TestS1Workflow:
         resp = do_transition_to(app_initiator, '/s1', 'propose')
         assert resp.status_code == 200
 
-    def test_propose_again_old_decision_date_is_removed(self, app_participant):
+    def test_propose_again_with_old_decision_date(self, app_participant):
         from adhocracy_core.sheets.workflow import IWorkflowAssignment
         resp = app_participant.get('/s1')
         state_data = resp.json['data'][IWorkflowAssignment.__identifier__]['state_data']
         datas = [x for x in state_data if x['name'] == 'result']
         decision_date = datas[0]['start_date']
-        assert decision_date is None
+        assert decision_date.endswith('+00:00')
 
     def test_propose_participant_can_create_proposals_again(self, app_participant):
         resp = _post_proposal_item(app_participant, path='/s1')


### PR DESCRIPTION
Do not remove the start date of the result phase when transiting to participate.

Fixes #2587 