### PR TITLE
fix core build

### DIFF
--- a/buildout-core.cfg
+++ b/buildout-core.cfg
@@ -5,6 +5,7 @@ extends =
 [adhocracy]
 frontend.static_dir = src/adhocracy_frontend/adhocracy_frontend/build
 backend_package_name = adhocracy_core
+redirect_url = /r/adhocracy/
 
 [test_run_unit]
 package_paths = src/adhocracy_*


### PR DESCRIPTION
`bin/buildout -c buildout-core.cfg` failed with the following error:

```
While:
  Installing.
  Getting section frontend_development.ini.
  Initializing section frontend_development.ini.
Error: Referenced option does not exist: adhocracy redirect_url
```