### PR TITLE
Create missing MANIFEST.in files during buildout

### DIFF
--- a/src/adhocracy_core/wheels.cfg
+++ b/src/adhocracy_core/wheels.cfg
@@ -1,3 +1,9 @@
+[buildout]
+parts +=
+     make_wheels
+     fix_manifest_deform
+     fix_manifest_substanced
+
 [make_wheels]
 recipe = collective.recipe.template
 target_dir = parts/wheels
@@ -6,7 +12,6 @@ wheels =
        src/substanced
        src/adhocracy_core
 platform = none
-
 input = inline:
     #!/bin/bash
     set -e
@@ -53,3 +58,17 @@ input = inline:
 
 output = ${buildout:bin-directory}/ad_make_wheels
 mode = 755
+
+[fix_manifest_deform]
+recipe = collective.recipe.template
+input = inline:
+    include *.txt *.ini *.cfg *.rst
+    recursive-include deform *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.js *.html *.xml *.mo *.po *.yaml
+output = src/deform/MANIFEST.in
+
+[fix_manifest_substanced]
+recipe = collective.recipe.template
+input = inline:
+    include *.txt *.ini *.cfg *.rst
+    recursive-include substanced *.ico *.png *.css *.gif *.jpg *.pt *.txt *.mak *.mako *.js *.html *.xml *.mo *.po *.yaml
+output = src/substanced/MANIFEST.in


### PR DESCRIPTION
`src/subscranced` and `src/deform` do not have a `MANIFEST.in` file, which leads to broken wheels. Fixing it upstream is not easy, so this is a quick solution to create the missing files.

Fixes #2448 

