### PR TITLE
consistent assignable badges

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Badge/Badge.ts
@@ -164,6 +164,20 @@ export var getBadgesFactory = (
     }
 };
 
+export var getAssignableBadgePaths = (rawOptions) : string[] => {
+    var requestBodyOptions : {content_type : string}[] = AdhUtil.deepPluck(rawOptions, [
+        "data", "POST", "request_body"
+    ]);
+
+    var assignableBadgeOptions = _.find(
+        requestBodyOptions,
+        (body) => body.content_type === RIBadgeAssignment.content_type);
+
+    return AdhUtil.deepPluck(assignableBadgeOptions, [
+        "data", SIBadgeAssignment.nick, "badge"
+    ]);
+};
+
 var bindPath = (
     adhHttp : AdhHttp.Service,
     adhPermissions : AdhPermissions.Service,
@@ -181,17 +195,7 @@ var bindPath = (
             return $q.when();
         }
 
-        var requestBodyOptions : {content_type : string}[] = AdhUtil.deepPluck(rawOptions, [
-            "data", "POST", "request_body"
-        ]);
-
-        var assignableBadgeOptions = _.find(
-            requestBodyOptions,
-            (body) => body.content_type === RIBadgeAssignment.content_type);
-
-        var assignableBadgePaths : string[] = AdhUtil.deepPluck(assignableBadgeOptions, [
-            "data", SIBadgeAssignment.nick, "badge"
-        ]);
+        var assignableBadgePaths : string[] = getAssignableBadgePaths(rawOptions);
 
         return $q.all(_.map(assignableBadgePaths, (b) => adhHttp.get(b).then(extractBadge))).then((badges : any) => {
             scope.badges = _.keyBy(badges, "path");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
@@ -3,7 +3,6 @@
         <adh-resource-dropdown
             data-resource-path="{{path}}"
             data-item-path="{{path | adhParentPath}}"
-            data-resource-with-badges-url="{{processUrl}}"
             data-ng-if="path"
             data-edit="true"
             data-image="processProperties.hasImage"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Proposal.ts
@@ -236,7 +236,6 @@ export var detailDirective = (
             processProperties: "="
         },
         link: (scope : IScope) => {
-            (<any>scope).$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             bindPath(adhHttp, adhPermissions, adhRate, adhTopLevelState, adhGetBadges, $q)(
                 scope, undefined);
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -26,7 +26,6 @@
         data-ng-if="assignBadges && resourcePath"
         data-modals="modals"
         data-class="action-bar-item"
-        data-resource-with-badges-url="{{resourceWithBadgesUrl}}"
         data-resource-path="{{resourcePath}}"></adh-assign-badges-action>
     <adh-modal-action
         data-ng-if="report"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -1,14 +1,13 @@
 import * as _ from "lodash";
 
+import * as AdhBadge from "../Badge/Badge";
 import * as AdhConfig from "../Config/Config";
 import * as AdhHttp from "../Http/Http";
 import * as AdhMovingColumns from "../MovingColumns/MovingColumns";
 import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 
-import * as SIBadge from "../../Resources_/adhocracy_core/sheets/badge/IBadge";
 import * as SIBadgeable from "../../Resources_/adhocracy_core/sheets/badge/IBadgeable";
-import * as SIPool from "../../Resources_/adhocracy_core/sheets/pool/IPool";
 
 var pkgLocation = "/ResourceActions";
 
@@ -193,7 +192,7 @@ export var assignBadgesActionDirective = (
     return {
         restrict: "E",
         transclude: true,
-        template: "<a data-ng-if=\"badgesExist && badgeAssignmentPoolOptions.PUT\" class=\"{{class}}\" href=\"\"" +
+        template: "<a data-ng-if=\"assignableBadgePaths.length\" class=\"{{class}}\" href=\"\"" +
             "data-ng-click=\"assignBadges();\"><ng-transclude></ng-transclude> " +
             "{{ 'TR__MANAGE_BADGE_ASSIGNMENTS' | translate }}</a>",
         scope: {
@@ -212,13 +211,11 @@ export var assignBadgesActionDirective = (
                     });
                 }
             });
-            adhPermissions.bindScope(scope, () => badgeAssignmentPoolPath, "badgeAssignmentPoolOptions");
-            var params = {
-                depth: 4,
-                content_type: SIBadge.nick
-            };
-            adhHttp.get(scope.resourceWithBadgesUrl, params).then((response) => {
-                scope.badgesExist = response.data[SIPool.nick].count > 0;
+            adhPermissions.bindScope(scope, () => badgeAssignmentPoolPath, "badgeAssignmentPoolOptions", {importOptions: false});
+            scope.$watch("badgeAssignmentPoolOptions", (rawOptions) => {
+                if (rawOptions) {
+                    scope.assignableBadgePaths = AdhBadge.getAssignableBadgePaths(rawOptions);
+                }
             });
 
             scope.assignBadges = () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -74,7 +74,6 @@ export var resourceActionsDirective = (
             // know the itemPath. If the resource is not versionable,
             // itemPath should be the same as resourcePath.
             itemPath: "@",
-            resourceWithBadgesUrl: "@?",
             deleteRedirectUrl: "@?",
             assignBadges: "=?",
             createDocument: "=?",
@@ -111,7 +110,6 @@ export var resourceDropdownDirective = (
         scope: {
             resourcePath: "@",
             itemPath: "@",
-            resourceWithBadgesUrl: "@?",
             deleteRedirectUrl: "@?",
             assignBadges: "=?",
             share: "=?",
@@ -197,7 +195,6 @@ export var assignBadgesActionDirective = (
             "{{ 'TR__MANAGE_BADGE_ASSIGNMENTS' | translate }}</a>",
         scope: {
             resourcePath: "@",
-            resourceWithBadgesUrl: "@?",
             class: "@",
             modals: "=",
             toggleDropdown: "=?"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceDropdown.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceDropdown.html
@@ -27,7 +27,6 @@
         <adh-assign-badges-action
             data-ng-if="assignBadges && resourcePath"
             data-modals="modals"
-            data-resource-with-badges-url="{{resourceWithBadgesUrl}}"
             data-resource-path="{{resourcePath}}"
             data-toggle-dropdown="toggleDropdown">
             <i class="icon-tags"></i>


### PR DESCRIPTION
related to #2606 

There are two places where we check whether a user can assign badges:

-  in the badge assignment UI (which badges can be assigned?)
-  in the resource action/dropdown (should we link to the badge assignment UI at all?)

While the badge assignment UI checks the OPTIONS response for assignable badges, the resource actions/dropdown did check for (1) the existence of badges at most 4 levels below the process resource and (2) PUT permissions on the assignment pool.

This PR changes that by using the first approach (OPTIONS) also with the resource action/dropdown, potentially fixing related bugs.