### PR TITLE
S1: Show correct meeting in left column for older proposals

### DIFF
--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
@@ -294,7 +294,7 @@ var getMeeting = (proposal : RIProposal, process : RIS1Process) => {
         var proposalDecisionDate = AdhUtil.deepPluck(
             AdhProcess.getStateData(proposal.data[SIWorkflowAssignment.nick], proposalState), ["start_date"]);
 
-        return (processDecisionDate === proposalDecisionDate) ? "current" : "archive";
+        return (proposalDecisionDate <= processDecisionDate) ? "archive" : "current";
     }
 };
 


### PR DESCRIPTION
This is a followup to https://github.com/liqd/adhocracy3/pull/2590. After that fix old proposals rendered in the wrong column and deep links to archived proposals would load the current column on the left.