### PR TITLE
Better wording for the show comments functionality.

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -17,6 +17,7 @@
     "TR__CHOOSE_BADGES": "Wähle ein oder mehrere Etiketten",
     "TR__CLOSE": "schließen",
     "TR__COMMENTS": "Kommentare",
+    "TR__COMMENTS_SHOW": "{{ number }} Kommentar zeigen",
     "TR__COMMENTS_TOTAL": "Kommentare (gesamt)",
     "TR__COMMENT_EMPTY_TEXT": "Noch keine Kommentare.",
     "TR__COMMENT_PLACEHOLDER": "Kommentar hier einfügen",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -17,6 +17,7 @@
     "TR__CHOOSE_BADGES": "Choose one or more badges",
     "TR__CLOSE": "close",
     "TR__COMMENTS": "comments",
+    "TR__COMMENTS_SHOW": "show {{ number }} comments",
     "TR__COMMENTS_TOTAL": "Total Comments",
     "TR__COMMENT_EMPTY_TEXT": "No comments yet.",
     "TR__COMMENT_PLACEHOLDER": "Add comment here",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_fr.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_fr.json
@@ -23,6 +23,7 @@
     "TR__CHOOSE_BADGES": "Choisir une ou quelques catégories",
     "TR__CLOSE": "fermer",
     "TR__COMMENTS": "commentaires",
+    "TR__COMMENTS_SHOW": "Voir les {{ number }} commentaires",
     "TR__COMMENTS_TOTAL": "Tous les commentaires",
     "TR__COMMENT_EMPTY_TEXT": "Il n'y a pas encore de commentaires.",
     "TR__COMMENT_PLACEHOLDER": "Ajouter un commentaire ici",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Document/Detail.html
@@ -19,7 +19,7 @@
 
             <ul class="resource-header-meta">
                 <li>
-                    <i class="icon-speechbubble"></i> {{ data.commentCountTotal }} {{ "TR__COMMENTS_TOTAL" | translate }}
+                    <i class="icon-speechbubble"></i>{{ "TR__COMMENTS_SHOW" | translate:{number: data.commentCountTotal} }}
                 </li>
             </ul>
         </header>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Proposal/Detail.html
@@ -44,7 +44,9 @@
                 </li>
                 <li>
                     <a href="{{ path | adhParentPath | adhResourceUrl:'comments' }}"
-                        ><i class="icon-speechbubble"></i> {{ data.commentCount }} {{ "TR__COMMENTS" | translate }}</a>
+                        ><i class="icon-speechbubble"></i>
+                        {{ "TR__COMMENTS_SHOW" | translate:{number: data.commentCount} }}
+                    </a>
                 </li>
             </ul>
 

--- a/src/s1/s1/static/js/Packages/S1/Proposal/Detail.html
+++ b/src/s1/s1/static/js/Packages/S1/Proposal/Detail.html
@@ -25,7 +25,8 @@
             </li>
             <li>
                 <a href="{{ path | adhParentPath | adhResourceUrl:'comments' }}"
-                    ><i class="icon-speechbubble"></i> {{ data.commentCount }} {{ "TR__COMMENTS" | translate }}</a>
+                    ><i class="icon-speechbubble"></i>
+                    {{ "TR__COMMENTS_SHOW" | translate:{number: data.commentCount} }}</a>
             </li>
         </ul>
 


### PR DESCRIPTION
User testing for S1 has shown that people miss the fact that they can show the comments column because they think that this is just an indicator how many comments are available. (Reasoning: It looks the same as other comment indicators, but it behaves different).

Thus the resolution: Make it look different too, to give people a reason to suspect that it does something. :)