### PR TITLE
Restore highlighting behavior of the meeting selector.

### DIFF
--- a/src/s1/s1/static/js/Packages/S1/Context/Context.ts
+++ b/src/s1/s1/static/js/Packages/S1/Context/Context.ts
@@ -65,6 +65,7 @@ export var meetingSelectorDirective = (
             processUrl: "@"
         },
         link: (scope) => {
+            scope.$on("$destroy", adhTopLevelState.bind("meeting", scope));
             adhHttp.get(scope.processUrl).then((process : RIS1Process) => {
                 scope.workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
             });

--- a/src/s1/s1/static/stylesheets/scss/components/_button_theme.scss
+++ b/src/s1/s1/static/stylesheets/scss/components/_button_theme.scss
@@ -11,7 +11,14 @@
     &.m-round {
         min-width: 2em;
     }
+
+    &.is-active {
+        background: $color-brand-two-normal;
+        color: $color-text-inverted;
+    }
+
 }
+
 
 /*doc
 ---


### PR DESCRIPTION
This was lost sometimes in the recent past, which led to the problem that users have no way to determine which meeting is currently active. It’s not so nice that the ‚create proposal button‘ shows the same way - but at least users know again what meeting is displayed.

I'm open to proposals on how to differentiate the 'create proposal' button better.