### PR TITLE
fix edit action permissions

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.html
@@ -6,12 +6,12 @@
         data-label="TR__CREATE_DOCUMENT"
         data-resource-path="{{itemPath}}"></adh-view-action>
     <adh-view-action
-        data-ng-if="edit && itemPath && options.PUT"
+        data-ng-if="edit && itemPath && canEdit()"
         data-class="action-bar-item"
         data-view="edit"
         data-label="TR__EDIT"
         data-resource-path="{{itemPath}}"></adh-view-action>
-    <adh-view-action data-ng-if="image && itemPath && options.PUT"
+    <adh-view-action data-ng-if="image && itemPath && canEdit()"
         data-class="action-bar-item"
         data-view="image"
         data-label="TR__IMAGE_UPLOAD"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -96,10 +96,19 @@ export var resourceDropdownDirective = (
 
             scope.modals = new Modals($timeout);
             adhPermissions.bindScope(scope, () => scope.resourcePath, "options");
+            adhPermissions.bindScope(scope, () => scope.itemPath, "itemOptions");
 
             scope.$watch("resourcePath", () => {
                 scope.modals.clear();
             });
+
+            scope.canEdit = () => {
+                if (scope.resourcePath === scope.itemPath) {
+                    return scope.options.PUT;
+                } else {
+                    return scope.itemOptions.POST;
+                }
+            };
 
             scope.toggleDropdown = () => {
                 scope.data.isShowDropdown = !scope.data.isShowDropdown;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -95,7 +95,7 @@ export var resourceDropdownDirective = (
             };
 
             scope.modals = new Modals($timeout);
-            adhPermissions.bindScope(scope, scope.resourcePath, "options");
+            adhPermissions.bindScope(scope, () => scope.resourcePath, "options");
 
             scope.$watch("resourcePath", () => {
                 scope.modals.clear();

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceActions.ts
@@ -60,7 +60,7 @@ export class Modals {
     }
 }
 
-export var resourceActionsDirective = (
+export var resourceDropdownDirective = (
     $timeout : angular.ITimeoutService,
     adhConfig : AdhConfig.IService,
     adhPermissions : AdhPermissions.Service
@@ -73,43 +73,6 @@ export var resourceActionsDirective = (
             // performed on the item instead. This is why we need to
             // know the itemPath. If the resource is not versionable,
             // itemPath should be the same as resourcePath.
-            itemPath: "@",
-            deleteRedirectUrl: "@?",
-            assignBadges: "=?",
-            createDocument: "=?",
-            share: "=?",
-            hide: "=?",
-            resourceWidgetDelete: "=?",
-            print: "=?",
-            report: "=?",
-            cancel: "=?",
-            edit: "=?",
-            image: "=?",
-            moderate: "=?",
-            messaging: "=?",
-            modals: "=?"
-        },
-        templateUrl: adhConfig.pkg_path + pkgLocation + "/ResourceActions.html",
-        link: (scope, element) => {
-            scope.modals = new Modals($timeout);
-            adhPermissions.bindScope(scope, scope.resourcePath, "options");
-
-            scope.$watch("resourcePath", () => {
-                scope.modals.clear();
-            });
-        }
-    };
-};
-
-export var resourceDropdownDirective = (
-    $timeout : angular.ITimeoutService,
-    adhConfig : AdhConfig.IService,
-    adhPermissions : AdhPermissions.Service
-) => {
-    return {
-        restrict: "E",
-        scope: {
-            resourcePath: "@",
             itemPath: "@",
             deleteRedirectUrl: "@?",
             assignBadges: "=?",
@@ -162,6 +125,19 @@ export var resourceDropdownDirective = (
         }
     };
 };
+
+
+export var resourceActionsDirective = (
+    $timeout : angular.ITimeoutService,
+    adhConfig : AdhConfig.IService,
+    adhPermissions : AdhPermissions.Service
+) => {
+    var directive = resourceDropdownDirective($timeout, adhConfig, adhPermissions);
+    directive.scope["createDocument"] = "=?";
+    directive.templateUrl = adhConfig.pkg_path + pkgLocation + "/ResourceActions.html";
+    return directive;
+};
+
 
 export var modalActionDirective = () => {
     return {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceDropdown.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/ResourceActions/ResourceDropdown.html
@@ -4,14 +4,14 @@
     </a>
     <div class="dropdown-menu" data-ng-if="data.isShowDropdown" aria-labelledby="{{id}}">
         <adh-view-action
-            data-ng-if="edit && itemPath && options.PUT"
+            data-ng-if="edit && itemPath && canEdit()"
             data-view="edit"
             data-label="TR__EDIT"
             data-resource-path="{{itemPath}}">
             <i class="icon-pencil"></i>
         </adh-view-action>
         <adh-view-action
-            data-ng-if="image && itemPath && options.PUT"
+            data-ng-if="image && itemPath && canEdit()"
             data-view="image"
             data-label="TR__IMAGE_UPLOAD"
             data-resource-path="{{itemPath}}">


### PR DESCRIPTION
I noticed (in s1) that sometimes the edit action shows up if I am not allowed to edit. The reason is most likely that `options.PUT` is only a valid check for simples. For versions, we have to check POST on the item.

Note: While thinking about this I had a second idea that might be worth investigating: Checking `options.PUT` might not actually be sufficient for simples because this may also just be `options.hide`, i.e. you can only put `SIMetadata.hidden = true`.