### PR TITLE
allow to anonymise rates

### DIFF
--- a/src/adhocracy_core/adhocracy_core/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/__init__.py
@@ -14,8 +14,6 @@ from adhocracy_core.authentication import MultiRouteAuthenticationPolicy
 from adhocracy_core.interfaces import SDI_ROUTE_NAME
 from adhocracy_core.resources.root import IRootPool
 from adhocracy_core.resources.principal import groups_and_roles_finder
-from adhocracy_core.resources.principal import get_user_or_anonymous
-from adhocracy_core.resources.principal import get_anonymized_user
 from adhocracy_core.auditing import set_auditlog
 from adhocracy_core.auditing import get_auditlog
 from adhocracy_core.interfaces import IFixtureAsset
@@ -102,12 +100,9 @@ def includeme(config):
     config.include('pyramid_mako')
     config.include('pyramid_chameleon')
     config.include('.authorization')
+    config.include('.authentication')
     authn_policy = _create_authentication_policy(settings, config)
     config.set_authentication_policy(authn_policy)
-    # FIXME mv user properties to authentication package
-    config.add_request_method(get_user_or_anonymous, name='user', reify=True)
-    config.add_request_method(get_anonymized_user, name='anonymized_user',
-                              reify=True)
     config.include('.renderers')
     config.include('.evolution')
     config.include('.events')

--- a/src/adhocracy_core/adhocracy_core/authentication/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/__init__.py
@@ -191,3 +191,15 @@ def is_created_anonymized(context: object) -> bool:
     """Check if `context` was created anonymized."""
     is_created_anonymized = bool(get_anonymized_creator(context))
     return is_created_anonymized
+
+
+def includeme(config):  # pragma: no cover
+    """Add request properties `user` and `anonymized_user`."""
+    from adhocracy_core.resources.principal import get_user_or_anonymous
+    from adhocracy_core.resources.principal import get_anonymized_user
+    config.add_request_method(get_user_or_anonymous,
+                              name='user',
+                              reify=True)
+    config.add_request_method(get_anonymized_user,
+                              name='anonymized_user',
+                              reify=True)

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -919,6 +919,15 @@ def add_allow_add_anonymized_sheet_to_comments(root,
     migrate_new_sheet(root, ICommentsService, IAllowAddAnonymized)
 
 
+@log_migration
+def add_allow_add_anonymized_sheet_to_rates(root,
+                                            registry):  # pragma: no cover
+    """Add allow add anonymized sheet to rates service."""
+    from adhocracy_core.sheets.anonymize import IAllowAddAnonymized
+    from adhocracy_core.resources.rate import IRatesService
+    migrate_new_sheet(root, IRatesService, IAllowAddAnonymized)
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -975,3 +984,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(add_global_anonymous_user)
     config.add_evolution_step(add_allow_add_anonymized_sheet_to_process)
     config.add_evolution_step(add_allow_add_anonymized_sheet_to_comments)
+    config.add_evolution_step(add_allow_add_anonymized_sheet_to_rates)

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -435,6 +435,8 @@ def get_system_user_anonymous(request: Request) -> IUser:
                                              'anonymous')
     adapter = request.registry.queryMultiAdapter((request.context, request),
                                                  IRolesUserLocator)
+    if adapter is None:  # ease testing
+        return
     return adapter.get_user_by_login(username)
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -423,13 +423,14 @@ def get_user_or_anonymous(request: Request) -> IUser:
     Meant to be use as request method 'user'.
     """
     if is_marked_anonymize(request):
-        user = _get_anonymous_user(request)
+        user = get_system_user_anonymous(request)
     else:
         user = _get_authenticated_user(request)
     return user
 
 
-def _get_anonymous_user(request: Request) -> IUser:
+def get_system_user_anonymous(request: Request) -> IUser:
+    """Return user used to anonymize other users."""
     username = request.registry.settings.get('adhocracy.anonymous_user',
                                              'anonymous')
     adapter = request.registry.queryMultiAdapter((request.context, request),

--- a/src/adhocracy_core/adhocracy_core/resources/rate.py
+++ b/src/adhocracy_core/adhocracy_core/resources/rate.py
@@ -9,8 +9,8 @@ from adhocracy_core.resources import add_resource_type_to_registry
 from adhocracy_core.resources.itemversion import itemversion_meta
 from adhocracy_core.resources.item import item_meta
 from adhocracy_core.resources.service import service_meta
-
 from adhocracy_core.sheets.rate import IRate
+from adhocracy_core.sheets.anonymize import IAllowAddAnonymized
 
 
 class IRateVersion(IItemVersion):
@@ -46,6 +46,8 @@ rates_meta = service_meta._replace(
     iresource=IRatesService,
     content_name='rates',
     element_types=(IRate,),
+    extended_sheets=(IAllowAddAnonymized,
+                     ),
 )
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_rate.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_rate.py
@@ -56,3 +56,14 @@ class TestRate:
         rate_index.reindex_resource(rate)
         search_result = set(rate_index.eq(0).execute())
         assert rate in search_result
+
+
+def test_rateservice_meta():
+    from . import rate
+    import adhocracy_core.sheets
+    meta = rate.rates_meta
+    assert meta.iresource is rate.IRatesService
+    assert meta.element_types == (rate.IRate,)
+    assert meta.content_name == 'rates'
+    assert meta.extended_sheets == (adhocracy_core.sheets.anonymize.IAllowAddAnonymized,
+                                    )

--- a/src/adhocracy_core/adhocracy_core/rest/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/subscriber.py
@@ -1,6 +1,7 @@
 """Subscriber to modify the http response object."""
 from pyramid.interfaces import IRequest
 from pyramid.events import NewResponse
+from adhocracy_core.authentication import AnonymizeHeader
 
 
 def set_response_headers(event: NewResponse):
@@ -17,7 +18,8 @@ def add_cors_headers(event: NewResponse):
     event.response.headers.update({
         'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Headers': 'Origin, Content-Type, Accept, '
-                                        'X-User-Path, X-User-Token',
+                                        'X-User-Path, X-User-Token, '
+                                        + AnonymizeHeader,
         'Access-Control-Allow-Credentials': 'true',
         'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS',
     })

--- a/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
@@ -34,6 +34,7 @@ def test_set_response_header_set_cors_header_if_api_request(request_,
 
 
 def test_add_cors_headers(request_):
+    from adhocracy_core.authentication import AnonymizeHeader
     from .subscriber import add_cors_headers
     response = testing.DummyResource(headers={})
     event = testing.DummyResource(response=response,
@@ -42,7 +43,8 @@ def test_add_cors_headers(request_):
     assert response.headers == \
         {'Access-Control-Allow-Origin': '*',
          'Access-Control-Allow-Headers': 'Origin, Content-Type, Accept,'
-                                         ' X-User-Path, X-User-Token',
+                                         ' X-User-Path, X-User-Token, '
+                                         + AnonymizeHeader ,
          'Access-Control-Allow-Credentials': 'true',
          'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS'}
 

--- a/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_rate.py
@@ -251,9 +251,13 @@ class TestCreateValidateIsUnique:
 
     def test_ignore_if_no_equal_rates(
             self, node, context, request_, value, query, mock_catalogs,
-            anonymous, mock_get_anonymous):
+            anonymous, mock_get_anonymous, version, search_result):
         from adhocracy_core.interfaces import Reference
         from .rate import IRate
+        mock_catalogs.search.side_effect =\
+            [search_result,
+             search_result._replace(elements=[version]),
+             ]
         validator = self.call_fut(context, request_)
         assert validator(node, value) is None
         assert mock_catalogs.search.call_args_list[0][0][0] == query._replace(

--- a/src/adhocracy_core/adhocracy_core/testing.py
+++ b/src/adhocracy_core/adhocracy_core/testing.py
@@ -337,7 +337,7 @@ def mock_catalogs(search_result) -> Mock:
 def search_result() -> SearchResult:
     """Return search result."""
     from adhocracy_core.interfaces import search_result
-    return search_result
+    return search_result._replace(elements=[])
 
 
 @fixture


### PR DESCRIPTION
add IAllowAddAnonymized sheet to rates service

add helper function get_system_user_anoymous

modify rate sheet validators to ensure "uniqueness" with anonymized  rates:

- validate rate subject is always the authenticated user or the anonymous
system user
- replace subject with anonymous user if anonymize request
- check anonymized_creator when validating "uniqueness" of rates