### PR TITLE
update frontend dependencies

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -146,26 +146,26 @@ inline =
         "name": "adhocracy-frontend",
         "version": "0.0.1",
         "devDependencies": {
-            "typescript": "1.8.7",
-            "tslint": "3.5.0",
+            "typescript": "1.8.10",
+            "tslint": "3.15.1",
             "bower": "1.7.9",
             "jasmine": "2.4.1",
             "protractor": "3.3.0",
             "sync-exec": "0.6.2",
             "q": "1.4.1",
-            "lodash": "4.6.1",
+            "lodash": "4.15.0",
             "node-fs": "0.1.7",
-            "grunt": "0.4.5",
-            "grunt-cli": "0.1.13",
-            "grunt-angular-templates": "1.0.3",
-            "requirejs": "2.1.22",
-            "grunt-contrib-requirejs": "0.4.4",
-            "htmlhint": "0.9.12",
-            "grunt-htmlhint": "0.9.12-fix",
-            "mailparser": "0.5.3",
+            "grunt": "1.0.1",
+            "grunt-cli": "1.2.0",
+            "grunt-angular-templates": "1.1.0",
+            "requirejs": "2.2.0",
+            "grunt-contrib-requirejs": "1.0.0",
+            "htmlhint": "0.9.13",
+            "grunt-htmlhint": "0.9.13",
+            "mailparser": "0.6.1",
             "ini": "1.3.4",
             "node-sass": "3.8.0",
-            "grunt-sass": "1.1.0",
+            "grunt-sass": "1.2.1",
             "grunt-sass-lint": "0.2.0"
         }
     }
@@ -190,28 +190,28 @@ stop-on-error = yes
 [bower]
 recipe = bowerrecipe
 packages =
-    jquery#2.2.0
-    angular#1.4.8
-    angular-animate#1.4.8
-    angular-aria#1.4.8
-    angular-messages#1.4.8
+    jquery#2.2.4
+    angular#1.5.8
+    angular-animate#1.5.8
+    angular-aria#1.5.8
+    angular-messages#1.5.8
     angular-cache#4.3.2
     angular-elastic#2.5.1
     angular-scroll#1.0.0
-    angular-translate#2.8.1
-    angular-translate-loader-static-files#2.8.1
+    angular-translate#2.11.1
+    angular-translate-loader-static-files#2.11.1
     markdown-it#5.1.0
     leaflet#0.7.7
-    leaflet.markercluster#v0.4.0-hotfix.1
-    lodash#4.6.1
-    requirejs#2.1.22
-    requirejs-text#2.0.14
+    leaflet.markercluster#v0.5.0
+    lodash#4.15.0
+    requirejs#2.2.0
+    requirejs-text#2.0.15
     jasmine#2.4.1
     blanket#1.1.7
     q#1.4.1
     moment#2.11.1
     relatively-sticky#2.0.0
-    ng-flow#2.6.1
+    ng-flow#2.7.4
     nidico/socialshareprivacy#392c61fef7b99b75dec90d16213c8c7a702d1809
     webshim#1.15.10
     lato#0.3.0


### PR DESCRIPTION
Mostly minor and patch releases. Grunt had a [major release](http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released), but it should not affect us.

Things that were not updated:

-   [protractor](https://github.com/angular/protractor/blob/master/CHANGELOG.md)
-   [angular-cache](https://github.com/jmdobry/angular-cache/blob/master/CHANGELOG.md) (see [issue](https://github.com/jmdobry/angular-cache/issues/234))
-   [typescript](https://blogs.msdn.microsoft.com/typescript/2016/07/11/announcing-typescript-2-0-beta/) announced version 2.0-beta some time ago, but the stable version has not yet been released.