### PR TITLE
anonymity default in user settings

### DIFF
--- a/etc/frontend_development.ini.in
+++ b/etc/frontend_development.ini.in
@@ -77,6 +77,9 @@ adhocracy.canonical_url = http://localhost:6551/static/embed.html#!
 # e.g. account activation.
 adhocracy.redirect_url = ${adhocracy:redirect_url}
 
+# Whether to allow users to post resources anonymously
+adhocracy.anonymize.enabled = false
+
 # If the Adhocracy frontend is embedded in a website from a trusted domain,
 # Adhocracy may pass user authentication token to the embedding website.
 adhocracy.trusted_domains =

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -8,6 +8,7 @@
     "TR__ACTIVATION_SUCCESS_TITLE": "Dein Account ist nun aktiv!",
     "TR__ADD_PARAGRAPH": "Absatz hinzufügen",
     "TR__ADD_TITLE": "{{ title }} hinzufügen",
+    "TR__ANONYMIZE_DEFAULT": "Standardmäßig anonym veröffentlichen",
     "TR__ASK_TO_CONFIRM_HIDE_ACTION": "Möchtest Du diese Resource wirklich entfernen?",
     "TR__BACK_TO_TOP": "nach oben",
     "TR__BADGE_ASSIGNMENT_UPDATED": "Etiketten wurden aktualisiert.",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -8,6 +8,7 @@
     "TR__ACTIVATION_SUCCESS_TITLE": "Your account has been activated!",
     "TR__ADD_PARAGRAPH": "add paragraph",
     "TR__ADD_TITLE": "Add {{ title }}",
+    "TR__ANONYMIZE_DEFAULT": "post anonymously by default",
     "TR__ASK_TO_CONFIRM_HIDE_ACTION": "Do you really want to delete this?",
     "TR__BACK_TO_TOP": "back to top",
     "TR__BADGE_ASSIGNMENT_UPDATED": "Badge assignments updated.",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
@@ -37,7 +37,7 @@
             {{ "TR__ERROR_TOO_SHORT_PASSWORD" | translate }}
         </span>
     </label>
-    <label>
+    <label data-ng-if="config.anonymize_enabled">
         <input
             type="checkbox"
             data-ng-model="data.anonymize" />

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
@@ -37,6 +37,12 @@
             {{ "TR__ERROR_TOO_SHORT_PASSWORD" | translate }}
         </span>
     </label>
+    <label>
+        <input
+            type="checkbox"
+            data-ng-model="data.anonymize" />
+        <span class="label-text">{{ "TR__ANONYMIZE_DEFAULT" | translate }}</span>
+    </label>
 
     <footer class="form-footer">
         <input

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -20,6 +20,7 @@ import RIComment from "../../Resources_/adhocracy_core/resources/comment/ICommen
 import RIProposal from "../../Resources_/adhocracy_core/resources/proposal/IProposal";
 import RIRate from "../../Resources_/adhocracy_core/resources/rate/IRate";
 import RIUser from "../../Resources_/adhocracy_core/resources/principal/IUser";
+import * as SIAnonymizeDefault from "../../Resources_/adhocracy_core/sheets/principal/IAnonymizeDefault";
 import * as SIDescription from "../../Resources_/adhocracy_core/sheets/description/IDescription";
 import * as SIHasAssetPool from "../../Resources_/adhocracy_core/sheets/asset/IHasAssetPool";
 import * as SIImageReference from "../../Resources_/adhocracy_core/sheets/image/IImageReference";
@@ -707,6 +708,7 @@ var postEdit = (
     data : {
         name : string;
         password? : string;
+        anonymize? : boolean;
     }
 ) => {
     return adhHttp.get(path).then((oldUser) => {
@@ -724,6 +726,9 @@ var postEdit = (
                 password: data.password,
             });
         }
+        patch.data[SIAnonymizeDefault.nick] = new SIAnonymizeDefault.Sheet({
+            anonymize: data.anonymize,
+        });
         return adhHttp.put(oldUser.path, patch);
     });
 };
@@ -753,6 +758,7 @@ export var userEditDirective = (
                         scope.data = {
                             name: user.data[SIUserBasic.nick].name,
                             password: "",
+                            anonymize: user.data[SIAnonymizeDefault.nick].anonymize,
                         };
                     });
                 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -751,6 +751,7 @@ export var userEditDirective = (
         },
         link: (scope, element) => {
             scope.showError = adhShowError;
+            scope.config = adhConfig;
 
             scope.$watch("path", (path) => {
                 if (path) {

--- a/src/meinberlin/meinberlin/static/i18n/core_de.json
+++ b/src/meinberlin/meinberlin/static/i18n/core_de.json
@@ -8,6 +8,7 @@
     "TR__ACTIVATION_SUCCESS_TITLE": "Ihr Account ist nun aktiv!",
     "TR__ADD_PARAGRAPH": "Absatz hinzufügen",
     "TR__ADD_TITLE": "{{ title }} hinzufügen",
+    "TR__ANONYMIZE_DEFAULT": "Standardmäßig anonym veröffentlichen",
     "TR__ASK_TO_CONFIRM_HIDE_ACTION": "Möchten Sie diese Resource wirklich entfernen?",
     "TR__BACK_TO_TOP": "nach oben",
     "TR__BADGE_ASSIGNMENT_UPDATED": "Etiketten wurden aktualisiert.",


### PR DESCRIPTION
This adds the anonymize default setting from #2615 to the user settings page from #2610. It already uses the `anonymize_enabled` config from (and thus actually needs) #2604.

Note that this default value is not yet applied to the use cases in #2604.