### PR TITLE
Reword the save button for user profile

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
@@ -63,7 +63,7 @@
 	        <input
 	            type="submit"
 	            name="submit"
-	            value="{{ 'TR__PUBLISH' | translate }}"
+	            value="{{ 'TR__SAVE' | translate }}"
 	            class="button-cta form-footer-button-cta" />
         </div>
         <div class="form-footer-left">


### PR DESCRIPTION
because you most likely want to ‚save‘ your password instead of  ‚publish‘-ing it.