### PR TITLE
fix/refactor password repeat

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
@@ -45,9 +45,8 @@
         <input
             type="password"
             name="password_repeat"
-            data-ng-model="data.passwordRepeat"
-            data-ng-class="{'ng-invalid': (input.password !== input.passwordRepeat) && userEditForm.password_repeat.$dirty}"/>
-        <span class="input-error" data-ng-show="(input.password !== input.passwordRepeat) && userEditForm.password_repeat.$dirty">
+            data-ng-model="data.passwordRepeat" />
+        <span class="input-error" data-ng-show="showError(userEditForm, userEditForm.password_repeat, 'repeat')">
             {{ "TR__ERROR_MATCH_PASSWORD" | translate }}
         </span>
     </label>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Edit.html
@@ -60,17 +60,17 @@
 
     <footer class="form-footer">
         <div class="form-footer-right">
-	        <input
-	            type="submit"
-	            name="submit"
-	            value="{{ 'TR__SAVE' | translate }}"
-	            class="button-cta form-footer-button-cta" />
+            <input
+                type="submit"
+                name="submit"
+                value="{{ 'TR__SAVE' | translate }}"
+                class="button-cta form-footer-button-cta" />
         </div>
         <div class="form-footer-left">
-	        <a
-	            href=""
-	            data-ng-click="cancel()"
-	            class="button form-footer-button">{{ "TR__CANCEL" | translate }}</a>
+            <a
+                href=""
+                data-ng-click="cancel()"
+                class="button form-footer-button">{{ "TR__CANCEL" | translate }}</a>
         </div>
     </footer>
 </form>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
@@ -51,9 +51,8 @@
                 type="password"
                 name="password_repeat"
                 data-ng-model="input.passwordRepeat"
-                required="required"
-                data-ng-class="{'ng-invalid': (input.password !== input.passwordRepeat) && registerForm.password_repeat.$dirty}"/>
-            <span class="input-error" data-ng-show="(input.password !== input.passwordRepeat) && registerForm.password_repeat.$dirty">
+                required="required" />
+            <span class="input-error" data-ng-show="showError(registerForm, registerForm.password_repeat, 'repeat')">
                 {{ "TR__ERROR_MATCH_PASSWORD" | translate }}
             </span>
         </label>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
@@ -1,5 +1,5 @@
 <div class="login">
-    <form novalidate="novalidate" class="login-form" name="registerForm" data-ng-if="!success && !loggedIn" data-ng-submit="register()">
+    <form novalidate="novalidate" class="login-form" name="form.register" data-ng-if="!success && !loggedIn" data-ng-submit="register()">
         <div class="form-error" data-ng-repeat="error in errors track by $index">
             <p>{{ error | translate }}</p>
         </div>
@@ -11,7 +11,7 @@
                 name="username"
                 data-ng-model="input.username"
                 required="required" />
-            <span class="input-error" data-ng-show="showError(registerForm, registerForm.username, 'required')">
+            <span class="input-error" data-ng-show="showError(form.register, form.register.username, 'required')">
                 {{ "TR__ERROR_REQUIRED_USERNAME" | translate }}
             </span>
         </label>
@@ -22,10 +22,10 @@
                 name="email"
                 data-ng-model="input.email"
                 required="required" />
-            <span class="input-error" data-ng-show="showError(registerForm, registerForm.email, 'required')">
+            <span class="input-error" data-ng-show="showError(form.register, form.register.email, 'required')">
                 {{ "TR__ERROR_REQUIRED_EMAIL" | translate }}
             </span>
-            <span class="input-error" data-ng-show="showError(registerForm, registerForm.email, 'email')">
+            <span class="input-error" data-ng-show="showError(form.register, form.register.email, 'email')">
                 {{ "TR__ERROR_FORMAT_EMAIL" | translate }}
             </span>
         </label>
@@ -38,10 +38,10 @@
                 required="required"
                 data-ng-minlength="6"
                 data-ng-maxlength="100" />
-            <span class="input-error" data-ng-show="showError(registerForm, registerForm.password, 'required')">
+            <span class="input-error" data-ng-show="showError(form.register, form.register.password, 'required')">
                 {{ "TR__ERROR_REQUIRED_PASSWORD" | translate }}
             </span>
-            <span class="input-error" data-ng-show="showError(registerForm, registerForm.password, 'minlength')">
+            <span class="input-error" data-ng-show="showError(form.register, form.register.password, 'minlength')">
                 {{ "TR__ERROR_TOO_SHORT_PASSWORD" | translate }}
             </span>
         </label>
@@ -52,7 +52,7 @@
                 name="password_repeat"
                 data-ng-model="input.passwordRepeat"
                 required="required" />
-            <span class="input-error" data-ng-show="showError(registerForm, registerForm.password_repeat, 'repeat')">
+            <span class="input-error" data-ng-show="showError(form.register, form.register.password_repeat, 'repeat')">
                 {{ "TR__ERROR_MATCH_PASSWORD" | translate }}
             </span>
         </label>
@@ -63,7 +63,7 @@
                     link: '&lt;a data-ng-href=&quot;\\{\\{ termsUrl \\}\\}&quot; target=&quot;_blank&quot;&gt;{{ content }}&lt;/a&gt;'
                 }"></span>
             </div>
-            <span class="input-error" data-ng-show="showError(registerForm, registerForm.registerCheck, 'required')">
+            <span class="input-error" data-ng-show="showError(form.register, form.register.registerCheck, 'required')">
                 {{ "TR__ERROR_REQUIRED_TERMS_AND_CONDITIONS" | translate }}
             </span>
         </label>
@@ -89,7 +89,7 @@
                 <span class="label-text">{{ "TR__ENTER_CAPTCHA" | translate }}</span>
                 <input type="text" name="thentos_captcha_guess" required="required"
                        data-ng-model="input.captchaGuess" />
-                <span class="input-error" data-ng-show="showError(registerForm, registerForm.thentos_captcha_guess, 'required')">
+                <span class="input-error" data-ng-show="showError(form.register, form.register.thentos_captcha_guess, 'required')">
                     {{ "TR__ERROR_REQUIRED_CAPTCHA" | translate }}
                 </span>
             </label>
@@ -99,7 +99,7 @@
             name="register"
             value="{{ 'TR__REGISTER' | translate }}"
             class="button-cta"
-            data-ng-disabled="registerForm.$invalid || input.password !== input.passwordRepeat" />
+            data-ng-disabled="form.register.$invalid || input.password !== input.passwordRepeat" />
         <div class="login-info">
             <p data-adh-html-translate="TR__REGISTRATION_LOGIN_INSTEAD" data-translate-templates="{
                 link: '&lt;a href=&quot;/login&quot;&gt;{{ content }}&lt;/a&gt;'

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Register.html
@@ -99,7 +99,7 @@
             name="register"
             value="{{ 'TR__REGISTER' | translate }}"
             class="button-cta"
-            data-ng-disabled="form.register.$invalid || input.password !== input.passwordRepeat" />
+            data-ng-disabled="form.register.$invalid" />
         <div class="login-info">
             <p data-adh-html-translate="TR__REGISTRATION_LOGIN_INSTEAD" data-translate-templates="{
                 link: '&lt;a href=&quot;/login&quot;&gt;{{ content }}&lt;/a&gt;'

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -408,6 +408,12 @@ export var registerDirective = (
                 captchaGuess: ""
             };
 
+            scope.$watchGroup(["input.passwordRepeat", "input.password"], (values) => {
+                if (scope.registerForm) {
+                    (<any>scope.registerForm).password_repeat.$setValidity("repeat", values[0] === values[1]);
+                }
+            });
+
             scope.enableCancel = ! _.includes(["login", "register"], adhEmbed.getContext());
 
             scope.cancel = scope.goBack = () => {
@@ -765,6 +771,11 @@ export var userEditDirective = (
                         };
                     });
                 }
+            });
+
+            scope.$watchGroup(["data.passwordRepeat", "data.password"], (values) => {
+                // empty may by "" or undefined, so it needs special handling
+                scope.userEditForm.password_repeat.$setValidity("repeat", (values[0] === values[1]) || (!values[0] && !values[1]));
             });
 
             scope.submit = () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -103,7 +103,9 @@ export interface IScopeLogin extends angular.IScope {
 
 
 export interface IScopeRegister extends angular.IScope {
-    registerForm : angular.IFormController;
+    form : {
+        register? : angular.IFormController;
+    };
     input : {
         username : string;
         email : string;
@@ -408,9 +410,11 @@ export var registerDirective = (
                 captchaGuess: ""
             };
 
+            scope.form = {};
+
             scope.$watchGroup(["input.passwordRepeat", "input.password"], (values) => {
-                if (scope.registerForm) {
-                    (<any>scope.registerForm).password_repeat.$setValidity("repeat", values[0] === values[1]);
+                if (scope.form.register) {
+                    (<any>scope.form.register).password_repeat.$setValidity("repeat", values[0] === values[1]);
                 }
             });
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/User/Views.ts
@@ -414,7 +414,6 @@ export var registerDirective = (
                 adhTopLevelState.goToCameFrom("/");
             };
 
-
             scope.errors = [];
             scope.supportEmail = adhConfig.support_email;
 


### PR DESCRIPTION
This is a fixup to ab2869c (#2649). See also https://github.com/liqd/adhocracy3/pull/2641#issuecomment-243478907

I fixed the validation of the password repeat in the user settings. I also ported the approach I used to the password repeat in the registration directive. Unfortunately I had to use a scoping hack there because the form was only available in a nested scope.