### PR TITLE
fix process overview

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/Util.ts
@@ -23,9 +23,15 @@ export function parentPath(path : string) : string {
     "use strict";
 
     var result;
+    var root = "";
 
     if (typeof path === "undefined") {
         return undefined;
+    }
+    if (path.substr(0, 4) === "http") {
+        var match = path.match("(https?://[^/]*)(/?.*)");
+        root = match[1];
+        path = match[2];
     }
     if (path[path.length - 1] === "/") {
         result = path.substring(0, path.lastIndexOf("/", path.length - 2) + 1);
@@ -37,7 +43,7 @@ export function parentPath(path : string) : string {
         result = "/";
     }
 
-    return result;
+    return root + result;
 };
 
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/UtilSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Util/UtilSpec.ts
@@ -22,6 +22,12 @@ export var register = () => {
             it("returns '/' for ''", () => {
                 expect(AdhUtil.parentPath("")).toBe("/");
             });
+            it("works with URLs", () => {
+                expect(AdhUtil.parentPath("http://example.com/foo/bar")).toBe("http://example.com/foo");
+                expect(AdhUtil.parentPath("https://example.com/foo/bar")).toBe("https://example.com/foo");
+                expect(AdhUtil.parentPath("http://example.com/foo/bar/")).toBe("http://example.com/foo/");
+                expect(AdhUtil.parentPath("http://example.com")).toBe("http://example.com/");
+            });
         });
 
         describe("normalizeName", () => {


### PR DESCRIPTION
The process overview introduced in #2027 is currently broken (404). I debugged the issue and found that `AdhUtil.parentPath("http://example.com/")` will return `"http://"`. I fixed it to properly handle URLs.

(Note that most frontend code uses the terms "path" and "url" synonymously. This is in our refactoring backlog.)