### PR TITLE
add dynamic info text on top of process overview

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Listing.html
@@ -1,3 +1,6 @@
+<div class="overview-description">
+    <adh-parse-markdown data-parsetext="overviewDesc"></adh-parse-markdown>
+</div>
 <adh-listing data-content-type="{{contentType}}" data-params="params" data-path="/" data-no-create-form="true">
     <adh-process-list-item data-path="{{element}}"></adh-process-list-item>
 </adh-listing>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Module.ts
@@ -1,3 +1,4 @@
+import * as AdhHttpModule from "../Http/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 
 import * as AdhProcess from "./Process";
@@ -8,6 +9,7 @@ export var moduleName = "adhProcess";
 export var register = (angular) => {
     angular
         .module(moduleName, [
+            AdhHttpModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
         .provider("adhProcess", AdhProcess.Provider)
@@ -15,6 +17,6 @@ export var register = (angular) => {
             "adhConfig", "adhHttp", "adhPermissions", "$q", "$translate", "$window", AdhProcess.workflowSwitchDirective])
         .directive("adhProcessView", ["adhTopLevelState", "adhProcess", "$compile", AdhProcess.processViewDirective])
         .directive("adhProcessListItem", ["adhConfig", "adhHttp", "adhProcess", AdhProcess.listItemDirective])
-        .directive("adhProcessListing", ["adhConfig", AdhProcess.listingDirective])
+        .directive("adhProcessListing", ["adhConfig", "adhHttp", AdhProcess.listingDirective])
         .directive("adhCurrentProcessTitle", ["adhTopLevelState", "adhHttp", AdhProcess.currentProcessTitleDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Process/Process.ts
@@ -192,7 +192,7 @@ export var listItemDirective = (
     };
 };
 
-export var listingDirective = (adhConfig : AdhConfig.IService) => {
+export var listingDirective = (adhConfig : AdhConfig.IService, adhHttp : AdhHttp.Service) => {
     return {
         restrict: "E",
         scope: {},
@@ -202,6 +202,9 @@ export var listingDirective = (adhConfig : AdhConfig.IService) => {
             scope.params = {
                 depth: "all"
             };
+            adhHttp.get("/").then((root) => {
+                scope.overviewDesc = root.data[SIDescription.nick].description;
+            });
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_list_item.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/components/_list_item.scss
@@ -107,3 +107,13 @@ $thumbnail-width: 105px;
 .list-item-badges {
     float: right;
 }
+
+.overview-description {
+    @include container;
+    @include rem(padding, 1.25em $padding);
+    display: block;
+    position: relative;
+    margin-bottom: 1em;
+    background: $color-background-base-introvert;
+}
+


### PR DESCRIPTION
This PR uses the `description` sheet of the `IRootPool` as an info text on top of the process overview.

The way I see it, there's a huge advantage and a disadvantage to this:

( + ) all of us can manually change the text in SDI
( - ) whatever the current language, the text will remain the same.

@xi and I agreed this disadvantage is bearable, because the content of the processes below the text will be monolingual as well.