### PR TITLE
Return default S1 process description during creation

### DIFF
--- a/src/adhocracy_s1/adhocracy_s1/sheets/description.py
+++ b/src/adhocracy_s1/adhocracy_s1/sheets/description.py
@@ -54,9 +54,9 @@ def deferred_default_short_description(node: MappingSchema, kw: dict) -> str:
     """Return default s1  short description for `context` resource."""
     creating = kw['creating']
     context = kw['context']
-    if IProcess.providedBy(context):
-        return DEFAULT_S1_SHORT_DESCRIPTION
-    elif creating and creating.iresource == IProcess:
+    is_process = IProcess.providedBy(context)
+    is_creating_process = creating and creating.iresource == IProcess
+    if is_process or is_creating_process:
         return DEFAULT_S1_SHORT_DESCRIPTION
     else:
         return ''
@@ -67,9 +67,9 @@ def deferred_default_description(node: MappingSchema, kw: dict) -> str:
     """Return default s1 description for `context` resource."""
     creating = kw['creating']
     context = kw['context']
-    if IProcess.providedBy(context):
-        return DEFAULT_S1_DESCRIPTION
-    elif creating and creating.iresource == IProcess:
+    is_process = IProcess.providedBy(context)
+    is_creating_process = creating and creating.iresource == IProcess
+    if is_process or is_creating_process:
         return DEFAULT_S1_DESCRIPTION
     else:
         return ''

--- a/src/adhocracy_s1/adhocracy_s1/sheets/description.py
+++ b/src/adhocracy_s1/adhocracy_s1/sheets/description.py
@@ -52,8 +52,11 @@ Eine Entscheidungsperiode - die Vorbereitung einer Sitzung - besteht aus drei Ph
 @deferred
 def deferred_default_short_description(node: MappingSchema, kw: dict) -> str:
     """Return default s1  short description for `context` resource."""
+    creating = kw['creating']
     context = kw['context']
     if IProcess.providedBy(context):
+        return DEFAULT_S1_SHORT_DESCRIPTION
+    elif creating and creating.iresource == IProcess:
         return DEFAULT_S1_SHORT_DESCRIPTION
     else:
         return ''
@@ -62,8 +65,11 @@ def deferred_default_short_description(node: MappingSchema, kw: dict) -> str:
 @deferred
 def deferred_default_description(node: MappingSchema, kw: dict) -> str:
     """Return default s1 description for `context` resource."""
+    creating = kw['creating']
     context = kw['context']
     if IProcess.providedBy(context):
+        return DEFAULT_S1_DESCRIPTION
+    elif creating and creating.iresource == IProcess:
         return DEFAULT_S1_DESCRIPTION
     else:
         return ''

--- a/src/adhocracy_s1/adhocracy_s1/sheets/test_description.py
+++ b/src/adhocracy_s1/adhocracy_s1/sheets/test_description.py
@@ -1,0 +1,89 @@
+from unittest.mock import Mock
+from pyramid import testing
+from pytest import fixture
+
+class TestDescriptionSheet:
+
+    @fixture
+    def meta(self):
+        from .description import description_meta
+        return description_meta
+
+    def test_default(self, meta, context):
+        from .description import deferred_default_short_description
+        from .description import deferred_default_description
+        inst = meta.sheet_class(meta, context, None)
+        assert inst.schema['short_description'].default \
+               == deferred_default_short_description
+        assert inst.schema['description'].default \
+               == deferred_default_description
+
+
+class TestDeferredDefaultShortDescription:
+
+    def call_fut(self, *args):
+        from .description import deferred_default_short_description
+        return deferred_default_short_description(*args)
+
+    def test_deferred_default_non_s1_process(self, node, kw):
+        kw['context'] = testing.DummyResource()
+        result = self.call_fut(node, kw)
+        assert result == ''
+
+    def test_deferred_default_s1_process(self, node, kw):
+        from adhocracy_s1.resources.s1 import IProcess
+        from .description import DEFAULT_S1_SHORT_DESCRIPTION
+        kw['context'] = testing.DummyResource(__provides__=IProcess)
+        result = self.call_fut(node, kw)
+        assert result == DEFAULT_S1_SHORT_DESCRIPTION
+
+    def test_deferred_default_creating_non_s1_process(self, node, kw,
+                                                      resource_meta):
+        kw['context'] = testing.DummyResource()
+        kw['creating'] = resource_meta
+        result = self.call_fut(node, kw)
+        assert result == ''
+
+    def test_deferred_default_creating_s1_process(self, node, kw,
+                                                  resource_meta):
+        from adhocracy_s1.resources.s1 import IProcess
+        from .description import DEFAULT_S1_SHORT_DESCRIPTION
+        kw['context'] = testing.DummyResource()
+        kw['creating'] = resource_meta._replace(iresource=IProcess)
+        result = self.call_fut(node, kw)
+        assert result == DEFAULT_S1_SHORT_DESCRIPTION
+
+
+class TestDeferredDefaultDescription:
+
+    def call_fut(self, *args):
+        from .description import deferred_default_description
+        return deferred_default_description(*args)
+
+    def test_deferred_default_non_s1_process(self, node, kw):
+        kw['context'] = testing.DummyResource()
+        result = self.call_fut(node, kw)
+        assert result == ''
+
+    def test_deferred_default_s1_process(self, node, kw):
+        from adhocracy_s1.resources.s1 import IProcess
+        from .description import DEFAULT_S1_DESCRIPTION
+        kw['context'] = testing.DummyResource(__provides__=IProcess)
+        result = self.call_fut(node, kw)
+        assert result == DEFAULT_S1_DESCRIPTION
+
+    def test_deferred_default_creating_non_s1_process(self, node, kw,
+                                                      resource_meta):
+        kw['context'] = testing.DummyResource()
+        kw['creating'] = resource_meta
+        result = self.call_fut(node, kw)
+        assert result == ''
+
+    def test_deferred_default_creating_s1_process(self, node, kw,
+                                                  resource_meta):
+        from adhocracy_s1.resources.s1 import IProcess
+        from .description import DEFAULT_S1_DESCRIPTION
+        kw['context'] = testing.DummyResource()
+        kw['creating'] = resource_meta._replace(iresource=IProcess)
+        result = self.call_fut(node, kw)
+        assert result == DEFAULT_S1_DESCRIPTION


### PR DESCRIPTION
Followup: #2680 

Includes:
- Return default values for s1 process description also during process creating, e.g. when creating a process in SDI (#2711)
- Add tests