### PR TITLE
Repin python mock version

### DIFF
--- a/rtd.txt
+++ b/rtd.txt
@@ -51,6 +51,7 @@ lingua==3.10
 logilab-common==0.63.2
 mccabe==0.3.1
 meld3==1.0.0
+mock==2.0.0
 mr.developer==1.31
 multipledispatch==0.4.8
 path.py==8.1.2

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -124,6 +124,10 @@ hexagonit.recipe.download = 1.7.1
 iso8601 = 0.1.10
 
 # Required by:
+# zodburi==2.0
+mock = 2.0.0
+
+# Required by:
 # cryptacular==1.4.1
 pbkdf2 = 1.3
 


### PR DESCRIPTION
This reverts commit 5cc2382e6d5786689cf99c95a0001352aeb00af1.

Fixes pyunit tests on travis.