### PR TITLE
use totalCount in listing-counter

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Listing/Listing.html
@@ -34,7 +34,8 @@
             </a>
         </div>
     </div>
-    <div class="listing-counter" data-ng-if="counter && elements.length > 0">{{elements.length}} {{contentType | adhResourceName | translate}}</div>
+    <div class="listing-counter" data-ng-if="counter && totalCount === 1">{{totalCount}} {{contentType | adhResourceName | translate}}</div>
+    <div class="listing-counter" data-ng-if="counter && totalCount > 1">{{totalCount}} {{contentType | adhResourceName:true | translate}}</div>
     <ol class="listing-elements">
         <li class="listing-element" data-ng-repeat="element in elements">
             <adh-inject data-transclusion-id="element-id"></adh-inject>


### PR DESCRIPTION
needs #2720. small fixup of #2717.

(`listing-counter`s listed `elements.length`. But if pagination comes into play, `elements.length` is curbed by `currentLimit`.)

@xi and I think this change reflects the semantics of the counter better: you want to know how many items of a certain type there are, not how many you are currently seeing on the page.