### PR TITLE
change / redirect logic

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Adhocracy.ts
@@ -104,9 +104,17 @@ export var init = (config : AdhConfig.IService, metaApi) => {
 
     app.config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
         adhTopLevelStateProvider
-            .when("", ["$location", ($location) : AdhTopLevelState.IAreaInput => {
+            .when("", ["$location", "adhConfig", "adhEmbed", ($location, adhConfig, adhEmbed) : AdhTopLevelState.IAreaInput => {
+                var url;
+                if (adhEmbed.initialUrl) {
+                    url = adhEmbed.initialUrl;
+                } else if (adhConfig.redirect_url !== "/") {
+                    url = adhConfig.redirect_url;
+                } else {
+                    url = "/r/";
+                }
                 $location.replace();
-                $location.path("/r/adhocracy/");
+                $location.path(url);
                 return {
                     skip: true
                 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -80,6 +80,7 @@ export class Provider implements angular.IServiceProvider {
 
 export class Service {
     private widget : string;
+    public initialUrl? : string;
 
     constructor(
         protected provider : Provider,
@@ -143,6 +144,7 @@ export class Service {
             };
         } else if (this.provider.hasContext(contextName)) {
             this.widget = contextName;
+            this.initialUrl = search.initialUrl;
             $location.url(search.initialUrl || "/");
             $location.replace();
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Embed/Embed.ts
@@ -80,7 +80,7 @@ export class Provider implements angular.IServiceProvider {
 
 export class Service {
     private widget : string;
-    public initialUrl? : string;
+    public initialUrl : string = "";
 
     constructor(
         protected provider : Provider,

--- a/src/demo/demo/static/js/Adhocracy.ts
+++ b/src/demo/demo/static/js/Adhocracy.ts
@@ -120,11 +120,17 @@ export var init = (config : AdhConfig.IService, metaApi) => {
 
     app.config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
         adhTopLevelStateProvider
-            .when("", ["$location", ($location) : AdhTopLevelState.IAreaInput => {
-                if (config.redirect_url !== "/") {
-                    $location.replace();
-                    $location.path(config.redirect_url);
+            .when("", ["$location", "adhConfig", "adhEmbed", ($location, adhConfig, adhEmbed) : AdhTopLevelState.IAreaInput => {
+                var url;
+                if (adhEmbed.initialUrl) {
+                    url = adhEmbed.initialUrl;
+                } else if (adhConfig.redirect_url !== "/") {
+                    url = adhConfig.redirect_url;
+                } else {
+                    url = "/r/";
                 }
+                $location.replace();
+                $location.path(url);
                 return {
                     skip: true
                 };

--- a/src/euth/euth/static/js/Adhocracy.ts
+++ b/src/euth/euth/static/js/Adhocracy.ts
@@ -113,11 +113,17 @@ export var init = (config: AdhConfig.IService, metaApi) => {
 
     app.config(["adhTopLevelStateProvider", (adhTopLevelStateProvider: AdhTopLevelState.Provider) => {
         adhTopLevelStateProvider
-            .when("", ["$location", ($location): AdhTopLevelState.IAreaInput => {
-                if (config.redirect_url !== "/") {
-                    $location.replace();
-                    $location.path(config.redirect_url);
+            .when("", ["$location", "adhConfig", "adhEmbed", ($location, adhConfig, adhEmbed) : AdhTopLevelState.IAreaInput => {
+                var url;
+                if (adhEmbed.initialUrl) {
+                    url = adhEmbed.initialUrl;
+                } else if (adhConfig.redirect_url !== "/") {
+                    url = adhConfig.redirect_url;
+                } else {
+                    url = "/r/";
                 }
+                $location.replace();
+                $location.path(url);
                 return {
                     skip: true
                 };

--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -120,11 +120,17 @@ export var init = (config : AdhConfig.IService, metaApi) => {
 
     app.config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
         adhTopLevelStateProvider
-            .when("", ["$location", ($location) : AdhTopLevelState.IAreaInput => {
-                if (config.redirect_url !== "/") {
-                    $location.replace();
-                    $location.path(config.redirect_url);
+            .when("", ["$location", "adhConfig", "adhEmbed", ($location, adhConfig, adhEmbed) : AdhTopLevelState.IAreaInput => {
+                var url;
+                if (adhEmbed.initialUrl) {
+                    url = adhEmbed.initialUrl;
+                } else if (adhConfig.redirect_url !== "/") {
+                    url = adhConfig.redirect_url;
+                } else {
+                    url = "/r/";
                 }
+                $location.replace();
+                $location.path(url);
                 return {
                     skip: true
                 };

--- a/src/mercator/mercator/static/js/Adhocracy.ts
+++ b/src/mercator/mercator/static/js/Adhocracy.ts
@@ -109,11 +109,17 @@ export var init = (config : AdhConfig.IService, metaApi) => {
 
     app.config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
         adhTopLevelStateProvider
-            .when("", ["$location", ($location) : AdhTopLevelState.IAreaInput => {
-                if (config.redirect_url !== "/") {
-                    $location.replace();
-                    $location.path(config.redirect_url);
+            .when("", ["$location", "adhConfig", "adhEmbed", ($location, adhConfig, adhEmbed) : AdhTopLevelState.IAreaInput => {
+                var url;
+                if (adhEmbed.initialUrl) {
+                    url = adhEmbed.initialUrl;
+                } else if (adhConfig.redirect_url !== "/") {
+                    url = adhConfig.redirect_url;
+                } else {
+                    url = "/r/";
                 }
+                $location.replace();
+                $location.path(url);
                 return {
                     skip: true
                 };

--- a/src/pcompass/pcompass/static/js/Adhocracy.ts
+++ b/src/pcompass/pcompass/static/js/Adhocracy.ts
@@ -111,11 +111,17 @@ export var init = (config : AdhConfig.IService, metaApi) => {
 
     app.config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
         adhTopLevelStateProvider
-            .when("", ["$location", ($location) : AdhTopLevelState.IAreaInput => {
-                if (config.redirect_url !== "/") {
-                    $location.replace();
-                    $location.path(config.redirect_url);
+            .when("", ["$location", "adhConfig", "adhEmbed", ($location, adhConfig, adhEmbed) : AdhTopLevelState.IAreaInput => {
+                var url;
+                if (adhEmbed.initialUrl) {
+                    url = adhEmbed.initialUrl;
+                } else if (adhConfig.redirect_url !== "/") {
+                    url = adhConfig.redirect_url;
+                } else {
+                    url = "/r/";
                 }
+                $location.replace();
+                $location.path(url);
                 return {
                     skip: true
                 };

--- a/src/s1/s1/static/js/Adhocracy.ts
+++ b/src/s1/s1/static/js/Adhocracy.ts
@@ -114,11 +114,17 @@ export var init = (config : AdhConfig.IService, metaApi) => {
 
     app.config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
         adhTopLevelStateProvider
-            .when("", ["$location", ($location) : AdhTopLevelState.IAreaInput => {
-                if (config.redirect_url !== "/") {
-                    $location.replace();
-                    $location.path(config.redirect_url);
+            .when("", ["$location", "adhConfig", "adhEmbed", ($location, adhConfig, adhEmbed) : AdhTopLevelState.IAreaInput => {
+                var url;
+                if (adhEmbed.initialUrl) {
+                    url = adhEmbed.initialUrl;
+                } else if (adhConfig.redirect_url !== "/") {
+                    url = adhConfig.redirect_url;
+                } else {
+                    url = "/r/";
                 }
+                $location.replace();
+                $location.path(url);
                 return {
                     skip: true
                 };

--- a/src/spd/spd/static/js/Adhocracy.ts
+++ b/src/spd/spd/static/js/Adhocracy.ts
@@ -118,11 +118,17 @@ export var init = (config : AdhConfig.IService, metaApi) => {
 
     app.config(["adhTopLevelStateProvider", (adhTopLevelStateProvider : AdhTopLevelState.Provider) => {
         adhTopLevelStateProvider
-            .when("", ["$location", ($location) : AdhTopLevelState.IAreaInput => {
-                if (config.redirect_url !== "/") {
-                    $location.replace();
-                    $location.path(config.redirect_url);
+            .when("", ["$location", "adhConfig", "adhEmbed", ($location, adhConfig, adhEmbed) : AdhTopLevelState.IAreaInput => {
+                var url;
+                if (adhEmbed.initialUrl) {
+                    url = adhEmbed.initialUrl;
+                } else if (adhConfig.redirect_url !== "/") {
+                    url = adhConfig.redirect_url;
+                } else {
+                    url = "/r/";
                 }
+                $location.replace();
+                $location.path(url);
                 return {
                     skip: true
                 };


### PR DESCRIPTION
(see #1965)

- if adhEmbed.initialUrl is set, use that
- if no other option is available, use '/r/' (home, see #2681)

Note that `adhConfig.redirect_url` is set in all current projects, so home is not used in practice yet.