### PR TITLE
mitmachen verboten

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/AddProposalButton.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/AddProposalButton.html
@@ -1,7 +1,7 @@
 <a
     class="button-cta m-add"
     data-ng-click="setCameFrom()"
-    data-ng-if="!(!processOptions.POST && processOptions.loggedIn)"
+    data-ng-if="workflowAllowsCreateProposal && !(!processOptions.POST && processOptions.loggedIn)"
     data-ng-href="{{processUrl | adhResourceUrl:'create_proposal'}}">
     {{ "TR__IDEA_COLLECTION_PARTICIPATE" | translate }}
 </a>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/AddProposalButton.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/AddProposalButton.html
@@ -1,7 +1,7 @@
 <a
     class="button-cta m-add"
     data-ng-click="setCameFrom()"
-    data-ng-if="workflowAllowsCreateProposal && !(!processOptions.POST && processOptions.loggedIn)"
+    data-ng-if="processOptions.POST || (workflowAllowsCreateProposal && !processOptions.loggedIn)"
     data-ng-href="{{processUrl | adhResourceUrl:'create_proposal'}}">
     {{ "TR__IDEA_COLLECTION_PARTICIPATE" | translate }}
 </a>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/Module.ts
@@ -46,5 +46,5 @@ export var register = (angular) => {
             "adhConfig", "adhTopLevelState", "adhResourceUrlFilter", "adhParentPathFilter", Workbench.proposalImageColumnDirective])
         .directive("adhIdeaCollectionDetailColumn", ["adhConfig", "adhTopLevelState", Workbench.detailColumnDirective])
         .directive("adhIdeaCollectionAddProposalButton", [
-            "adhConfig", "adhPermissions", "adhTopLevelState", Workbench.addProposalButtonDirective]);
+            "adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", Workbench.addProposalButtonDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/Workbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/IdeaCollection/Workbench/Workbench.ts
@@ -117,6 +117,7 @@ export var detailColumnDirective = (
 
 export var addProposalButtonDirective = (
     adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service,
     adhPermissions : AdhPermissions.Service,
     adhTopLevelState : AdhTopLevelState.Service
 ) => {
@@ -126,6 +127,10 @@ export var addProposalButtonDirective = (
         link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
+            adhHttp.get(scope.processUrl).then((process) => {
+                var workflow = process.data[SIWorkflow.nick].workflow;
+                scope.workflowAllowsCreateProposal = (workflow !== "debate" && workflow !== "debate_private");
+            });
 
             scope.setCameFrom = () => {
                 adhTopLevelState.setCameFrom();


### PR DESCRIPTION
Stops displaying the "participate" button in IdeaCollection to non-logged-in users.

The process in US https://tree.taiga.io/project/ggr-meinberlinteam/us/458?milestone=93539 (IdeaColl with fixed proposals) required that users may not create proposals. @2e2a implemented this by taking an `IdeaCollection` and setting its `workflow` to `debate(_private)`.

this is a quickfix to make the "mitmachen" button = `AddProposalButton` disappear: check whether `workflow` is `debate(_private)`.