### PR TITLE
Extend cross window mesg with set and delete token

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/CrossWindowMessaging/CrossWindowMessaging.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/CrossWindowMessaging/CrossWindowMessaging.ts
@@ -130,7 +130,6 @@ export class Service implements IService {
         _self.registerMessageHandler("setToken", _self.setToken.bind(_self));
         _self.registerMessageHandler("deleteToken", _self.deleteToken.bind(_self));
 
-
         _self.manageResize();
 
         for (var messageHandler of providedMessageHandlers) {
@@ -172,13 +171,13 @@ export class Service implements IService {
         );
     }
 
-    private setToken(data: IMessageData) : void {
+    private setToken(data : IMessageData) : void {
         if (data.token && data.userPath) {
             this.adhCredentials.storeAndEnableToken(data.token, data.userPath);
         }
     }
 
-    private deleteToken(data: IMessageData) :  void {
+    private deleteToken(data : IMessageData) :  void {
         this.adhCredentials.deleteToken();
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/CrossWindowMessaging/CrossWindowMessaging.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/CrossWindowMessaging/CrossWindowMessaging.ts
@@ -127,6 +127,10 @@ export class Service implements IService {
         var _self : Service = this;
 
         _self.registerMessageHandler("setup", _self.setup.bind(_self));
+        _self.registerMessageHandler("setToken", _self.setToken.bind(_self));
+        _self.registerMessageHandler("deleteToken", _self.deleteToken.bind(_self));
+
+
         _self.manageResize();
 
         for (var messageHandler of providedMessageHandlers) {
@@ -166,6 +170,16 @@ export class Service implements IService {
             "resize",
             {height: height}
         );
+    }
+
+    private setToken(data: IMessageData) : void {
+        if (data.token && data.userPath) {
+            this.adhCredentials.storeAndEnableToken(data.token, data.userPath);
+        }
+    }
+
+    private deleteToken(data: IMessageData) :  void {
+        this.adhCredentials.deleteToken();
     }
 
     private sendAuthMessages() {


### PR DESCRIPTION
Meant to replace the session extradiction to trusted sites as it has been used for policycompass. Introduces two new cross window messages:

- set auth token and user path (via `setToken`)
- delete auth token (via `deleteToken`)

The embedding site has somehow to get hold of an A3 auth token (eg. creating it using the login api endpoint). It can then set the token to an embedded iFrame.