### PR TITLE
Add roadmap to documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Contents
    projects/index
    attic/index
    CHANGES
+   roadmap
    glossary
 
 

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -5,17 +5,6 @@ Roadmap
 End of September 2016
 ---------------------
 
-Goal
-++++
-
-Polish the meinberlin project.
-
-KPIs
-++++
-
--   project managers can create all currently available process types on
-    meinberlin
-
 Features
 ++++++++
 
@@ -45,14 +34,11 @@ KPIs
 Features
 ++++++++
 
--   process overview can be filtered by region/city
 -   idea collection process with or without a map
 -   private and public processes
--   project managers can invite new users
+-   new users can be invited by liqd
 -   users can edit their own account information
--   project managers can generate embed snippets for a process
--   moderators of processes can download a data file (e.g. CSV) with
-    process contents
+-   embed snippets can be generated for a process
 -   concept for newsfeed / event-stream
 -   concept for notifications (users can follow processes and proposals
     in processes)
@@ -65,15 +51,13 @@ Goal
 ++++
 
 Adhocracy should be optimized to allow processes to be administered by
-initiators to take the workload off of our project managers and
-developers. It also should optimize platform features that allow users
+initiators. It also should optimize platform features that allow users
 and organizations to feel more at home.
 
 KPIs
 ++++
 
 -   we can offer an initial set up of a new process and organization
-    with little effort
 -   At least two persons feel comfortable configuring the adhocracy
     backend (#busfactor)
 -   we have a written strategy for onboarding of new developers
@@ -113,7 +97,7 @@ Goal
 
 -   Adhocracy provides an attractive environment that allows users to
     easily setup a simple participation process.
--   Project managers can easily setup more complex processes without
+-   More complex processes can be setup easily without
     help from developers.
 -   We have a dedicated concept for trainings in adhocracy and other
     activities related to online participation.
@@ -122,7 +106,6 @@ KPIs
 ++++
 
 -   we can offer an initial set up of a new process and organization
-    with tiny effort
 -   Over 80% of all identified adhocracy development debt has been
     tackled (#debt)
 -   at least two people are able to independently further develop
@@ -136,7 +119,7 @@ Features
 -   better discovery of processes (recommended processes, featured
     processes)
 -   search function for comments and contents
--   project managers can edit permissions in all processes
+-   permissions can be added in all processes
 -   more filtering options for processes (e.g. most activity)
 
 

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -36,9 +36,9 @@ Features
 
 -   idea collection process with or without a map
 -   private and public processes
--   new users can be invited by liqd
+-   initiators can invite new users
 -   users can edit their own account information
--   embed snippets can be generated for a process
+-   initiators can generate embed snippets for processes
 -   concept for newsfeed / event-stream
 -   concept for notifications (users can follow processes and proposals
     in processes)
@@ -57,7 +57,7 @@ and organizations to feel more at home.
 KPIs
 ++++
 
--   we can offer an initial set up of a new process and organization
+-   we've reduced the effort to set up new processes and organizations
 -   At least two persons feel comfortable configuring the adhocracy
     backend (#busfactor)
 -   we have a written strategy for onboarding of new developers
@@ -119,7 +119,7 @@ Features
 -   better discovery of processes (recommended processes, featured
     processes)
 -   search function for comments and contents
--   permissions can be added in all processes
+-   initiators can edit permissions in all processes
 -   more filtering options for processes (e.g. most activity)
 
 

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -57,7 +57,8 @@ and organizations to feel more at home.
 KPIs
 ++++
 
--   we've reduced the effort to set up new processes and organizations
+-   we can offer an initial set up of a new process and organization
+    with little effort
 -   At least two persons feel comfortable configuring the adhocracy
     backend (#busfactor)
 -   we have a written strategy for onboarding of new developers
@@ -106,6 +107,7 @@ KPIs
 ++++
 
 -   we can offer an initial set up of a new process and organization
+    with tiny effort
 -   Over 80% of all identified adhocracy development debt has been
     tackled (#debt)
 -   at least two people are able to independently further develop

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -2,39 +2,60 @@ Roadmap
 =======
 
 
-Middle of February 2017
+End of September 2016
+---------------------
+
+Goal
+++++
+
+Polish the meinberlin project.
+
+KPIs
+++++
+
+-   project managers can create all currently available process types on
+    meinberlin
+
+Features
+++++++++
+
+-   process navigation
+-   SDI for managing processes and users
+
+
+Middle of November 2016
 -----------------------
 
 Goal
 ++++
 
--   Adhocracy provides an attractive environment that allows users to
-    easily setup a simple participation process.
--   Project managers can easily setup more complex processes without
-    help from developers.
--   We have a dedicated concept for trainings in adhocracy and other
-    activities related to online participation.
+A3 will develop into a product for civic participation. We want to offer
+city administrations and other political institutions the first version
+of the platform adhocracy.de, which lets them run idea collection
+processes with or without maps. It should get them interested in the
+topic of e-participation and trying it for their processes.
 
 KPIs
 ++++
 
 -   we can offer an initial set up of a new process and organization
-    with tiny effort
--   Over 80% of all identified adhocracy development debt has been
-    tackled (#debt)
--   at least two people are able to independently further develop
-    backend and frontend (#busfactor)
+    with medium effort
+-   all development debt is mapped as far as possible (#debt)
 
 Features
 ++++++++
 
--   initiator interface for processes and organizations
--   new process type: participatory budgeting
--   better discovery of processes (recommended processes, featured
-    processes)
--   search function for comments and contents
--   project managers can edit permissions in all processes
--   more filtering options for processes (e.g. most activity)
+-   process overview can be filtered by region/city
+-   idea collection process with or without a map
+-   private and public processes
+-   project managers can invite new users
+-   users can edit their own account information
+-   project managers can generate embed snippets for a process
+-   moderators of processes can download a data file (e.g. CSV) with
+    process contents
+-   concept for newsfeed / event-stream
+-   concept for notifications (users can follow processes and proposals
+    in processes)
 
 
 End of December 2016
@@ -84,60 +105,39 @@ Features
 -   simple subscription management (email/notification) for users
 
 
-Middle of November 2016
+Middle of February 2017
 -----------------------
 
 Goal
 ++++
 
-A3 will develop into a product for civic participation. We want to offer
-city administrations and other political institutions the first version
-of the platform adhocracy.de, which lets them run idea collection
-processes with or without maps. It should get them interested in the
-topic of e-participation and trying it for their processes.
+-   Adhocracy provides an attractive environment that allows users to
+    easily setup a simple participation process.
+-   Project managers can easily setup more complex processes without
+    help from developers.
+-   We have a dedicated concept for trainings in adhocracy and other
+    activities related to online participation.
 
 KPIs
 ++++
 
 -   we can offer an initial set up of a new process and organization
-    with medium effort
--   all development debt is mapped as far as possible (#debt)
+    with tiny effort
+-   Over 80% of all identified adhocracy development debt has been
+    tackled (#debt)
+-   at least two people are able to independently further develop
+    backend and frontend (#busfactor)
 
 Features
 ++++++++
 
--   process overview can be filtered by region/city
--   idea collection process with or without a map
--   private and public processes
--   project managers can invite new users
--   users can edit their own account information
--   project managers can generate embed snippets for a process
--   moderators of processes can download a data file (e.g. CSV) with
-    process contents
--   concept for newsfeed / event-stream
--   concept for notifications (users can follow processes and proposals
-    in processes)
-
-
-End of September 2016
----------------------
-
-Goal
-++++
-
-Polish the meinberlin project.
-
-KPIs
-++++
-
--   project managers can create all currently available process types on
-    meinberlin
-
-Features
-++++++++
-
--   process navigation
--   SDI for managing processes and users
+-   initiator interface for processes and organizations
+-   new process type: participatory budgeting
+-   better discovery of processes (recommended processes, featured
+    processes)
+-   search function for comments and contents
+-   project managers can edit permissions in all processes
+-   more filtering options for processes (e.g. most activity)
 
 
 Constraints/challenges which we identified

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -1,0 +1,148 @@
+Roadmap
+=======
+
+
+Middle of February 2017
+-----------------------
+
+Goal
+++++
+
+-   Adhocracy provides an attractive environment that allows users to
+    easily setup a simple participation process.
+-   Project managers can easily setup more complex processes without
+    help from developers.
+-   We have a dedicated concept for trainings in adhocracy and other
+    activities related to online participation.
+
+KPIs
+++++
+
+-   we can offer an initial set up of a new process and organization
+    with tiny effort
+-   Over 80% of all identified adhocracy development debt has been
+    tackled (#debt)
+-   at least two people are able to independently further develop
+    backend and frontend (#busfactor)
+
+Features
+++++++++
+
+-   initiator interface for processes and organizations
+-   new process type: participatory budgeting
+-   better discovery of processes (recommended processes, featured
+    processes)
+-   search function for comments and contents
+-   project managers can edit permissions in all processes
+-   more filtering options for processes (e.g. most activity)
+
+
+End of December 2016
+--------------------
+
+Goal
+++++
+
+Adhocracy should be optimized to allow processes to be administered by
+initiators to take the workload off of our project managers and
+developers. It also should optimize platform features that allow users
+and organizations to feel more at home.
+
+KPIs
+++++
+
+-   we can offer an initial set up of a new process and organization
+    with little effort
+-   At least two persons feel comfortable configuring the adhocracy
+    backend (#busfactor)
+-   we have a written strategy for onboarding of new developers
+    (#busfactor)
+-   we have a strategy to tackle identified critical development debt on
+    the go (#debt)
+
+Features
+++++++++
+
+-   initiator interface to edit process info and users
+-   improved user profile
+    -   avatars
+    -   description
+    -   link to social media
+-   organization pages with organization info (short description, link,
+    logo) to collect processes by an organization
+-   new process type: polls with discussion
+-   simple stats on landing page and for processes (number of users,
+    number of comments, number of votes)
+-   better embedding
+-   single-sign on with popular identity providers (e.g. Google,
+    Twitter, Facebook)
+-   follow processes or organizations with notifications
+-   allow platform/organization/process initiators to communicate with
+    participants of the platform/organization/process (email/newsletter)
+-   user dashboard where users can see the content they created and
+    follow
+-   simple subscription management (email/notification) for users
+
+
+Middle of November 2016
+-----------------------
+
+Goal
+++++
+
+A3 will develop into a product for civic participation. We want to offer
+city administrations and other political institutions the first version
+of the platform adhocracy.de, which lets them run idea collection
+processes with or without maps. It should get them interested in the
+topic of e-participation and trying it for their processes.
+
+KPIs
+++++
+
+-   we can offer an initial set up of a new process and organization
+    with medium effort
+-   all development debt is mapped as far as possible (#debt)
+
+Features
+++++++++
+
+-   process overview can be filtered by region/city
+-   idea collection process with or without a map
+-   private and public processes
+-   project managers can invite new users
+-   users can edit their own account information
+-   project managers can generate embed snippets for a process
+-   moderators of processes can download a data file (e.g. CSV) with
+    process contents
+-   concept for newsfeed / event-stream
+-   concept for notifications (users can follow processes and proposals
+    in processes)
+
+
+End of September 2016
+---------------------
+
+Goal
+++++
+
+Polish the meinberlin project.
+
+KPIs
+++++
+
+-   project managers can create all currently available process types on
+    meinberlin
+
+Features
+++++++++
+
+-   process navigation
+-   SDI for managing processes and users
+
+
+Constraints/challenges which we identified
+------------------------------------------
+
+-   Busfactor (at least two people should be able to operate/fix/further
+    develop backend and frontend at any time (#busfactor)
+-   development debt (#debt)


### PR DESCRIPTION
We have been working on a project roadmap internally and now we want to
publish it.

We also discussed publishing it as github milestones or on a github wiki
page but finally decided that it best fits in our documentation.

For anyone who has seen the previous (internal) draft: I stripped out
anything that I thought should not be publicised and also anything that
is not directly connected to the software but rather to individual
deployments or organizational aspects.