### PR TITLE
fix pcompass

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Module.ts
@@ -11,6 +11,8 @@ import * as AdhTopLevelStateModule from "../../TopLevelState/Module";
 
 import * as Proposal from "./Proposal";
 
+import RIProposal from "../../../../Resources_/adhocracy_core/resources/proposal/IProposal";
+import RIProposalVersion from "../../../../Resources_/adhocracy_core/resources/proposal/IProposalVersion";
 
 export var moduleName = "adhIdeaCollectionProposal";
 
@@ -28,6 +30,10 @@ export var register = (angular) => {
             AdhResourceAreaModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
+        .config(["adhResourceAreaProvider", (adhResourceAreaProvider) => {
+                adhResourceAreaProvider.names[RIProposal.content_type] = "TR__PROPOSALS";
+                adhResourceAreaProvider.names[RIProposalVersion.content_type] = "TR__PROPOSALS";
+            }])
         .directive("adhIdeaCollectionProposalDetail", [
             "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhGetBadges", "$q", Proposal.detailDirective])
         .directive("adhIdeaCollectionProposalListItem", [

--- a/src/pcompass/pcompass/static/js/Packages/Core/TopLevelState/templates/defaultHeader.html
+++ b/src/pcompass/pcompass/static/js/Packages/Core/TopLevelState/templates/defaultHeader.html
@@ -1,0 +1,5 @@
+<header class="l-header main-header">
+    <div class="l-header-left">
+        <ng-include data-ng-if="areaHeaderSlot" src="areaHeaderSlot"></ng-include>
+    </div>
+</header>


### PR DESCRIPTION
this quickly fixes two regressions:

- counter in listing was displayed without "proposals" (regression introduced by #2717)
- "add proposal button" was moved to the header (which is used in #2528), which is not displayed in `pcompass`, because there should be no login.

to display a correct header, the embed option `hideHeader` must be set to false again.