### PR TITLE
Additional info columns in sdi

### DIFF
--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -262,6 +262,7 @@ class ResourceMetadata(namedtuple('ResourceMetadata',
                                    'autonaming_prefix',
                                    'use_autonaming_random',
                                    'is_sdi_addable',
+                                   'sdi_column_mapper',
                                    'element_types',
                                    'default_workflow',
                                    'alternative_workflows',
@@ -303,6 +304,9 @@ class ResourceMetadata(namedtuple('ResourceMetadata',
     is_sdi_addable:
         Make this resource type automatically addable with the substanced
         admin interface (sdi).
+    sdi_column_mapper:
+        Mapping function to add columns with addition information to an sdi
+        folder view.
 
 
     IPool fields:

--- a/src/adhocracy_core/adhocracy_core/resources/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/resources/__init__.py
@@ -41,6 +41,7 @@ resource_meta = ResourceMetadata(content_name='',
                                  autonaming_prefix='',
                                  use_autonaming_random=False,
                                  is_sdi_addable=False,
+                                 sdi_column_mapper=None,
                                  element_types=(),
                                  default_workflow='',
                                  alternative_workflows=tuple(),
@@ -75,6 +76,8 @@ def add_resource_type_to_registry(metadata: ResourceMetadata,
         meta['add_view'] = add_view_name
         if hasattr(config, 'add_sdi_add_view'):  # ease tests
             config.add_sdi_add_view(metadata.iresource, add_view_name)
+    if metadata.sdi_column_mapper:
+        meta['columns'] = metadata.sdi_column_mapper
     add_content_type(config, iresource.__identifier__,
                      ResourceFactory(metadata),
                      factory_type=iresource.__identifier__, **meta)

--- a/src/adhocracy_core/adhocracy_core/resources/organisation.py
+++ b/src/adhocracy_core/adhocracy_core/resources/organisation.py
@@ -10,6 +10,8 @@ from adhocracy_core.sheets.asset import IHasAssetPool
 from adhocracy_core.sheets.description import IDescription
 from adhocracy_core.sheets.image import IImageReference
 from adhocracy_core.sheets.notification import IFollowable
+from adhocracy_core.sheets.title import ITitle
+from adhocracy_core.utils import get_iresource
 
 
 class IOrganisation(IPool):
@@ -23,12 +25,31 @@ def enabled_ordering(pool: IPool, registry: Registry, **kwargs):
         pool.set_order(initial_order, reorderable=True)
 
 
+def sdi_organisation_columns(folder, subobject, request, default_columnspec):
+    """Mapping function to add info columns to the sdi organisation listing."""
+    content = request.registry.content
+    content_name = ''
+    title = ''
+    if subobject:
+        iresource = get_iresource(subobject)
+        metadata = content.resources_meta[iresource]
+        content_name = metadata.content_name
+        if IProcess.providedBy(subobject):
+            title = content.get_sheet_field(subobject, ITitle, 'title')
+    additional_columns = [
+        {'name': 'Type', 'value': content_name},
+        {'name': 'Title', 'value': title},
+    ]
+    return default_columnspec + additional_columns
+
+
 organisation_meta = pool_meta._replace(
     content_name='Organisation',
     iresource=IOrganisation,
     permission_create='create_organisation',
     is_implicit_addable=True,
     is_sdi_addable=True,
+    sdi_column_mapper=sdi_organisation_columns,
     element_types=(IProcess,
                    IOrganisation,
                    ),

--- a/src/adhocracy_core/adhocracy_core/resources/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_init.py
@@ -74,6 +74,15 @@ class TestAddResourceTypeToRegistry:
         config.add_sdi_add_view.assert_called_with(resource_meta.iresource,
                                                    'add_' + type_id)
 
+    def test_add_sdi_columns_if_is_sdi_column_mapper(self, config,
+                                                     resource_meta):
+        config.include('adhocracy_core.content')
+        type_id = IResource.__identifier__
+        add_columns = MagicMock()
+        resource_meta = resource_meta._replace(sdi_column_mapper=add_columns)
+        self.make_one(resource_meta, config)
+        assert config.registry.content.meta[type_id]['columns'] == add_columns
+
 
 class TestResourceFactory:
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_organisation.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_organisation.py
@@ -1,5 +1,7 @@
+from pyramid import testing
 from pytest import mark
 from pytest import fixture
+from unittest.mock import Mock
 
 
 class TestOrganisation:
@@ -13,11 +15,13 @@ class TestOrganisation:
         import adhocracy_core.sheets
         from .organisation import IOrganisation
         from .organisation import enabled_ordering
+        from .organisation import sdi_organisation_columns
         from .process import IProcess
         from adhocracy_core.interfaces import IPool
         assert meta.iresource is IOrganisation
         assert IOrganisation.isOrExtends(IPool)
         assert meta.is_sdi_addable
+        assert meta.sdi_column_mapper == sdi_organisation_columns
         assert meta.is_implicit_addable is True
         assert meta.permission_create == 'create_organisation'
         assert meta.element_types == (IProcess,
@@ -53,3 +57,46 @@ def test_enable_ordering(context, mocker):
     enabled_ordering(context, None)
     assert context.set_order.call_args[0] == (['child'],)
     assert context.set_order.call_args[1] == {'reorderable': True}
+
+
+class TestSdiOrganisationColums:
+
+    @fixture
+    def request_(self, context, registry_with_content):
+        request = testing.DummyRequest(context=context)
+        request.registry = registry_with_content
+        return request
+
+    def call_fut(self, *args, **kwargs):
+        from .organisation import sdi_organisation_columns
+        return sdi_organisation_columns(*args, **kwargs)
+
+    def test_sdi_organisation_columns_no_context(self, request_):
+        result = self.call_fut(None, None, request_, [])
+        assert result == [
+            {'name': 'Type','value': ''},
+            {'name': 'Title','value': ''},
+        ]
+
+    def test_sdi_user_columns_organisation(self, request_, resource_meta):
+        from .organisation import IOrganisation
+        context = testing.DummyResource(__provides__=IOrganisation)
+        request_.registry.content.resources_meta[IOrganisation] = \
+            resource_meta._replace(content_name='Organisation')
+        result = self.call_fut(None, context, request_, [])
+        assert result == [
+            {'name': 'Type','value': 'Organisation'},
+            {'name': 'Title','value': ''},
+        ]
+
+    def test_sdi_user_columns_process(self, request_, resource_meta):
+        from .process import IProcess
+        context = testing.DummyResource(__provides__=IProcess)
+        request_.registry.content.resources_meta[IProcess] = \
+            resource_meta._replace(content_name='Process')
+        request_.registry.content.get_sheet_field = Mock(return_value='Test')
+        result = self.call_fut(None, context, request_, [])
+        assert result == [
+            {'name': 'Type','value': 'Process'},
+            {'name': 'Title','value': 'Test'},
+        ]

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -86,6 +86,7 @@ class TestUsers:
         assert meta.iresource is principal.IUsersService
         assert meta.permission_create == 'create_service'
         assert meta.content_name == 'users'
+        assert meta.sdi_column_mapper == principal.sdi_user_columns
         assert sheets.asset.IHasAssetPool in meta.extended_sheets
         assert badge.add_badge_assignments_service in meta.after_creation
         assert asset.add_assets_service in meta.after_creation
@@ -105,6 +106,40 @@ def test_create_asset_permission(context, registry, mocker):
     set_acl.assert_called_with(context,
                                [('Allow', 'system.Authenticated', 'create_asset')],
                                registry=registry)
+
+
+class TestSdiUserColums:
+
+    @fixture
+    def request_(self, context, registry_with_content):
+        request = testing.DummyRequest(context=context)
+        request.registry = registry_with_content
+        return request
+
+    def call_fut(self, *args, **kwargs):
+        from .principal import sdi_user_columns
+        return sdi_user_columns(*args, **kwargs)
+
+    def test_sdi_user_columns_none_user(self, context, request_):
+        context = testing.DummyResource()
+        result = self.call_fut(None, context, request_, [])
+        assert result == [
+            {'name': 'User','value': ''},
+            {'name': 'Email','value': ''},
+        ]
+
+    def test_sdi_user_columns_user(self, context, request_):
+        from .principal import IUser
+        from adhocracy_core.sheets.principal import IUserBasic
+        context = testing.DummyResource(__provides__=IUser)
+        mock_get_sheet_field = Mock()
+        mock_get_sheet_field.side_effect = ['Admin', 'admin@example.com']
+        request_.registry.content.get_sheet_field = mock_get_sheet_field
+        result = self.call_fut(None, context, request_, [])
+        assert result == [
+            {'name': 'User','value': 'Admin'},
+            {'name': 'Email','value': 'admin@example.com'},
+        ]
 
 
 class TestUser:

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -120,7 +120,7 @@ class TestSdiUserColums:
         from .principal import sdi_user_columns
         return sdi_user_columns(*args, **kwargs)
 
-    def test_sdi_user_columns_none_user(self, context, request_):
+    def test_sdi_user_columns_none_user(self, request_):
         context = testing.DummyResource()
         result = self.call_fut(None, context, request_, [])
         assert result == [
@@ -128,9 +128,8 @@ class TestSdiUserColums:
             {'name': 'Email','value': ''},
         ]
 
-    def test_sdi_user_columns_user(self, context, request_):
+    def test_sdi_user_columns_user(self, request_):
         from .principal import IUser
-        from adhocracy_core.sheets.principal import IUserBasic
         context = testing.DummyResource(__provides__=IUser)
         mock_get_sheet_field = Mock()
         mock_get_sheet_field.side_effect = ['Admin', 'admin@example.com']


### PR DESCRIPTION
* Adds mail and user-name to /principal/users/ view
* Adds Type and Title to organisation/process view, e.g. root

Fixes #2639 