### PR TITLE
Show IEmbed sheet in SDI

### DIFF
--- a/src/adhocracy_core/adhocracy_core/sdi/views/sheets.py
+++ b/src/adhocracy_core/adhocracy_core/sdi/views/sheets.py
@@ -11,7 +11,6 @@ from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import IResourceSheet
 from adhocracy_core.schema import MappingSchema
 from adhocracy_core.sdi.form import FormView
-from adhocracy_core.sheets.embed import IEmbed
 from adhocracy_core.sheets.metadata import IMetadata
 from adhocracy_core.utils import create_schema
 
@@ -83,7 +82,7 @@ class AddResourceSheetsBase(FormView):
 
     buttons = (_('add'),)
     iresource = None
-    _disabled = (IMetadata, IEmbed)
+    _disabled = (IMetadata)
     """Sheets not working with this add view yet, use sheets tabs instead."""
 
     def __init__(self, context: IResource, request: IRequest):

--- a/src/adhocracy_core/adhocracy_core/sheets/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/__init__.py
@@ -57,9 +57,10 @@ class BaseResourceSheet:
     def get_schema_with_bindings(self) -> colander.MappingSchema:
         bindings = self._get_basic_bindings()
         context = bindings.pop('context')
+        request = bindings.pop('request')
         schema = create_schema(self.meta.schema_class,
                                context,
-                               self.request,
+                               request,
                                **bindings
                                )
         schema.name = self.meta.isheet.__identifier__
@@ -70,6 +71,7 @@ class BaseResourceSheet:
     def _get_basic_bindings(self) -> dict:
         return {'context': self.context,
                 'registry': self.registry,
+                'request': self.request,
                 'creating': self.creating,
                 }
 

--- a/src/adhocracy_core/adhocracy_core/sheets/embed.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/embed.py
@@ -2,6 +2,7 @@
 import os.path
 
 from colander import deferred
+from deform.widget import TextAreaWidget
 from pyramid.interfaces import IRequest
 from pyramid.renderers import render
 from zope.interface import Interface
@@ -64,8 +65,8 @@ class EmbedSchema(MappingSchema):
     `external_url`: canonical URL that embeds the `context` resource.
     """
 
-    embed_code = Text(readonly=True,
-                      default=deferred_default_embed_code,
+    embed_code = Text(default=deferred_default_embed_code,
+                      widget=TextAreaWidget(rows=10),
                       )
     external_url = URL()
 

--- a/src/adhocracy_core/adhocracy_core/sheets/test_embed.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_embed.py
@@ -81,11 +81,12 @@ class TestEmbedSheet:
 
     def test_create(self, meta, context):
         from .embed import deferred_default_embed_code
+        from deform.widget import TextAreaWidget
         inst = meta.sheet_class(meta, context, None)
         assert inst
-        assert inst.schema['embed_code'].readonly
         assert inst.schema['embed_code'].default \
                == deferred_default_embed_code
+        assert isinstance(inst.schema['embed_code'].widget, TextAreaWidget)
 
     def test_get_empty(self, meta, context):
         inst = meta.sheet_class(meta, context, None)

--- a/src/adhocracy_core/adhocracy_core/sheets/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_init.py
@@ -122,8 +122,8 @@ class TestBaseResourceSheet:
         assert inst.get() == {'count': 0}
 
     def test_get_with_deferred_default(self, inst):
-        """A dictionary with 'registry', 'context', 'creating is passed
-        to deferred default functions.
+        """A dictionary with 'registry', 'context', 'creating' and 'request' is
+        passed to deferred default functions.
         """
         schema = inst.schema.bind()
         @colander.deferred
@@ -131,7 +131,7 @@ class TestBaseResourceSheet:
             return len(kw)
         schema['count'].default = default
         inst.schema = schema
-        assert inst.get() == {'count': 3}
+        assert inst.get() == {'count': 4}
 
     def test_get_with_omit_defaults(self, inst):
         assert inst.get(omit_defaults=True) == {}


### PR DESCRIPTION
Allows to view the default embed-code or set a custom embed-code for a process via SDI.

Currently only enabled for bplan processes (see `/manage/demo/bplan/`).