### PR TITLE
Use german renominate info in s1

### DIFF
--- a/src/adhocracy_s1/adhocracy_s1/workflows/s1.py
+++ b/src/adhocracy_s1/adhocracy_s1/workflows/s1.py
@@ -124,8 +124,8 @@ def _add_renominate_info(version: IProposalVersion, request: Request) -> None:
     description_sheet = registry.content.get_sheet(version, IDescription)
     description = description_sheet.get()['description']
     renominate_info = '\n\n---'\
-                      '\n\nrenominated by: {0}'\
-                      '\nold rating: {1}'\
+                      '\n\nErneut vorgeschlagen von: {0}'\
+                      '\nBefürworter*innen davor: {1}'\
                       '\n'.format(editor, rates)
     description_sheet.set({'description': description + renominate_info})
 

--- a/src/adhocracy_s1/adhocracy_s1/workflows/test_s1.py
+++ b/src/adhocracy_s1/adhocracy_s1/workflows/test_s1.py
@@ -189,8 +189,8 @@ class TestAddRenominateDescription:
 
         wanted = 'old_description' \
                  '\n\n---' \
-                 '\n\nrenominated by: username' \
-                 '\nold rating: 10' \
+                 '\n\nErneut vorgeschlagen von: username' \
+                 '\nBefürworter*innen davor: 10' \
                  '\n'
         index_rates.assert_called_with(context, 0)
         description_sheet.set.assert_called_with({'description': wanted})


### PR DESCRIPTION
The renominate info text appended to the description of a renominated proposal is now in german.