### PR TITLE
fix debate workbench

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -6,6 +6,7 @@
     "TR__ACTIVATION_ERROR_SUPPORT": "Um einen neuen Link zu erhalten, kontaktiere bitte unser Support-Team und gib dabei die E-Mail-Adresse an, mit der Du Dich registrierst hast.",
     "TR__ACTIVATION_ERROR_TITLE": "Hoppla, das ging schief!",
     "TR__ACTIVATION_SUCCESS_TITLE": "Dein Account ist nun aktiv!",
+    "TR__ADD_DOCUMENT": "Dokument hinzufügen",
     "TR__ADD_PARAGRAPH": "Absatz hinzufügen",
     "TR__ADD_TITLE": "{{ title }} hinzufügen",
     "TR__ANONYMIZE": "Anonym veröffentlichen",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -6,6 +6,7 @@
     "TR__ACTIVATION_ERROR_SUPPORT": "To request a new link, please contact our support team, explicitly stating the email address you registered with, via",
     "TR__ACTIVATION_ERROR_TITLE": "Oops, error!",
     "TR__ACTIVATION_SUCCESS_TITLE": "Your account has been activated!",
+    "TR__ADD_DOCUMENT": "add document",
     "TR__ADD_PARAGRAPH": "add paragraph",
     "TR__ADD_TITLE": "Add {{ title }}",
     "TR__ANONYMIZE": "publish anonymously",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/AddDocumentButton.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/AddDocumentButton.html
@@ -1,0 +1,7 @@
+<a
+    class="button-cta m-add"
+    data-ng-click="setCameFrom()"
+    data-ng-if="processOptions.POST"
+    data-ng-href="{{processUrl | adhResourceUrl:'create_document'}}">
+    {{ "TR__ADD_DOCUMENT" | translate }}
+</a>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/DebateWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/DebateWorkbench.ts
@@ -25,7 +25,7 @@ import * as SIParagraph from "../../../Resources_/adhocracy_core/sheets/document
 import * as SITitle from "../../../Resources_/adhocracy_core/sheets/title/ITitle";
 import * as SIWorkflow from "../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
 
-var pkgLocation = "/Core/DebateWorkbench";
+export var pkgLocation = "/Core/DebateWorkbench";
 
 
 export var debateWorkbenchDirective = (
@@ -113,6 +113,26 @@ export var processDetailColumnDirective = (
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             var context = adhEmbed.getContext();
             scope.hasResourceHeader = (context === "");
+        }
+    };
+};
+
+export var addDocumentButtonDirective = (
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service,
+    adhPermissions : AdhPermissions.Service,
+    adhTopLevelState : AdhTopLevelState.Service
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/AddDocumentButton.html",
+        link: (scope) => {
+            scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
+            adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
+
+            scope.setCameFrom = () => {
+                adhTopLevelState.setCameFrom();
+            };
         }
     };
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/Module.ts
@@ -43,6 +43,8 @@ export var register = (angular) => {
             "adhConfig", "adhTopLevelState", DebateWorkbench.documentEditColumnDirective])
         .directive("adhDebateProcessDetailColumn", [
             "adhConfig", "adhEmbed", "adhHttp", "adhPermissions", "adhTopLevelState", DebateWorkbench.processDetailColumnDirective])
+        .directive("adhDebateAddDocumentButton", [
+            "adhConfig", "adhHttp", "adhPermissions", "adhTopLevelState", DebateWorkbench.addDocumentButtonDirective])
         .directive("adhDebateProcessDetailAnnounceColumn", [
             "adhConfig",
             "adhEmbed",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/ProcessDetailColumn.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/ProcessDetailColumn.html
@@ -15,7 +15,8 @@
                 <adh-resource-dropdown
                     data-resource-path="{{processUrl}}"
                     data-item-path="{{processUrl}}"
-                    data-create-document="true">
+                    data-create-document="true"
+                    data-print="true">
                 </adh-resource-dropdown>
             </div>
             <adh-background-image

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/ProcessHeaderSlot.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/ProcessHeaderSlot.html
@@ -1,0 +1,1 @@
+<adh-debate-add-document-button></adh-debate-add-document-button>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Listing/Listing.ts
@@ -241,7 +241,7 @@ export class Listing<Container extends ResourcesBase.IResource> {
                     return getElements($scope.currentLimit).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = $scope.container.path;
-                        $scope.totalCount = $scope.container.data[SIPool.nick].count;
+                        $scope.totalCount = parseInt($scope.container.data[SIPool.nick].count, 10);
 
                         // avoid modifying the cached result
                         $scope.elements = _.clone($scope.container.data[SIPool.nick].elements);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Names/Names.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Names/Names.ts
@@ -18,6 +18,6 @@ export class Service {
         } else {
             ret = "TR__RESOURCE";
         }
-        return amount != 1 ? ret + "_PLURAL" : ret;
+        return amount !== 1 ? ret + "_PLURAL" : ret;
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Names/Names.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Names/Names.ts
@@ -18,6 +18,6 @@ export class Service {
         } else {
             ret = "TR__RESOURCE";
         }
-        return amount !== 1 ? ret + "_PLURAL" : ret;
+        return amount != 1 ? ret + "_PLURAL" : ret;
     }
 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
@@ -910,7 +910,7 @@ export var adhUserActivityOverviewDirective = (
                 params[SIMetadata.nick + ":creator"] = scope.path;
 
                 adhHttp.get(adhConfig.rest_url, params)
-                    .then((pool) => { scope[scopeTarget] = pool.data[SIPool.nick].count; });
+                    .then((pool) => { scope[scopeTarget] = parseInt(pool.data[SIPool.nick].count, 10); });
             };
 
             requestCountInto(RIComment, "commentCount", attrs.showComments);

--- a/src/demo/demo/static/js/Adhocracy.ts
+++ b/src/demo/demo/static/js/Adhocracy.ts
@@ -142,7 +142,11 @@ export var init = (config : AdhConfig.IService, metaApi) => {
         adhProcessProvider.templates[RICollaborativeTextProcess.content_type] =
             "<adh-debate-workbench></adh-debate-workbench>";
     }]);
-    app.config(["adhResourceAreaProvider", AdhDebateWorkbench.registerRoutes(RICollaborativeTextProcess)]);
+    app.config(["adhConfig", "adhResourceAreaProvider", (adhConfig, adhResourceAreaProvider) => {
+        var processHeaderSlot = adhConfig.pkg_path + AdhDebateWorkbench.pkgLocation + "/ProcessHeaderSlot.html";
+        adhResourceAreaProvider.processHeaderSlots[RICollaborativeTextProcess.content_type] = processHeaderSlot;
+        AdhDebateWorkbench.registerRoutes(RICollaborativeTextProcess)(adhResourceAreaProvider);
+    }]);
 
     app.value("angular", angular);
     app.value("leaflet", leaflet);

--- a/src/euth/euth/static/js/Packages/Euth/CollaborativeTextediting/Module.ts
+++ b/src/euth/euth/static/js/Packages/Euth/CollaborativeTextediting/Module.ts
@@ -20,6 +20,11 @@ export var register = (angular) => {
             adhProcessProvider.templates[RIEuthCollaborativeTextPrivateProcess.content_type] =
                 "<adh-debate-workbench></adh-debate-workbench>";
         }])
-        .config(["adhResourceAreaProvider", AdhDebateWorkbench.registerRoutes(RIEuthCollaborativeTextProcess)])
-        .config(["adhResourceAreaProvider", AdhDebateWorkbench.registerRoutes(RIEuthCollaborativeTextPrivateProcess)]);
+        .config(["adhConfig", "adhResourceAreaProvider", (adhConfig, adhResourceAreaProvider) => {
+            var processHeaderSlot = adhConfig.pkg_path + AdhDebateWorkbench.pkgLocation + "/ProcessHeaderSlot.html";
+            adhResourceAreaProvider.processHeaderSlots[RIEuthCollaborativeTextProcess.content_type] = processHeaderSlot;
+            AdhDebateWorkbench.registerRoutes(RIEuthCollaborativeTextProcess)(adhResourceAreaProvider);
+            adhResourceAreaProvider.processHeaderSlots[RIEuthCollaborativeTextPrivateProcess.content_type] = processHeaderSlot;
+            AdhDebateWorkbench.registerRoutes(RIEuthCollaborativeTextPrivateProcess)(adhResourceAreaProvider);
+        }]);
 };

--- a/src/meinberlin/meinberlin/static/i18n/core_de.json
+++ b/src/meinberlin/meinberlin/static/i18n/core_de.json
@@ -6,6 +6,7 @@
     "TR__ACTIVATION_ERROR_SUPPORT": "Um einen neuen Link zu erhalten, kontaktieren Sie bitte unser Support-Team und geben Sie dabei die E-Mail-Adresse an, mit der Sie sich registriert haben.",
     "TR__ACTIVATION_ERROR_TITLE": "Hoppla, das ging schief!",
     "TR__ACTIVATION_SUCCESS_TITLE": "Ihr Account ist nun aktiv!",
+    "TR__ADD_DOCUMENT": "Dokument hinzufügen",
     "TR__ADD_PARAGRAPH": "Absatz hinzufügen",
     "TR__ADD_TITLE": "{{ title }} hinzufügen",
     "TR__ANONYMIZE": "Anonym veröffentlichen",

--- a/src/meinberlin/meinberlin/static/js/Adhocracy.ts
+++ b/src/meinberlin/meinberlin/static/js/Adhocracy.ts
@@ -139,7 +139,11 @@ export var init = (config : AdhConfig.IService, metaApi) => {
         adhProcessProvider.templates[RICollaborativeTextProcess.content_type] =
             "<adh-debate-workbench></adh-debate-workbench>";
     }]);
-    app.config(["adhResourceAreaProvider", AdhDebateWorkbench.registerRoutes(RICollaborativeTextProcess)]);
+    app.config(["adhConfig", "adhResourceAreaProvider", (adhConfig, adhResourceAreaProvider) => {
+        var processHeaderSlot = adhConfig.pkg_path + AdhDebateWorkbench.pkgLocation + "/ProcessHeaderSlot.html";
+        adhResourceAreaProvider.processHeaderSlots[RICollaborativeTextProcess.content_type] = processHeaderSlot;
+        AdhDebateWorkbench.registerRoutes(RICollaborativeTextProcess)(adhResourceAreaProvider);
+    }]);
     app.config(["adhNamesProvider", (adhNamesProvider : AdhNames.Provider) => {
         adhNamesProvider.names[RICollaborativeTextProcess.content_type] = "TR__RESOURCE_COLLABORATIVE_TEXT_EDITING";
     }]);

--- a/src/spd/spd/static/js/Adhocracy.ts
+++ b/src/spd/spd/static/js/Adhocracy.ts
@@ -132,7 +132,11 @@ export var init = (config : AdhConfig.IService, metaApi) => {
         adhProcessProvider.templates[RIDigitalLebenProcess.content_type] =
             "<adh-debate-workbench></adh-debate-workbench>";
     }]);
-    app.config(["adhResourceAreaProvider", AdhDebateWorkbench.registerRoutes(RIDigitalLebenProcess)]);
+    app.config(["adhConfig", "adhResourceAreaProvider", (adhConfig, adhResourceAreaProvider) => {
+        var processHeaderSlot = adhConfig.pkg_path + AdhDebateWorkbench.pkgLocation + "/ProcessHeaderSlot.html";
+        adhResourceAreaProvider.processHeaderSlots[RIDigitalLebenProcess.content_type] = processHeaderSlot;
+        AdhDebateWorkbench.registerRoutes(RIDigitalLebenProcess)(adhResourceAreaProvider);
+    }]);
 
     app.value("angular", angular);
     app.value("leaflet", leaflet);


### PR DESCRIPTION
- there is now no empty resource dropdown in the process header (fixup of #2741) 
- the document listing counter now says "1 resource" (unfortunately, the linter complains about `!=`)
- a button saying "add document" appears in the header (i.e. in the `processHeaderSlot`; sort-of continues #2143 and #2113).

I tested `meinberlin`, `demo` and `euth`.