### PR TITLE
Fix request to parent resource on subpath rest_url

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/ResourceArea/ResourceArea.ts
@@ -270,20 +270,17 @@ export class Service implements AdhTopLevelState.IAreaInput {
     private conditionallyRedirectVersionToLast(resourceUrl : string, view? : string) : angular.IPromise<boolean> {
         var self : Service = this;
 
-        return self.$q.all([
-            self.adhHttp.get(resourceUrl),
-            self.adhHttp.get(AdhUtil.parentPath(resourceUrl))
-        ]).then((args : ResourcesBase.IResource[]) => {
-            var version = args[0];
-            var item = args[1];
-            if (version.data.hasOwnProperty(SIVersionable.nick) && item.data.hasOwnProperty(SITags.nick)) {
-                var lastUrl = item.data[SITags.nick].LAST;
-                if (lastUrl === resourceUrl) {
-                    return false;
-                } else {
-                    self.$location.path(self.adhResourceUrlFilter(lastUrl, view));
-                    return true;
-                }
+        return self.adhHttp.get(resourceUrl).then((version) => {
+            if (version.data.hasOwnProperty(SIVersionable.nick)) {
+                return self.adhHttp.get(AdhUtil.parentPath(resourceUrl)).then((item) => {
+                    var lastUrl = item.data[SITags.nick].LAST;
+                    if (lastUrl === resourceUrl) {
+                        return false;
+                    } else {
+                        self.$location.path(self.adhResourceUrlFilter(lastUrl, view));
+                        return true;
+                    }
+                });
             } else {
                 return false;
             }


### PR DESCRIPTION
Steps to reproduce the issue:

-   have rest API running on a subpath, e.g. /api/
-   visit the root resource (`/r/`) in the browser

This will request `/` and subsequently throw an error because the response can not be parsed as JSON.

This fix works because the root resource is not versionable.