### PR TITLE
Add simple static page resources

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -14,6 +14,7 @@ permissions:
   # create structure
   - [create_organisation,            ~,         ~,             ~,            ~,         ~,       ~,         A] # create organisation
   - [create_process,                 ~,         ~,             ~,            ~,         ~,       A,         A] # create process
+  - [create_page,                    ~,         ~,             ~,            ~,         ~,       A,         A] # create a static page
   # create process content
   - [create_asset,                   ~,         ~,             ~,            ~,         ~,       ~,         A] # create asset (image/file upload)
   - [create_external,                ~,         ~,             A,            ~,         ~,       ~,         A] # create external (store external URL)

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -931,6 +931,16 @@ def add_local_roles_to_acl(root, registry):  # pragma: no cover
         _set_acl_with_local_roles(resource, acl, registry)
 
 
+@log_migration
+def add_pages_service_to_root(root, registry):  # pragma: no cover
+    """Add pages service to root."""
+    from adhocracy_core.resources.page import add_page_service
+    pages = find_service(root, 'pages')
+    if pages is None:
+        logger.info('Add pages service to {0}'.format(root))
+        add_page_service(root, registry, {})
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -991,3 +1001,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(add_anonymize_default_sheet_to_user)
     config.add_evolution_step(add_allow_add_anonymized_sheet_to_rates)
     config.add_evolution_step(add_local_roles_to_acl)
+    config.add_evolution_step(add_pages_service_to_root)

--- a/src/adhocracy_core/adhocracy_core/resources/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/resources/__init__.py
@@ -318,3 +318,4 @@ def includeme(config):
     config.include('.service')
     config.include('.logbook')
     config.include('.relation')
+    config.include('.page')

--- a/src/adhocracy_core/adhocracy_core/resources/page.py
+++ b/src/adhocracy_core/adhocracy_core/resources/page.py
@@ -1,0 +1,54 @@
+"""'Simple page resource type."""
+from pyramid.registry import Registry
+
+from adhocracy_core.interfaces import ISimple
+from adhocracy_core.interfaces import IPool
+from adhocracy_core.interfaces import IServicePool
+from adhocracy_core.resources import add_resource_type_to_registry
+from adhocracy_core.resources.simple import simple_meta
+from adhocracy_core.resources.service import service_meta
+
+import adhocracy_core.sheets
+
+
+class IPage(ISimple):
+    """A simple page."""
+
+
+page_meta = simple_meta._replace(
+    content_name='Page',
+    iresource=IPage,
+    use_autonaming=False,
+    basic_sheets=(adhocracy_core.sheets.name.IName,
+                  adhocracy_core.sheets.title.ITitle,
+                  adhocracy_core.sheets.description.IDescription,
+                  adhocracy_core.sheets.metadata.IMetadata,
+                  ),
+    permission_create='create_page',
+    is_sdi_addable=True,
+
+)
+
+
+class IPageService(IServicePool):
+    """The 'page' ServicePool."""
+
+
+page_service_meta = service_meta._replace(
+    iresource=IPageService,
+    content_name='pages',
+    element_types=(IPage,),
+)
+
+
+def add_page_service(context: IPool, registry: Registry, options: dict):
+    """Add `page` service to context."""
+    registry.content.create(IPageService.__identifier__,
+                            parent=context,
+                            autoupdated=True)
+
+
+def includeme(config):
+    """Add resource type to registry."""
+    add_resource_type_to_registry(page_meta, config)
+    add_resource_type_to_registry(page_service_meta, config)

--- a/src/adhocracy_core/adhocracy_core/resources/root.py
+++ b/src/adhocracy_core/adhocracy_core/resources/root.py
@@ -19,6 +19,7 @@ from adhocracy_core.resources.principal import ISystemUser
 from adhocracy_core.resources.principal import IGroup
 from adhocracy_core.resources.process import IProcess
 from adhocracy_core.resources.geo import add_locations_service
+from adhocracy_core.resources.page import add_page_service
 from adhocracy_core.catalog import ICatalogsService
 import adhocracy_core.sheets.principal
 import adhocracy_core.sheets.name
@@ -41,6 +42,7 @@ def create_initial_content_for_app_root(context: IPool, registry: Registry,
     _add_anonymous_user(context, registry)
     add_locations_service(context, registry, {})
     add_assets_service(context, registry, {})
+    add_page_service(context, registry, {})
 
 
 def _add_objectmap_to_app_root(root):

--- a/src/adhocracy_core/adhocracy_core/resources/test_page.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_page.py
@@ -1,0 +1,57 @@
+from pytest import fixture
+from pytest import mark
+
+class TestPage:
+
+    @fixture
+    def meta(self):
+        from .page import page_meta
+        return page_meta
+
+    def test_meta(self, meta):
+        from adhocracy_core.interfaces import ISimple
+        from . import page
+        import adhocracy_core.sheets
+        assert meta.iresource is page.IPage
+        assert meta.iresource.isOrExtends(ISimple)
+        assert meta.permission_create == 'create_page'
+        assert meta.basic_sheets == \
+               (adhocracy_core.sheets.name.IName,
+                adhocracy_core.sheets.title.ITitle,
+                adhocracy_core.sheets.description.IDescription,
+                adhocracy_core.sheets.metadata.IMetadata,
+                )
+        assert meta.use_autonaming == False
+        assert meta.is_sdi_addable == True
+
+    @mark.usefixtures('integration')
+    def test_create(self, registry):
+        from .page import IPage
+        res = registry.content.create(IPage.__identifier__)
+        assert IPage.providedBy(res)
+
+
+class TestPageService:
+
+    @fixture
+    def meta(self):
+        from .page import page_service_meta
+        return page_service_meta
+
+    def test_meta(self, meta):
+        from adhocracy_core.interfaces import IServicePool
+        from . import page
+        assert meta.iresource is page.IPageService
+        assert meta.iresource.isOrExtends(IServicePool)
+        assert meta.element_types == (page.IPage,)
+
+    @mark.usefixtures('integration')
+    def test_create(self, pool, registry, meta):
+        assert registry.content.create(meta.iresource.__identifier__, pool)
+
+    @mark.usefixtures('integration')
+    def test_add_page_service(self, pool, registry, meta):
+        from substanced.util import find_service
+        from .page import add_page_service
+        add_page_service(pool, registry, {})
+        assert find_service(pool, 'pages')

--- a/src/adhocracy_core/adhocracy_core/resources/test_root.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_root.py
@@ -53,6 +53,7 @@ class TestRoot:
         assert find_catalog(inst, 'adhocracy') is not None
         assert find_service(inst, 'principals', 'users') is not None
         assert find_service(inst, 'locations') is not None
+        assert find_service(inst, 'pages') is not None
 
     def test_create_root_with_initial_god_user(self, registry, request_):
         from substanced.interfaces import IUserLocator


### PR DESCRIPTION
When a resource has an IPageService  a "pages/" element is added to the resource pool that can contain IPage elements.

The service is added to the root resource.

To test:
* Create page elements with SDI
* Fetch the pages via the API