### PR TITLE
Fix admin multi-polygons creation permissions

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
+++ b/src/adhocracy_core/adhocracy_core/authorization/root_permissions.yaml
@@ -23,6 +23,7 @@ permissions:
   - [create_comment,                 ~,         ~,             ~,            ~,         ~,       ~,         A] # create comment
   - [create_rate,                    ~,         ~,             ~,            ~,         ~,       ~,         ~] # create rate
   - [edit_rate,                      ~,         ~,             ~,            ~,         ~,       ~,         ~] # create rate version (edit for rates)
+  - [create_multipolygon,            ~,         ~,             ~,            ~,         ~,       ~,         A] # create geo multipolygon
   # badges
   - [create_badge,                   ~,         ~,             ~,            A,         ~,       A,         A] # create badge
   - [create_badge_assignment,        ~,         ~,             ~,            ~,         ~,       ~,         A] # create badge assingment


### PR DESCRIPTION
Adds a missing permission used to add multi-polygons to locations.

When logged in as an admin user in sdi (not god), it should be possible now to add multi-polygons under `/locations.