### PR TITLE
Fix Stadtforum workbench

### DIFF
--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
@@ -134,13 +134,13 @@ export var detailDirective = (
             }];
             scope.sort = "item_creation_date";
 
+            scope.contentType = RIProposalVersion.content_type;
+
             scope.$watch("path", (value : string) => {
                 if (value) {
                     adhHttp.get(value).then((resource) => {
                         scope.data.title = resource.data[SITitle.nick].title;
                         scope.data.shortDescription = resource.data[SIDescription.nick].short_description;
-
-                        scope.contentType = RIProposalVersion.content_type;
                     });
                 }
             });

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
@@ -163,7 +163,7 @@ export var registerRoutes = (
         })
         .default(RIStadtforumProcess, "create_proposal", processType, context, {
             space: "content",
-            movingColumns: "is-show-hide-hide"
+            movingColumns: "is-show-show-hide"
         })
         .specific(RIStadtforumProcess, "create_proposal", processType, context, [
             "adhHttp", (adhHttp : AdhHttp.Service) => (resource : RIStadtforumProcess) => {

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Create.html
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Create.html
@@ -32,5 +32,11 @@
                 value="{{ 'TR__PUBLISH' | translate }}"
                 class="button-cta" />
         </div>
+        <div class="form-footer-left">
+            <a
+                href=""
+                data-ng-click="cancel()"
+                class="button">{{ "TR__CANCEL" | translate }}</a>
+        </div>
     </footer>
 </form>

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Detail.html
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Detail.html
@@ -1,7 +1,9 @@
 <article>
-    <h1>{{ data.title }}</h1>
+    <div class="l-padding">
+        <h1>{{ data.title }}</h1>
 
-    <adh-opinion data-refers-to="{{path}}"></adh-opinion>
+        <adh-opinion data-refers-to="{{path}}"></adh-opinion>
+    </div>
 
     <adh-comment-listing data-path="{{path}}"></adh-comment-listing>
 </article>

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Module.ts
@@ -42,6 +42,21 @@ export var register = (angular) => {
             "$location",
             Proposal.createDirective
         ])
+        .directive("adhMeinberlinStadtforumProposalEdit", [
+            "adhConfig",
+            "adhHttp",
+            "adhPermissions",
+            "adhPreliminaryNames",
+            "adhRate",
+            "adhResourceUrlFilter",
+            "adhShowError",
+            "adhSubmitIfValid",
+            "adhTopLevelState",
+            "adhGetBadges",
+            "$location",
+            "$q",
+            Proposal.editDirective
+        ])
         .directive("adhMeinberlinStadtforumProposalListItem", [
             "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhGetBadges", "$q", Proposal.listItemDirective]);
 };

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -7,6 +7,7 @@ import * as AdhPermissions from "../../../Core/Permissions/Permissions";
 import * as AdhPreliminaryNames from "../../../Core/PreliminaryNames/PreliminaryNames";
 import * as AdhRate from "../../../Core/Rate/Rate";
 import * as AdhTopLevelState from "../../../Core/TopLevelState/TopLevelState";
+import * as AdhUtil from "../../../Core/Util/Util";
 
 import * as SICommentable from "../../../../Resources_/adhocracy_core/sheets/comment/ICommentable";
 import * as SIDescription from "../../../../Resources_/adhocracy_core/sheets/description/IDescription";
@@ -169,7 +170,10 @@ export var createDirective = (
 
             scope.submit = () => {
                 return adhSubmitIfValid(scope, element, scope.proposalForm, () => {
-                    return postCreate(adhHttp, adhPreliminaryNames)(scope, scope.poolPath);
+                    return postCreate(adhHttp, adhPreliminaryNames)(scope, scope.poolPath)
+                        .then((result) => {
+                            $location.url(adhResourceUrlFilter(AdhUtil.parentPath(result[1].path)));
+                        });
                 });
             };
         }

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -176,6 +176,11 @@ export var createDirective = (
                         });
                 });
             };
+
+            scope.cancel = () => {
+                var fallback = adhResourceUrlFilter(scope.poolPath);
+                adhTopLevelState.goToCameFrom(fallback);
+            };
         }
     };
 };

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -121,6 +121,23 @@ var postCreate = (
     return adhHttp.deepPost([proposal, proposalVersion]);
 };
 
+var postEdit = (
+    adhHttp : AdhHttp.Service,
+    adhPreliminaryNames : AdhPreliminaryNames.Service
+) => (
+    scope : IScope,
+    oldVersion : RIProposalVersion
+) => {
+    var proposalVersion = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
+    proposalVersion.parent = AdhUtil.parentPath(oldVersion.path);
+    proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+        follows: [oldVersion.path]
+    });
+    fill(scope, proposalVersion);
+
+    return adhHttp.deepPost([proposalVersion]);
+};
+
 
 export var detailDirective = (
     adhConfig : AdhConfig.IService,
@@ -179,6 +196,49 @@ export var createDirective = (
 
             scope.cancel = () => {
                 var fallback = adhResourceUrlFilter(scope.poolPath);
+                adhTopLevelState.goToCameFrom(fallback);
+            };
+        }
+    };
+};
+
+export var editDirective = (
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service,
+    adhPermissions : AdhPermissions.Service,
+    adhPreliminaryNames : AdhPreliminaryNames.Service,
+    adhRate : AdhRate.Service,
+    adhResourceUrlFilter,
+    adhShowError,
+    adhSubmitIfValid,
+    adhTopLevelState : AdhTopLevelState.Service,
+    adhGetBadges : AdhBadge.IGetBadgeAssignments,
+    $location : angular.ILocationService,
+    $q : angular.IQService
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Create.html",
+        scope: {
+            path: "@"
+        },
+        link: (scope, element) => {
+            scope.errors = [];
+            scope.data = {};
+            scope.showError = adhShowError;
+            bindPath(adhHttp, adhPermissions, adhRate, adhTopLevelState, adhGetBadges, $q)(scope);
+
+            scope.submit = () => {
+                return adhSubmitIfValid(scope, element, scope.proposalForm, () => {
+                    return postEdit(adhHttp, adhPreliminaryNames)(scope, scope.resource)
+                        .then((result) => {
+                            $location.url(adhResourceUrlFilter(AdhUtil.parentPath(result[0].path)));
+                        });
+                });
+            };
+
+            scope.cancel = () => {
+                var fallback = adhResourceUrlFilter(AdhUtil.parentPath(scope.path));
                 adhTopLevelState.goToCameFrom(fallback);
             };
         }


### PR DESCRIPTION
Some fixups to #2746.

- When coming from the process overview, the poll listing was empty. This was fixed in 	834413f.
- The layout was improved.
- The create form was improved
- Edit was implemented

Still to do (separately):

- Handle the fact that a poll is in draft state after creation (either show something useful or do transition to participate directly)
- Add links to edit/create in the UI