### PR TITLE
Remove some embed widget parameter from the IEmbed sheet if false

### DIFF
--- a/src/adhocracy_core/adhocracy_core/sheets/test_embed.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_embed.py
@@ -65,6 +65,23 @@ class TestDeferredEmbedCode:
         result = self.call_fut(node, kw)
         assert 'data-path="http:localhost/1"' in result
 
+    def test_remove_noheader_from_embed_code_if_false(
+            self, mock_config_adapter, config, node, kw):
+        config.include('pyramid_mako')
+        mock_config_adapter.return_value = \
+            mock_config_adapter.return_value = {'noheader': 'false'}
+        result = self.call_fut(node, kw)
+        assert 'data-noheader' not in result
+
+
+    def test_remove_nocenter_from_embed_code_if_false(
+        self, mock_config_adapter, config, node, kw):
+        config.include('pyramid_mako')
+        mock_config_adapter.return_value = \
+            mock_config_adapter.return_value = {'nocenter': 'false'}
+        result = self.call_fut(node, kw)
+        assert 'data-nocenter' not in result
+
 
 class TestEmbedSheet:
 

--- a/src/adhocracy_core/adhocracy_core/templates/embed_code.html.mako
+++ b/src/adhocracy_core/adhocracy_core/templates/embed_code.html.mako
@@ -22,7 +22,11 @@
      data-locale="${locale}"
      data-autourl="${autourl}"
      data-initial-url="${initial_url}"
+     %if nocenter!="false":
      data-nocenter="${nocenter}"
+     %endif
+     %if noheader!="false":
      data-noheader="${noheader}"
+     %endif
      style="${style}">
 </div>


### PR DESCRIPTION
See #2772 

The `noheader` and `nocenter` cannot be disabled when setting to false.

As a temporary fix these parameters are deleted from the embed sheet template when set to false.