### PR TITLE
Allow to set empty description and short description

### DIFF
--- a/src/adhocracy_core/adhocracy_core/sheets/description.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/description.py
@@ -18,8 +18,8 @@ class DescriptionSchema(MappingSchema):
     `description`: a full description
     """
 
-    short_description = Text()
-    description = Text()
+    short_description = Text(missing='')
+    description = Text(missing='')
 
 
 description_meta = sheet_meta._replace(isheet=IDescription,

--- a/src/adhocracy_core/adhocracy_core/sheets/test_description.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_description.py
@@ -31,3 +31,24 @@ class TestDescriptionSheet:
     def test_includeme_register_sheet(self, meta, config):
         context = testing.DummyResource(__provides__=meta.isheet)
         assert config.registry.content.get_sheet(context, meta.isheet)
+
+
+class TestDescriptionSchema:
+
+    def make_one(self):
+        from .description import DescriptionSchema
+        return DescriptionSchema().bind()
+
+    def test_create(self):
+        from adhocracy_core.schema import Text
+        inst = self.make_one()
+        assert isinstance(inst['description'], Text)
+        assert isinstance(inst['short_description'], Text)
+
+    def test_serialize_emtpy(self):
+        import colander
+        inst = self.make_one()
+        assert inst.deserialize({}) == {
+            'description': '',
+            'short_description': '',
+        }


### PR DESCRIPTION
Fixes #2521 

Allows empty values for `description` and `short_description` of the `IDescription` sheet.

**Important:**
Colander does not differentiate between setting a sheet field to an empty string and not providing the sheet field at all. E.g. Just setting `{description:"Text"}` will set `short_description` to `''`. This means, when changing the description via the API both fields must be provided.

Alternatively, we could also think of allowing the empty value for the text fields in all sheets, but this might break something, if the frontend does not provide all sheet fields.
