### PR TITLE
Make badges and badge-groups addable in sdi

### DIFF
--- a/src/adhocracy_core/adhocracy_core/resources/badge.py
+++ b/src/adhocracy_core/adhocracy_core/resources/badge.py
@@ -28,6 +28,7 @@ badge_meta = simple_meta._replace(
         adhocracy_core.sheets.badge.IBadge,
     ),
     permission_create='create_badge',
+    is_sdi_addable=True,
 )._add(
     extended_sheets=(adhocracy_core.sheets.name.IName,)
 )
@@ -46,6 +47,7 @@ badge_group_meta = pool_meta._replace(
     element_types=(IBadge,
                    IBadgeGroup,
                    ),
+    is_sdi_addable=True,
 )
 
 
@@ -58,7 +60,9 @@ participants_assignable_badge_group_meta = badge_group_meta._replace(
     default_workflow='badge_assignment',
     element_types=(IBadge,
                    IBadgeGroup,
-                   IParticipantsAssignableBadgeGroup,),
+                   IParticipantsAssignableBadgeGroup,
+                   ),
+    is_implicit_addable=True,
 )
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/test_badge.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_badge.py
@@ -20,6 +20,7 @@ class TestBadge:
                                         sheets.badge.IBadge,
                                         sheets.name.IName,)
         assert meta.permission_create == 'create_badge'
+        assert meta.is_sdi_addable == True
 
     @mark.usefixtures('integration')
     def test_create(self, context, registry, meta):
@@ -42,6 +43,7 @@ class TestBadgeGroup:
         assert meta.element_types == (resources.badge.IBadge,
                                       meta.iresource,
                                       )
+        assert meta.is_sdi_addable == True
 
     @mark.usefixtures('integration')
     def test_create(self, context, registry, meta):
@@ -68,6 +70,7 @@ class TestParticipantsAssignableBadgeGroup:
                                       meta.iresource,
                                       )
         assert meta.default_workflow == 'badge_assignment'
+        assert meta.is_implicit_addable == True
 
     @mark.usefixtures('integration')
     def test_create(self, context, registry, meta):


### PR DESCRIPTION
In a `badges/` service (e.g. of an idea collection) it is now possible to add badge-groups and badges via SDI.