### PR TITLE
Better filtering of users in SDI

### DIFF
--- a/src/adhocracy_core/adhocracy_core/catalog/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/__init__.py
@@ -322,5 +322,6 @@ def includeme(config):
     add_resource_type_to_registry(catalogs_service_meta, config)
     config.scan('substanced.catalog')
     config.scan('.index')
+    config.include('.system')
     config.include('.adhocracy')
     config.include('.subscriber')

--- a/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/subscriber.py
@@ -122,6 +122,12 @@ def _get_affected_commentables(commentable):
     return commentables
 
 
+def reindex_user_text(event):
+    """Reindex indexes `text`."""
+    catalogs = find_service(event.object, 'catalogs')
+    catalogs.reindex_index(event.object, 'text')
+
+
 def includeme(config):
     """Register index subscribers."""
     config.add_subscriber(reindex_tag,
@@ -164,5 +170,11 @@ def includeme(config):
     config.add_subscriber(reindex_comments,
                           ISheetBackReferenceModified,
                           event_isheet=ICommentable)
+    config.add_subscriber(reindex_user_text,
+                          IResourceSheetModified,
+                          event_isheet=IUserBasic)
+    config.add_subscriber(reindex_user_text,
+                          IResourceSheetModified,
+                          event_isheet=IUserExtended)
     # add subscriber to updated allowed index
     config.scan('substanced.objectmap.subscribers')

--- a/src/adhocracy_core/adhocracy_core/catalog/system.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/system.py
@@ -1,0 +1,46 @@
+"""Custom system index views."""
+from pyramid.traversal import get_current_registry
+
+from adhocracy_core.sheets.principal import IUserBasic
+from adhocracy_core.sheets.principal import IUserExtended
+
+
+def index_user_text(resource, default) -> str:
+    """Return text index for users."""
+    registry = get_current_registry(resource)
+    name = getattr(resource, '__name__', '')
+    name_text_index = _get_text_index(name)
+    user_name = registry.content.get_sheet_field(resource, IUserBasic, 'name')
+    user_name_text_index = _get_text_index(user_name)
+    user_email = registry.content.get_sheet_field(resource,
+                                                  IUserExtended,
+                                                  'email')
+    user_email_text_index = _get_text_index(user_email)
+    text_index = ' '.join([name_text_index,
+                           user_name_text_index,
+                           user_email_text_index])
+    return text_index
+
+
+def _get_text_index(string):
+    """Copied from substanced/catalog/system.py."""
+    val = string
+    for char in (',', '-', '_', '.'):
+        val = ' '.join([x.strip() for x in val.split(char)])
+    if val != string:
+        return string + ' ' + val
+    return string
+
+
+def includeme(config):
+    """Overload system catalog index views."""
+    config.add_indexview(index_user_text,
+                         catalog_name='system',
+                         index_name='text',
+                         context=IUserBasic,
+                         )
+    config.add_indexview(index_user_text,
+                         catalog_name='system',
+                         index_name='text',
+                         context=IUserExtended,
+                         )

--- a/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
@@ -213,10 +213,11 @@ def test_register_subscriber(registry):
     assert subscriber.reindex_tag.__name__ in handlers
     assert subscriber.reindex_visibility.__name__ in handlers
     assert subscriber.reindex_rates.__name__ in handlers
+    assert subscriber.reindex_controversiality.__name__ in handlers
     assert subscriber.reindex_badge.__name__ in handlers
     assert subscriber.reindex_item_badge.__name__ in handlers
     assert subscriber.reindex_workflow_state.__name__ in handlers
     assert subscriber.reindex_user_name.__name__ in handlers
     assert subscriber.reindex_user_email.__name__ in handlers
-    assert subscriber.reindex_controversiality.__name__ in handlers
+    assert subscriber.reindex_comments.__name__ in handlers
 

--- a/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_subscriber.py
@@ -205,6 +205,10 @@ class TestReindexComments:
         catalog.reindex_index.assert_any_call(event.object, 'comments')
         catalog.reindex_index.assert_any_call(reference, 'comments')
 
+def test_reindex_user_text(event, catalog):
+    from .subscriber import reindex_user_text
+    reindex_user_text(event)
+    catalog.reindex_index.assert_called_with(event.object, 'text')
 
 @mark.usefixtures('integration')
 def test_register_subscriber(registry):

--- a/src/adhocracy_core/adhocracy_core/catalog/test_system.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_system.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+from pyramid import testing
+from pytest import fixture
+from pytest import mark
+
+
+class TestIndexUserText:
+
+    @fixture
+    def registry(self, registry_with_content):
+        return registry_with_content
+
+    def call_fut(self, *args):
+        from .system import index_user_text
+        return index_user_text(*args)
+
+    def test_return_user_name(self, registry, context, mock_sheet):
+        from copy import deepcopy
+        context.__name__ = '0000006'
+        user_basic_sheet = deepcopy(mock_sheet)
+        user_basic_sheet.get.return_value = {'name': 'user_name'}
+        user_extended_sheet = deepcopy(mock_sheet)
+        user_extended_sheet.get.return_value = {'email': 'user@example.com'}
+        registry.content.get_sheet.side_effect = [user_basic_sheet,
+                                                  user_extended_sheet]
+        result = self.call_fut(context, 'default')
+        assert result == '0000006 ' \
+                         'user_name user name ' \
+                         'user@example.com user@example com'

--- a/src/adhocracy_core/adhocracy_core/catalog/test_system.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_system.py
@@ -14,7 +14,7 @@ class TestIndexUserText:
         from .system import index_user_text
         return index_user_text(*args)
 
-    def test_return_user_name(self, registry, context, mock_sheet):
+    def test_return_user_text(self, registry, context, mock_sheet):
         from copy import deepcopy
         context.__name__ = '0000006'
         user_basic_sheet = deepcopy(mock_sheet)

--- a/src/adhocracy_core/adhocracy_core/evolution/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/evolution/__init__.py
@@ -948,6 +948,15 @@ def add_embed_sheet_to_processes(root, registry):  # pragma: no cover
     migrate_new_sheet(root, IProcess, IEmbed)
 
 
+@log_migration
+def reindex_users_text(root, registry):  # pragma: no cover
+    """Reindex user system text index."""
+    catalogs = find_service(root, 'catalogs')
+    users = find_service(root, 'principals', 'users')
+    for user in users.values():
+        catalogs.reindex_index(user, 'text')
+
+
 def includeme(config):  # pragma: no cover
     """Register evolution utilities and add evolution steps."""
     config.add_directive('add_evolution_step', add_evolution_step)
@@ -1010,3 +1019,4 @@ def includeme(config):  # pragma: no cover
     config.add_evolution_step(add_local_roles_to_acl)
     config.add_evolution_step(add_pages_service_to_root)
     config.add_evolution_step(add_embed_sheet_to_processes)
+    config.add_evolution_step(reindex_users_text)


### PR DESCRIPTION
Allows to filter users by user-name or email.

Substanced uses the `text`index of the system catalog for the filtering functionality, so we extend this index by adding the user-name and email.

To test use the filter field in the SDI users overview.