### PR TITLE
stop wrapping resources in classes in Http/Convert.ts

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Convert.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Convert.ts
@@ -53,7 +53,7 @@ var importField = (value, field : AdhMetaApi.ISheetField) => {
             parser = (point) => _.map(point, toFloat);
             break;
         case "adhocracy_core.sheets.geo.Polygon":
-            parser = (polygon) => _.map(polygon, (line) => _.map(line, toFloat));
+            parser = (polygon : any[][][]) => _.map(polygon, (line) => _.map(line, (point) => _.map(point, toFloat)));
             break;
     }
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Convert.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Convert.ts
@@ -14,7 +14,7 @@ import * as SIPool from "../../../Resources_/adhocracy_core/sheets/pool/IPool";
 import * as AdhCache from "./Cache";
 
 
-var sanityCheck = (obj : ResourcesBase.IResource) : void => {
+var sanityCheck = (obj : ResourcesBase.IResource, adhMetaApi : AdhMetaApi.Service) : void => {
     if (typeof obj !== "object") {
         throw ("unexpected type: " + (typeof obj).toString() + "\nin object:\n" + JSON.stringify(obj, null, 2));
     }
@@ -23,7 +23,7 @@ var sanityCheck = (obj : ResourcesBase.IResource) : void => {
         throw ("resource has no content_type field:\n" + JSON.stringify(obj, null, 2));
     }
 
-    if (!Resources_.resourceRegistry.hasOwnProperty(obj.content_type)) {
+    if (!adhMetaApi.resourceExists(obj.content_type)) {
         throw ("unknown content_type: " + obj.content_type + "\nin object:\n" + JSON.stringify(obj, null, 2));
     }
 };
@@ -43,7 +43,7 @@ export var importResource = <R extends ResourcesBase.IResource>(
     "use strict";
 
     var obj = response.data;
-    sanityCheck(obj);
+    sanityCheck(obj, metaApi);
 
     if (!obj.hasOwnProperty("path")) {
         throw ("resource has no path field: " + JSON.stringify(obj, null, 2));
@@ -68,7 +68,7 @@ export var importResource = <R extends ResourcesBase.IResource>(
     // iterate over all delivered sheets and construct instances
 
     _.forOwn(obj.data, (jsonSheet, sheetName) => {
-        if (!Resources_.sheetRegistry.hasOwnProperty(sheetName)) {
+        if (!metaApi.sheetExists(sheetName)) {
             throw ("unknown property sheet: " + sheetName + " " + JSON.stringify(obj, null, 2));
         }
 
@@ -203,7 +203,7 @@ export var exportResource = <R extends ResourcesBase.IResource>(
 ) : R => {
     "use strict";
 
-    sanityCheck(obj);
+    sanityCheck(obj, adhMetaApi);
     var newobj : R = _.cloneDeep(obj);
 
     // remove some fields from newobj.data[*] and empty sheets from

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Convert.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Convert.ts
@@ -8,6 +8,7 @@ import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
 import * as ResourcesBase from "../../../ResourcesBase";
 import * as Resources_ from "../../../Resources_";
 
+import * as SIMetadata from "../../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
 import * as SIPool from "../../../Resources_/adhocracy_core/sheets/pool/IPool";
 
 import * as AdhCache from "./Cache";
@@ -223,7 +224,7 @@ export var exportResource = <R extends ResourcesBase.IResource>(
                     }
                     // workaround, as normal users can not set `hidden` field
                     // FIXME: use more appropriate place, e.g. expose in meta api
-                    if (!keepMetadata && sheetName === "adhocracy_core.sheets.metadata.IMetadata" && fieldName === "hidden") {
+                    if (!keepMetadata && sheetName === SIMetadata.nick && fieldName === "hidden") {
                         delete sheet[fieldName];
                     }
                 }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/HttpSpec.ts
@@ -54,6 +54,7 @@ var mkAdhMetaApiMock = () => {
             }
         },
 
+        resourceExists: () => true,
         sheetExists: () => true,
         fieldExists: () => true,
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Image.ts
@@ -5,8 +5,8 @@ import * as AdhHttp from "../Http/Http";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 
 import RIImage from "../../../Resources_/adhocracy_core/resources/image/IImage";
-import * as SIAssetData from "../../../Resources_/adhocracy_core/sheets/asset/IHasAssetPool";
-import * as SIHasAssetPool from "../../../Resources_/adhocracy_core/sheets/asset/IAssetData";
+import * as SIAssetData from "../../../Resources_/adhocracy_core/sheets/asset/IAssetData";
+import * as SIHasAssetPool from "../../../Resources_/adhocracy_core/sheets/asset/IHasAssetPool";
 import * as SIImageMetadata from "../../../Resources_/adhocracy_core/sheets/image/IImageMetadata";
 import * as SIImageReference from "../../../Resources_/adhocracy_core/sheets/image/IImageReference";
 import * as SIVersionable from "../../../Resources_/adhocracy_core/sheets/versions/IVersionable";

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Image.ts
@@ -5,7 +5,8 @@ import * as AdhHttp from "../Http/Http";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 
 import RIImage from "../../../Resources_/adhocracy_core/resources/image/IImage";
-import * as SIHasAssetPool from "../../../Resources_/adhocracy_core/sheets/asset/IHasAssetPool";
+import * as SIAssetData from "../../../Resources_/adhocracy_core/sheets/asset/IHasAssetPool";
+import * as SIHasAssetPool from "../../../Resources_/adhocracy_core/sheets/asset/IAssetData";
 import * as SIImageMetadata from "../../../Resources_/adhocracy_core/sheets/image/IImageMetadata";
 import * as SIImageReference from "../../../Resources_/adhocracy_core/sheets/image/IImageReference";
 import * as SIVersionable from "../../../Resources_/adhocracy_core/sheets/versions/IVersionable";
@@ -55,7 +56,7 @@ export var uploadImageFactory = (
 
     var formData = new FormData();
     formData.append("content_type", contentType);
-    formData.append("data:adhocracy_core.sheets.asset.IAssetData:data", bytes());
+    formData.append("data:" + SIAssetData.nick + ":data", bytes());
 
     return adhHttp.get(poolPath)
         .then((pool) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtil.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtil.ts
@@ -37,7 +37,7 @@ export var hasEqualContent = (resource1 : ResourcesBase.IResource, resource2 : R
     _.forOwn(resource1.data, (sheet, key) => {
         var sheet2 = resource2.data[key];
 
-        if (key !== "adhocracy_core.sheets.versions.IVersionable") {
+        if (key !== SIVersionable.nick) {
             _.forOwn(sheet, (value, field) => {
                 if (!_.isEqual(value, sheet2[field])) {
                     equal = false;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtil.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtil.ts
@@ -1,6 +1,7 @@
 import * as _ from "lodash";
 
 import * as AdhMetaApi from "../MetaApi/MetaApi";
+import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
 
 import * as ResourcesBase from "../../../ResourcesBase";
 
@@ -12,18 +13,24 @@ import * as AdhUtil from "./Util";
 /**
  * Create a new version following an existing one.
  */
-export var derive = <R extends ResourcesBase.IResource>(oldVersion : R, settings) : R => {
-    var resource = new (<any>oldVersion).constructor(settings);
+export var derive = (
+    oldVersion : ResourcesBase.IResource,
+    settings : {preliminaryNames : AdhPreliminaryNames.Service}
+) : ResourcesBase.IResource => {
+    var resource : ResourcesBase.IResource = {
+        data: {},
+        path: settings.preliminaryNames.nextPreliminary(),
+        content_type: oldVersion.content_type,
+        first_version_path: settings.preliminaryNames.nextPreliminary(),
+    };
 
     _.forOwn(oldVersion.data, (sheet, key) => {
-        resource.data[key] = new sheet.constructor(settings);
-
-        _.forOwn(sheet, (value, field) => {
-            resource.data[key][field] = _.cloneDeep(value);
-        });
+        resource.data[key] = _.cloneDeep(sheet);
     });
 
-    resource.data[SIVersionable.nick] = new SIVersionable.Sheet({follows: [oldVersion.path]});
+    resource.data[SIVersionable.nick] = {
+        follows: [oldVersion.path]
+    };
 
     return resource;
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtilSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtilSpec.ts
@@ -150,8 +150,12 @@ export var register = () => {
 
         describe("isInstanceOf", () => {
             var mockMetaApiData = {};
-            mockMetaApiData[RIProcess.content_type] = RIProcess;
-            mockMetaApiData[RIPool.content_type] = RIPool;
+            mockMetaApiData[RIProcess.content_type] = {
+                super_types: [RIPool.content_type]
+            };
+            mockMetaApiData[RIPool.content_type] = {
+                super_types: []
+            };
 
             var adhMetaApiMock = jasmine.createSpyObj("adhMetaApi", ["resource"]);
             adhMetaApiMock.resource.and.callFake((name) => mockMetaApiData[name]);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtilSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtilSpec.ts
@@ -128,10 +128,15 @@ export var register = () => {
             };
 
             beforeEach(() => {
+                var preliminaryNamesMock = <any>{
+                    nextPreliminary: () => "@0",
+                };
                 oldResource = new testResource({});
                 oldResource.path = "/old/path";
                 oldResource.data["test.sheet"] = new testSheet({});
-                resource = AdhResourceUtil.derive(oldResource, {});
+                resource = AdhResourceUtil.derive(oldResource, {
+                    preliminaryNames: preliminaryNamesMock,
+                });
             });
 
             it("sets the right content type", () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
@@ -34,7 +34,6 @@ export class Resource implements IResource {
     public parent : string;
     public first_version_path : string;
     public root_versions : string[];
-    public static sheets : string[];
 
     constructor(public content_type : string) {
         this.data = {};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/ResourcesBase.ts
@@ -34,7 +34,6 @@ export class Resource implements IResource {
     public parent : string;
     public first_version_path : string;
     public root_versions : string[];
-    public static super_types : string[];
     public static sheets : string[];
 
     constructor(public content_type : string) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -137,7 +137,6 @@ var mkResourceClassName : (resource : string) => string;
 var mkModuleName : (module : string, metaApi : MetaApi.IMetaApi) => string;
 var mkImportStatement : (modulePath : string, relativeRoot : string, metaApi : MetaApi.IMetaApi) => string;
 var mkNick : (modulePath : string, metaApi : MetaApi.IMetaApi) => string;
-var mkSuperTypes : (modulePath : string, metaApi : MetaApi.IMetaApi) => string;
 var mkSheets : (modulePath : string, metaApi : MetaApi.IMetaApi) => string;
 var mkFieldType : (field : MetaApi.ISheetField) => FieldType;
 var mkFlags : (field : MetaApi.ISheetField, comment? : boolean) => string;
@@ -720,7 +719,6 @@ renderResource = (modulePath : string, resource : MetaApi.IResource, modules : M
 
     resourceC += "class " + mkResourceClassName(mkNick(modulePath, metaApi)) + " extends Base.Resource {\n";
     resourceC += "    public static content_type = \"" + modulePath + "\";\n";
-    resourceC += "    public static super_types = " + mkSuperTypes(modulePath, metaApi) + ";\n";
     resourceC += "    public static sheets = " + mkSheets(modulePath, metaApi) + ";\n\n";
     resourceC += mkConstructor("    ") + "\n\n";
     resourceC += mkDataDeclaration("    ") + "\n\n";
@@ -772,11 +770,6 @@ mkNick = (modulePath : string, metaApi : MetaApi.IMetaApi) : string => {
     } else {
         throw "mkNick: " + modulePath;
     }
-};
-
-mkSuperTypes = (modulePath : string, metaApi : MetaApi.IMetaApi) : string => {
-    var superTypes : string[] = metaApi.resources[modulePath].super_types;
-    return JSON.stringify(superTypes);
 };
 
 mkSheets = (modulePath : string, metaApi : MetaApi.IMetaApi) : string => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -137,7 +137,6 @@ var mkResourceClassName : (resource : string) => string;
 var mkModuleName : (module : string, metaApi : MetaApi.IMetaApi) => string;
 var mkImportStatement : (modulePath : string, relativeRoot : string, metaApi : MetaApi.IMetaApi) => string;
 var mkNick : (modulePath : string, metaApi : MetaApi.IMetaApi) => string;
-var mkSheets : (modulePath : string, metaApi : MetaApi.IMetaApi) => string;
 var mkFieldType : (field : MetaApi.ISheetField) => FieldType;
 var mkFlags : (field : MetaApi.ISheetField, comment? : boolean) => string;
 var isReadableField : (field : MetaApi.ISheetField) => boolean;
@@ -718,8 +717,7 @@ renderResource = (modulePath : string, resource : MetaApi.IResource, modules : M
     };
 
     resourceC += "class " + mkResourceClassName(mkNick(modulePath, metaApi)) + " extends Base.Resource {\n";
-    resourceC += "    public static content_type = \"" + modulePath + "\";\n";
-    resourceC += "    public static sheets = " + mkSheets(modulePath, metaApi) + ";\n\n";
+    resourceC += "    public static content_type = \"" + modulePath + "\";\n\n";
     resourceC += mkConstructor("    ") + "\n\n";
     resourceC += mkDataDeclaration("    ") + "\n\n";
     resourceC += mkGettersSetters("    ") + "\n";
@@ -770,11 +768,6 @@ mkNick = (modulePath : string, metaApi : MetaApi.IMetaApi) : string => {
     } else {
         throw "mkNick: " + modulePath;
     }
-};
-
-mkSheets = (modulePath : string, metaApi : MetaApi.IMetaApi) : string => {
-    var sheets : string[] = metaApi.resources[modulePath].sheets;
-    return JSON.stringify(sheets);
 };
 
 mkFieldType = (field : MetaApi.ISheetField) : FieldType => {


### PR DESCRIPTION
After several months I finally got around to work on #2206 again!

The first few commits are just some general refactoring, but the last two commits (		5277b2d and b68d948) are a big step: I implemented the field conversion in `Http/Convert.ts` purely based on the `adhMetaApi` service. This means that there is no longer a reason to wrap incoming resources in generated classes.

We should be **very careful** about merging this. I already found a potential issue in `adhResourceUtils.derive` (fix in f7f544e) and there may well be more.