### PR TITLE
change password security

### DIFF
--- a/src/adhocracy_core/adhocracy_core/authentication/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authentication/test_init.py
@@ -273,16 +273,16 @@ class TestMultiRouteAuthenticationPolicy:
         assert inst.forget(request_) == [('1','1'), ('2', '2')]
 
 
-def test_is_header_password_true_if_password_header(request_):
-    from . import is_header_password
+def test_has_password_header_true_if_password_header(request_):
+    from . import has_password_header
     from . import UserPasswordHeader
     request_.headers[UserPasswordHeader] = 'pwd'
-    assert is_header_password(request_) is True
+    assert has_password_header(request_) is True
 
 
-def test_is_header_password_false_if_no_password_header(request_):
-    from . import is_header_password
-    assert is_header_password(request_) is False
+def test_has_password_header_false_if_no_password_header(request_):
+    from . import has_password_header
+    assert has_password_header(request_) is False
 
 
 def test_get_header_password_true_if_password_header(request_):
@@ -310,7 +310,7 @@ class TestValidatePasswordHeader:
     @fixture
     def mock_header_password(self, mocker):
         return mocker.patch(
-            'adhocracy_core.authentication.is_header_password',
+            'adhocracy_core.authentication.has_password_header',
             return_value=True)
 
     @fixture

--- a/src/adhocracy_core/adhocracy_core/authorization/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/__init__.py
@@ -310,10 +310,7 @@ def is_password_required_to_edit(sheet: ISheet):
 
 def is_password_required_to_edit_some(sheets: [ISheet]):
     """Check if some of the sheets require a password for editing."""
-    for sheet in sheets:
-        if is_password_required_to_edit(sheet):
-            return True
-    return False
+    return any(is_password_required_to_edit(sheet) for sheet in sheets)
 
 
 def includeme(config):

--- a/src/adhocracy_core/adhocracy_core/authorization/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/__init__.py
@@ -18,6 +18,8 @@ from substanced.stats import statsd_timer
 import transaction
 
 from adhocracy_core.authentication import get_anonymized_creator
+from adhocracy_core.interfaces import ISheet
+from adhocracy_core.interfaces import ISheetRequirePassword
 from adhocracy_core.interfaces import IResource
 from adhocracy_core.interfaces import IRoleACLAuthorizationPolicy
 from adhocracy_core.events import LocalRolesModified
@@ -299,6 +301,19 @@ def _remove_local_role_permissions_from_acl(acl: []) -> []:
         if 'group:' not in ace_principal:
             acl_without_local_roles.append(ace)
     return acl_without_local_roles
+
+
+def is_password_required_to_edit(sheet: ISheet):
+    """Check if the sheets requires a password for editing."""
+    return sheet.meta.isheet.isOrExtends(ISheetRequirePassword)
+
+
+def is_password_required_to_edit_some(sheets: [ISheet]):
+    """Check if some of the sheets require a password for editing."""
+    for sheet in sheets:
+        if is_password_required_to_edit(sheet):
+            return True
+    return False
 
 
 def includeme(config):

--- a/src/adhocracy_core/adhocracy_core/authorization/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/test_init.py
@@ -474,9 +474,7 @@ def test_root_acm_extensions_adapter_register(registry, context):
     from . import IRootACMExtension
     root_acm_extension = registry.getAdapter(context, IRootACMExtension)
     assert root_acm_extension == {'principals': [],
-
                                   'permissions': []}
-
 
 class TestIsPasswordRequiredToEdit:
 

--- a/src/adhocracy_core/adhocracy_core/authorization/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/test_init.py
@@ -188,6 +188,7 @@ def test_set_local_roles_update_acl(context, registry, set_acl_with_roles):
                                           [('principal', 'role:admin', 'view')],
                                           registry)
 
+
 def test_set_local_roles_removes_old_role_aces(context, registry,
                                                set_acl_with_roles):
     from . import set_local_roles
@@ -299,7 +300,7 @@ class TestSetACMSForAppRoot:
     @fixture
     def root_acl(self, mocker):
         mock = mocker.patch('adhocracy_core.authorization._get_root_base_acl')
-        mock.return_value =[('Allow', 'role:admin', 'view')]
+        mock.return_value = [('Allow', 'role:admin', 'view')]
         return mock
 
     def test_set_god_permissions(self, mocker, root, event, root_acl):
@@ -475,6 +476,7 @@ def test_root_acm_extensions_adapter_register(registry, context):
     root_acm_extension = registry.getAdapter(context, IRootACMExtension)
     assert root_acm_extension == {'principals': [],
                                   'permissions': []}
+
 
 class TestIsPasswordRequiredToEdit:
 

--- a/src/adhocracy_core/adhocracy_core/authorization/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/authorization/test_init.py
@@ -474,4 +474,37 @@ def test_root_acm_extensions_adapter_register(registry, context):
     from . import IRootACMExtension
     root_acm_extension = registry.getAdapter(context, IRootACMExtension)
     assert root_acm_extension == {'principals': [],
+
                                   'permissions': []}
+
+
+class TestIsPasswordRequiredToEdit:
+
+    def call_fut(self, *args):
+        from . import is_password_required_to_edit
+        return is_password_required_to_edit(*args)
+
+    def test_false_if_no_marker_sheet(self, mock_sheet):
+        assert self.call_fut(mock_sheet) is False
+
+    def test_true_if_marker_sheet(self, mock_sheet):
+        from adhocracy_core.interfaces import ISheetRequirePassword
+        mock_sheet.meta = \
+            mock_sheet.meta._replace(isheet=ISheetRequirePassword)
+        assert self.call_fut(mock_sheet) is True
+
+
+class TestIsPasswordRequiredToEditSome:
+
+    def call_fut(self, *args):
+        from . import is_password_required_to_edit_some
+        return is_password_required_to_edit_some(*args)
+
+    def test_false_if_no_marker_sheets(self, mock_sheet):
+        assert self.call_fut([mock_sheet]) is False
+
+    def test_true_if_markers_sheet(self, mock_sheet):
+        from adhocracy_core.interfaces import ISheetRequirePassword
+        mock_sheet.meta = \
+            mock_sheet.meta._replace(isheet=ISheetRequirePassword)
+        assert self.call_fut([mock_sheet]) is True

--- a/src/adhocracy_core/adhocracy_core/content/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/content/__init__.py
@@ -18,6 +18,7 @@ from adhocracy_core.interfaces import ISheet
 from adhocracy_core.interfaces import IPool
 from adhocracy_core.interfaces import ResourceMetadata
 from adhocracy_core.interfaces import SheetMetadata
+from adhocracy_core.interfaces import ISheetRequirePassword
 from adhocracy_core.interfaces import IResourceSheet
 from adhocracy_core.sheets.anonymize import IAllowAddAnonymized
 from adhocracy_core.sheets.anonymize import ANONYMIZE_PERMISSION
@@ -325,6 +326,14 @@ class ResourceContentRegistry(ContentRegistry):
         """Check if `context` may be deleted anonymously."""
         can_anonymize = _is_anonymized_and_has_permission(context, request)
         return can_anonymize
+
+    def is_password_required(self, context: object, request: Request) -> bool:
+        """Check if some sheets of `context` require a password for editing."""
+        sheets_edit = self.get_sheets_edit(context, request)
+        sheets_require_password = \
+            [s for s in sheets_edit
+             if s.meta.isheet.isOrExtends(ISheetRequirePassword)]
+        return bool(sheets_require_password)
 
 
 def _is_anonymized_and_has_permission(context: object,

--- a/src/adhocracy_core/adhocracy_core/content/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/content/__init__.py
@@ -12,13 +12,13 @@ from substanced.workflow import IWorkflow
 from zope.interface.interfaces import IInterface
 
 from adhocracy_core.authentication import is_created_anonymized
+from adhocracy_core.authorization import is_password_required_to_edit_some
 from adhocracy_core.exceptions import RuntimeConfigurationError
 from adhocracy_core.interfaces import IItem
 from adhocracy_core.interfaces import ISheet
 from adhocracy_core.interfaces import IPool
 from adhocracy_core.interfaces import ResourceMetadata
 from adhocracy_core.interfaces import SheetMetadata
-from adhocracy_core.interfaces import ISheetRequirePassword
 from adhocracy_core.interfaces import IResourceSheet
 from adhocracy_core.sheets.anonymize import IAllowAddAnonymized
 from adhocracy_core.sheets.anonymize import ANONYMIZE_PERMISSION
@@ -330,10 +330,7 @@ class ResourceContentRegistry(ContentRegistry):
     def is_password_required(self, context: object, request: Request) -> bool:
         """Check if some sheets of `context` require a password for editing."""
         sheets_edit = self.get_sheets_edit(context, request)
-        sheets_require_password = \
-            [s for s in sheets_edit
-             if s.meta.isheet.isOrExtends(ISheetRequirePassword)]
-        return bool(sheets_require_password)
+        return is_password_required_to_edit_some(sheets_edit)
 
 
 def _is_anonymized_and_has_permission(context: object,

--- a/src/adhocracy_core/adhocracy_core/content/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/content/test_init.py
@@ -429,6 +429,17 @@ class TestResourceContentRegistry:
         mock_created_anonymized.return_value = True
         assert inst.can_delete_anonymized(context, request_) is True
 
+    def test_password_required_false(self, config, inst, context, request_,
+                                     mock_sheet):
+        assert inst.is_password_required(context, request_) is False
+
+    def test_password_required_true(self, config, inst, context, request_,
+                                     mock_sheet):
+        from adhocracy_core.interfaces import ISheetRequirePassword
+        mock_sheet.meta = \
+            mock_sheet.meta._replace(isheet=ISheetRequirePassword)
+        assert inst.is_password_required(context, request_) is True
+
 
 @fixture
 def integration(config):

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -249,6 +249,13 @@ class IResourceSheet(IPropertySheet):  # pragma: no cover
         """Delete values for every field name in `fields`."""
 
 
+class ISheetRequirePassword(ISheet):
+    """Sheet Interface indicating that a password if required for editing.
+
+    To edit such a Sheet the password needs to be send in the request.
+    """
+
+
 class ResourceMetadata(namedtuple('ResourceMetadata',
                                   ['content_name',
                                    'iresource',

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -250,9 +250,10 @@ class IResourceSheet(IPropertySheet):  # pragma: no cover
 
 
 class ISheetRequirePassword(ISheet):
-    """Sheet Interface indicating that a password if required for editing.
+    """Sheet Interface indicating that a password is required for editing.
 
-    To edit such a Sheet the password needs to be send in the request.
+    To edit such a Sheet the password needs to be send in an additional request
+    header.
     """
 
 

--- a/src/adhocracy_core/adhocracy_core/resources/principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/principal.py
@@ -38,6 +38,7 @@ from adhocracy_core.sheets.metadata import IMetadata
 from adhocracy_core.sheets.metadata import is_older_than
 from adhocracy_core.sheets.principal import IUserBasic
 from adhocracy_core.sheets.principal import IUserExtended
+from adhocracy_core.sheets.principal import IPasswordAuthentication
 import adhocracy_core.sheets.metadata
 import adhocracy_core.sheets.principal
 import adhocracy_core.sheets.pool
@@ -146,6 +147,13 @@ class User(Pool):
         appstruct['hidden'] = not active
         statsd_incr('users.activated', 1)
         sheet.set(appstruct)
+
+    def is_password_valid(self, registry: Registry, password: str):
+        """Validate password against the IPasswordAuthentication sheet."""
+        sheet = registry.content.get_sheet(self, IPasswordAuthentication)
+        valid = sheet.check_plaintext_password(password)
+        return valid
+
 
 user_meta = pool_meta._replace(
     iresource=IUser,

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -200,6 +200,9 @@ class TestUser:
         assert user.tzname == 'UTC'
         assert user.roles == []
         assert user.timezone == timezone(user.tzname)
+        assert user.is_password_valid(registry, '123456') == False
+        assert user.is_password_valid(registry, 'fodThyd2') == True
+
 
 
 class TestSystemUser:

--- a/src/adhocracy_core/adhocracy_core/resources/test_principal.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_principal.py
@@ -204,7 +204,6 @@ class TestUser:
         assert user.is_password_valid(registry, 'fodThyd2') == True
 
 
-
 class TestSystemUser:
 
     @fixture

--- a/src/adhocracy_core/adhocracy_core/rest/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/rest/__init__.py
@@ -2,6 +2,7 @@
 from pyramid.view import view_config
 from adhocracy_core.authentication import validate_user_headers
 from adhocracy_core.authentication import validate_anonymize_header
+from adhocracy_core.authentication import validate_password_header
 from adhocracy_core.caching import set_cache_header
 from adhocracy_core.rest.schemas import validate_request_data
 from adhocracy_core.rest.schemas import validate_visibility
@@ -60,6 +61,7 @@ class api_view(view_config):  # noqa
         settings = {'renderer': 'json',
                     'decorator': [validate_user_headers,
                                   validate_anonymize_header,
+                                  validate_password_header,
                                   validate_visibility,
                                   set_cache_header,
                                   ]

--- a/src/adhocracy_core/adhocracy_core/rest/batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/batchview.py
@@ -10,6 +10,7 @@ from adhocracy_core.rest.exceptions import handle_error_500_exception
 from adhocracy_core.rest.exceptions import JSONHTTPClientError
 from adhocracy_core.rest.exceptions import get_json_body
 from adhocracy_core.authentication import AnonymizeHeader
+from adhocracy_core.authentication import UserPasswordHeader
 from pyramid.request import Request
 from pyramid.interfaces import IRequest
 from pyramid.view import view_defaults
@@ -185,6 +186,7 @@ class BatchView:
         self.copy_header_if_exists('X-User-Path', request)
         self.copy_header_if_exists('X-User-Token', request)
         self.copy_header_if_exists(AnonymizeHeader, request)
+        self.copy_header_if_exists(UserPasswordHeader, request)
 
         # properly setup subrequest in case script_name env is set,
         # see https://github.com/Pylons/pyramid/issues/1434

--- a/src/adhocracy_core/adhocracy_core/rest/schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/schemas.py
@@ -536,8 +536,7 @@ def create_validate_login_password(request: Request,
         user = request.validated.get('user', None)
         if user is None:
             return
-        sheet = registry.content.get_sheet(user, IPasswordAuthentication)
-        valid = sheet.check_plaintext_password(password)
+        valid = user.is_password_valid(registry, password)
         if not valid:
             error = Invalid(node)
             error.add(Invalid(node['password'], msg=error_msg_wrong_login))

--- a/src/adhocracy_core/adhocracy_core/rest/subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/subscriber.py
@@ -2,6 +2,7 @@
 from pyramid.interfaces import IRequest
 from pyramid.events import NewResponse
 from adhocracy_core.authentication import AnonymizeHeader
+from adhocracy_core.authentication import UserPasswordHeader
 
 
 def set_response_headers(event: NewResponse):
@@ -19,7 +20,8 @@ def add_cors_headers(event: NewResponse):
         'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Headers': 'Origin, Content-Type, Accept, '
                                         'X-User-Path, X-User-Token, '
-                                        + AnonymizeHeader,
+                                        + AnonymizeHeader + ', '
+                                        + UserPasswordHeader,
         'Access-Control-Allow-Credentials': 'true',
         'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS',
     })

--- a/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_batchview.py
@@ -102,6 +102,7 @@ class TestBatchView:
             self, context, request_, mock_invoke_subrequest):
         from pyramid.traversal import resource_path
         from adhocracy_core.authentication import AnonymizeHeader
+        from adhocracy_core.authentication import UserPasswordHeader
         from adhocracy_core.utils import is_batchmode
         request_.validated = [self._make_subrequest_cstruct(
             path='http://a.org/virtual/adhocracy/blah')]
@@ -111,6 +112,7 @@ class TestBatchView:
         request_.headers['X-User-Path'] = 2
         request_.headers['X-User-Token'] = 3
         request_.headers[AnonymizeHeader] = ''
+        request_.headers[UserPasswordHeader] = 'pwd'
         # Needed to stop the validator from complaining if these headers are
         # present
         request_.authenticated_userid = resource_path(context)
@@ -129,6 +131,7 @@ class TestBatchView:
         assert subrequest.headers.get('X-User-Path') == 2
         assert subrequest.headers.get('X-User-Token') == 3
         assert subrequest.headers.get(AnonymizeHeader) == ''
+        assert subrequest.headers.get(UserPasswordHeader) == 'pwd'
         assert subrequest.script_name == '/virtual'
         assert subrequest.path_info == '/adhocracy/blah'
 

--- a/src/adhocracy_core/adhocracy_core/rest/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_init.py
@@ -44,6 +44,7 @@ class TestAPIView:
         assert config.settings ==\
                [{'decorator': [authentication.validate_user_headers,
                                authentication.validate_anonymize_header,
+                               authentication.validate_password_header,
                                schemas.validate_visibility,
                                caching.set_cache_header,
                                ],

--- a/src/adhocracy_core/adhocracy_core/rest/test_schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_schemas.py
@@ -1620,24 +1620,25 @@ class TestCreateValidateLoginPassword:
         assert validator(node, {'password': 'secret'}) is None
 
     def test_validate_password(self, node, request_, registry, mock_sheet):
-        user = testing.DummyResource()
+        from adhocracy_core.resources.principal import User
+        user = Mock(spec=User)
+        user.is_password_valid.return_value = True
         request_.validated['user'] = user
-        registry.content.get_sheet.return_value = mock_sheet
         validator = self.call_fut(request_, registry)
-        mock_sheet.check_plaintext_password.return_value = True
         assert validator(node, {'password': 'secret'}) is None
-        mock_sheet.check_plaintext_password.assert_called_with('secret')
+        user.is_password_valid.assert_called_with(registry, 'secret')
 
     def test_raise_if_wrong_password(self, node, request_, registry,
                                      mock_sheet):
-        user = testing.DummyResource()
+        from adhocracy_core.resources.principal import User
+        user = Mock(spec=User)
+        user.is_password_valid.return_value = False
         request_.validated['user'] = user
-        registry.content.get_sheet.return_value = mock_sheet
         validator = self.call_fut(request_, registry)
-        mock_sheet.check_plaintext_password.return_value = False
         node['password'] = node.clone()  # used to raise error
         with raises(colander.Invalid):
             validator(node, {'password': 'secret'})
+        user.is_password_valid.assert_called_with(registry, 'secret')
 
 
 class TestCreateValidateAccountActive:

--- a/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_subscriber.py
@@ -35,6 +35,7 @@ def test_set_response_header_set_cors_header_if_api_request(request_,
 
 def test_add_cors_headers(request_):
     from adhocracy_core.authentication import AnonymizeHeader
+    from adhocracy_core.authentication import UserPasswordHeader
     from .subscriber import add_cors_headers
     response = testing.DummyResource(headers={})
     event = testing.DummyResource(response=response,
@@ -44,7 +45,8 @@ def test_add_cors_headers(request_):
         {'Access-Control-Allow-Origin': '*',
          'Access-Control-Allow-Headers': 'Origin, Content-Type, Accept,'
                                          ' X-User-Path, X-User-Token, '
-                                         + AnonymizeHeader ,
+                                         + AnonymizeHeader + ', '
+                                         + UserPasswordHeader,
          'Access-Control-Allow-Credentials': 'true',
          'Access-Control-Allow-Methods': 'POST,GET,DELETE,PUT,OPTIONS'}
 

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -207,6 +207,20 @@ class TestResourceRESTView:
         assert response['PUT']['request_headers'] == {'X-Anonymize': []}
         assert response['DELETE']['request_headers'] == {'X-Anonymize': []}
 
+    def test_options_with_allow_x_user_password_header(
+            self, request_, context, resource_meta, mock_sheet):
+        from adhocracy_core.interfaces import ISheetRequirePassword
+        content = request_.registry.content
+        mock_sheet.meta = \
+            mock_sheet.meta._replace(isheet=ISheetRequirePassword)
+        content.get_sheets_edit.return_value = [mock_sheet]
+        content.get_resources_meta_addable.return_value = [resource_meta]
+        inst = self.make_one(context, request_)
+        response = inst.options()
+        assert response['POST']['request_headers'] == {}
+        assert response['PUT']['request_headers'] == {'X-User-Password': []}
+        assert response['DELETE']['request_headers'] == {}
+
     def test_add_workflow_permissions_info(
             self, request_, registry, context, mock_sheet, mock_workflow):
         from adhocracy_core.sheets.workflow import IWorkflowAssignment

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -302,6 +302,35 @@ class TestSimpleRESTView:
         data = {'content_type': 'X',
                 'data': {ISheet.__identifier__: {'x': 'y'}}}
         request_.validated = data
+        inst = self.make_one(context, request_)
+
+        response = inst.put()
+        assert mock_sheet.set.call_args[0][0] == {'x': 'y'}
+
+    def test_put_with_sheets_require_password_no_password(
+            self, request_, context, mock_sheet):
+        from adhocracy_core.interfaces import ISheetRequirePassword
+        mock_sheet.meta = \
+            mock_sheet.meta._replace(isheet=ISheetRequirePassword)
+        request_.registry.content.get_sheets_edit.return_value = [mock_sheet]
+        data = {'content_type': 'X',
+                'data': {ISheet.__identifier__: {'x': 'y'}}}
+        request_.validated = data
+
+        inst = self.make_one(context, request_)
+        response = inst.put()
+        assert not mock_sheet.set.called
+
+    def test_put_with_sheets_require_password(
+            self, request_, context, mock_sheet):
+        from adhocracy_core.interfaces import ISheetRequirePassword
+        mock_sheet.meta = \
+            mock_sheet.meta._replace(isheet=ISheetRequirePassword)
+        request_.registry.content.get_sheets_edit.return_value = [mock_sheet]
+        request_.password = '123456'
+        data = {'content_type': 'X',
+                'data': {ISheetRequirePassword.__identifier__: {'x': 'y'}}}
+        request_.validated = data
 
         inst = self.make_one(context, request_)
         response = inst.put()

--- a/src/adhocracy_core/adhocracy_core/sheets/principal.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/principal.py
@@ -13,6 +13,7 @@ from deform.widget import SelectWidget
 import requests
 
 from adhocracy_core.interfaces import ISheet
+from adhocracy_core.interfaces import ISheetRequirePassword
 from substanced.interfaces import IUserLocator
 from adhocracy_core.interfaces import SheetToSheet
 from adhocracy_core.sheets import BaseResourceSheet
@@ -266,7 +267,7 @@ permissions_meta = sheet_meta._replace(
 )
 
 
-class IPasswordAuthentication(ISheet):
+class IPasswordAuthentication(ISheet, ISheetRequirePassword):
     """Marker interface for the password sheet."""
 
 

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -440,6 +440,11 @@ attribute in the json tree.)
 
 PUT responses have the same fields as POST responses.
 
+Note, when putting multiple sheets in a request some changes might be currently
+dropped when the request does not have sufficient permissions, e.g. cannot be
+edit by the user or requires an additional header.
+
+
 ERROR Handling
 ~~~~~~~~~~~~~~
 

--- a/src/adhocracy_core/docs/rest_api.rst
+++ b/src/adhocracy_core/docs/rest_api.rst
@@ -440,9 +440,12 @@ attribute in the json tree.)
 
 PUT responses have the same fields as POST responses.
 
-Note, when putting multiple sheets in a request some changes might be currently
-dropped when the request does not have sufficient permissions, e.g. cannot be
-edit by the user or requires an additional header.
+.. note::
+
+   When putting multiple sheets in a request some changes might be
+   currently dropped when the request does not have sufficient
+   permissions, e.g. cannot be edit by the user or requires an
+   additional header.
 
 
 ERROR Handling

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_de.json
@@ -147,6 +147,7 @@
     "TR__PARAGRAPH_PLACEHOLDER": "Hier Text eingeben.",
     "TR__PARTICIPATION_DATES": "Beteiligung von {{ startDate | date }} bis {{ endDate | date }}",
     "TR__PASSWORD": "Passwort",
+    "TR__PASSWORD_OLD": "Altes Passwort",
     "TR__PASSWORD_REPEAT": "Passwort Wiederholung",
     "TR__PASSWORD_RESET_CLOSE_THIS_TAB_AND_PROCEED": "Dein Passwort wurde erfolgreich gesetzt. Du kannst diese Seite schließen und zurück gehen zu {{siteName}}.",
     "TR__PASSWORD_RESET_TITLE": "Neues Passwort setzen",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/i18n/core_en.json
@@ -147,6 +147,7 @@
     "TR__PARAGRAPH_PLACEHOLDER": "Add text here.",
     "TR__PARTICIPATION_DATES": "Participation is possible from {{ startDate | date }} until {{ endDate | date }}",
     "TR__PASSWORD": "password",
+    "TR__PASSWORD_OLD": "old password",
     "TR__PASSWORD_REPEAT": "password repeat",
     "TR__PASSWORD_RESET_CLOSE_THIS_TAB_AND_PROCEED": "Your password has been successfully set. You can now close this tab and go back to {{siteName}}.",
     "TR__PASSWORD_RESET_TITLE": "Set new password",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Http.ts
@@ -33,6 +33,7 @@ export interface IHttpConfig {
     noCredentials? : boolean;
     noExport? : boolean;
     anonymize? : boolean;
+    password? : string;
 }
 
 export interface IHttpOptionsConfig extends IHttpConfig {
@@ -133,6 +134,11 @@ export class Service {
             _.assign(headers, {
                 // the header is non-empty so it doesn't get deleted by browsers
                 "X-Anonymize": "X-Anonymize"
+            });
+        }
+        if (config.password) {
+            _.assign(headers, {
+                "X-User-Password": config.password
             });
         }
         return headers;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Edit.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Edit.html
@@ -47,6 +47,17 @@
             {{ "TR__ERROR_MATCH_PASSWORD" | translate }}
         </span>
     </label>
+    <label>
+        <span class="label-text">{{ "TR__PASSWORD_OLD" | translate }}</span>
+        <input
+            type="password"
+            name="password_old"
+            data-ng-required="data.password"
+            data-ng-model="data.passwordOld" />
+        <span class="input-error" data-ng-show="showError(userEditForm, userEditForm.password_old, 'required')">
+            {{ "TR__ERROR_REQUIRED_PASSWORD" | translate }}
+        </span>
+    </label>
     <label data-ng-if="config.anonymize_enabled">
         <input
             type="checkbox"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Edit.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Edit.html
@@ -33,9 +33,6 @@
             data-ng-model="data.password"
             data-ng-minlength="6"
             data-ng-maxlength="100" />
-        <span class="input-error" data-ng-show="showError(userEditForm, userEditForm.password, 'required')">
-            {{ "TR__ERROR_REQUIRED_PASSWORD" | translate }}
-        </span>
         <span class="input-error" data-ng-show="showError(userEditForm, userEditForm.password, 'minlength')">
             {{ "TR__ERROR_TOO_SHORT_PASSWORD" | translate }}
         </span>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
@@ -735,6 +735,7 @@ var postEdit = (
         name : string;
         password? : string;
         anonymize? : boolean;
+        passwordOld? : string;
     }
 ) => {
     return adhHttp.get(path).then((oldUser) => {
@@ -755,7 +756,9 @@ var postEdit = (
         patch.data[SIAnonymizeDefault.nick] = new SIAnonymizeDefault.Sheet({
             anonymize: data.anonymize,
         });
-        return adhHttp.put(oldUser.path, patch);
+        return adhHttp.put(oldUser.path, patch, {
+            password: data.passwordOld
+        });
     });
 };
 

--- a/src/meinberlin/meinberlin/static/i18n/core_de.json
+++ b/src/meinberlin/meinberlin/static/i18n/core_de.json
@@ -147,6 +147,7 @@
     "TR__PARAGRAPH_PLACEHOLDER": "Hier Text eingeben.",
     "TR__PARTICIPATION_DATES": "Beteiligung von {{ startDate | date }} bis {{ endDate | date }}",
     "TR__PASSWORD": "Passwort",
+    "TR__PASSWORD_OLD": "Altes Passwort",
     "TR__PASSWORD_REPEAT": "Passwort Wiederholung",
     "TR__PASSWORD_RESET_CLOSE_THIS_TAB_AND_PROCEED": "Ihr Passwort wurde erfolgreich gesetzt. Sie können diese Seite schließen und zurück gehen zu {{siteName}}.",
     "TR__PASSWORD_RESET_TITLE": "Neues Passwort setzen",


### PR DESCRIPTION
We decided that users should be required to enter their password in order to change it. This improves security in cases where the attacker gains access to a user's session, but not their password.

- [X] frontend
- [x] backend