### PR TITLE
plain resources

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
@@ -33,7 +33,7 @@ export interface IBadgeAssignment {
 }
 
 export interface IGetBadgeAssignments {
-    (resource : SIBadgeable.HasSheet) : angular.IPromise<IBadgeAssignment[]>;
+    (resource : ResourcesBase.IResource) : angular.IPromise<IBadgeAssignment[]>;
 }
 
 export interface IBadge {
@@ -129,7 +129,7 @@ export var getBadgesFactory = (
     adhHttp : AdhHttp.Service,
     $q : angular.IQService
 ) : IGetBadgeAssignments => (
-    resource : SIBadgeable.HasSheet,
+    resource : ResourcesBase.IResource,
     includeParent? : boolean
 ) : angular.IPromise<IBadgeAssignment[]> => {
     if (typeof includeParent === "undefined") {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
@@ -262,11 +262,11 @@ export var badgeAssignment = (
                                         content_type: RIBadgeAssignment.content_type,
                                         data: {},
                                     };
-                                    assignment.data[SIBadgeAssignment.nick] = {
+                                    SIBadgeAssignment.set(assignment, {
                                         badge: badgePath,
                                         object: scope.badgeablePath,
                                         subject: adhCredentials.userPath
-                                    };
+                                    });
                                     transaction.post(scope.poolPath, assignment);
                                 } else if (!checked && assignmentExisted) {
                                     transaction.delete(scope.assignments[badgePath].path);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
@@ -257,7 +257,11 @@ export var badgeAssignment = (
                             _.forOwn(scope.checkboxes, (checked, badgePath) => {
                                 var assignmentExisted = scope.assignments.hasOwnProperty(badgePath);
                                 if (checked && !assignmentExisted) {
-                                    var assignment = new RIBadgeAssignment({ preliminaryNames : adhPreliminaryNames });
+                                    var assignment : ResourcesBase.IResource = {
+                                        path: adhPreliminaryNames.nextPreliminary(),
+                                        content_type: RIBadgeAssignment.content_type,
+                                        data: {},
+                                    };
                                     assignment.data[SIBadgeAssignment.nick] = {
                                         badge: badgePath,
                                         object: scope.badgeablePath,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
@@ -11,6 +11,8 @@ import * as AdhPermissions from "../Permissions/Permissions";
 import * as AdhPreliminaryNames from "../PreliminaryNames/PreliminaryNames";
 import * as AdhUtil from "../Util/Util";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RIBadgeAssignment from "../../../Resources_/adhocracy_core/resources/badge/IBadgeAssignment";
 import * as SIBadge from "../../../Resources_/adhocracy_core/sheets/badge/IBadge";
 import * as SIBadgeable from "../../../Resources_/adhocracy_core/sheets/badge/IBadgeable";
@@ -137,7 +139,7 @@ export var getBadgesFactory = (
     var assignmentPaths = resource.data[SIBadgeable.nick].assignments;
 
     var getBadge = (assignmentPath : string) => {
-        return adhHttp.get(assignmentPath).then((assignment : RIBadgeAssignment) => {
+        return adhHttp.get(assignmentPath).then((assignment : ResourcesBase.IResource) => {
             var badgePath = assignment.data[SIBadgeAssignment.nick].badge;
             return adhHttp.get(badgePath).then((badge) => {
                 return {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Badge.ts
@@ -51,17 +51,17 @@ export interface IBadgeGroup {
 
 var extractBadge = (badge) : IBadge => {
     return {
-        name: badge.data[SIName.nick].name,
-        title: badge.data[SITitle.nick].title,
+        name: SIName.get(badge).name,
+        title: SITitle.get(badge).title,
         path: badge.path,
-        groups: badge.data[SIBadge.nick].groups
+        groups: SIBadge.get(badge).groups
     };
 };
 
 var extractGroup = (group) : IBadgeGroup => {
     return {
-        name: group.data[SIName.nick].name,
-        title: group.data[SITitle.nick].title,
+        name: SIName.get(group).name,
+        title: SITitle.get(group).title,
         path: group.path
     };
 };
@@ -115,7 +115,7 @@ export var getBadgeFacets = (
     };
 
     return adhHttp.get(path, params).then((response) => {
-        var badgePaths = <string[]>_.map(response.data[SIPool.nick].elements, "path");
+        var badgePaths = <string[]>_.map(SIPool.get(response).elements, "path");
         return httpMap(badgePaths, extractBadge).then((badges) => {
             var groupPaths = _.union.apply(_, _.map(badges, "groups"));
             return httpMap(groupPaths, extractGroup).then((badgeGroups) => {
@@ -136,16 +136,16 @@ export var getBadgesFactory = (
         includeParent = !!resource.content_type.match(/Version$/);
     }
 
-    var assignmentPaths = resource.data[SIBadgeable.nick].assignments;
+    var assignmentPaths = SIBadgeable.get(resource).assignments;
 
     var getBadge = (assignmentPath : string) => {
         return adhHttp.get(assignmentPath).then((assignment : ResourcesBase.IResource) => {
-            var badgePath = assignment.data[SIBadgeAssignment.nick].badge;
+            var badgePath = SIBadgeAssignment.get(assignment).badge;
             return adhHttp.get(badgePath).then((badge) => {
                 return {
-                    title: badge.data[SITitle.nick].title,
-                    name: badge.data[SIName.nick].name,
-                    description: assignment.data[SIDescription.nick].description,
+                    title: SITitle.get(badge).title,
+                    name: SIName.get(badge).name,
+                    description: SIDescription.get(assignment).description,
                     path: assignmentPath,
                     badgePath: badgePath
                 };
@@ -157,7 +157,7 @@ export var getBadgesFactory = (
         var parentPath = AdhUtil.parentPath(resource.path);
 
         return adhHttp.get(parentPath).then((parentResource) => {
-            var parentAssignments = parentResource.data[SIBadgeable.nick].assignments;
+            var parentAssignments = SIBadgeable.get(parentResource).assignments;
             assignmentPaths = assignmentPaths.concat(parentAssignments);
             return $q.all(_.map(assignmentPaths, getBadge));
         });
@@ -236,14 +236,14 @@ export var badgeAssignment = (
             scope.data = {};
 
             adhHttp.get(scope.path).then((proposal) => {
-                scope.poolPath = proposal.data[SIBadgeable.nick].post_pool;
+                scope.poolPath = SIBadgeable.get(proposal).post_pool;
 
                 return adhGetBadges(proposal).then((assignments : IBadgeAssignment[]) => {
 
                     bindPath(adhHttp, adhPermissions, $q)(scope);
 
                     adhHttp.get(scope.badgeablePath).then((proposal) => {
-                        scope.poolPath = proposal.data[SIBadgeable.nick].post_pool;
+                        scope.poolPath = SIBadgeable.get(proposal).post_pool;
 
                         scope.assignments = _.keyBy(assignments, "badgePath");
                         // The following object only contains the current assignments. In order to render the badge

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Comment/Comment.ts
@@ -10,6 +10,8 @@ import * as AdhResourceUtil from "../Util/ResourceUtil";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 import * as AdhUtil from "../Util/Util";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RIComment from "../../../Resources_/adhocracy_core/resources/comment/IComment";
 import RICommentVersion from "../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
 import RIExternalResource from "../../../Resources_/adhocracy_core/resources/external_resource/IExternalResource";
@@ -17,6 +19,7 @@ import RISystemUser from "../../../Resources_/adhocracy_core/resources/principal
 import * as SICommentable from "../../../Resources_/adhocracy_core/sheets/comment/ICommentable";
 import * as SIComment from "../../../Resources_/adhocracy_core/sheets/comment/IComment";
 import * as SIMetadata from "../../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
+import * as SIName from "../../../Resources_/adhocracy_core/sheets/name/IName";
 import * as SIPool from "../../../Resources_/adhocracy_core/sheets/pool/IPool";
 import * as SIVersionable from "../../../Resources_/adhocracy_core/sheets/versions/IVersionable";
 
@@ -133,14 +136,18 @@ export var postCreate = (
     scope : ICommentResourceScope,
     poolPath : string
 ) => {
-    var item = new RIComment({
-        preliminaryNames: adhPreliminaryNames
-    });
+    var item : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIComment.content_type,
+        data: {},
+    };
     item.parent = poolPath;
 
-    var version = new RICommentVersion({
-        preliminaryNames: adhPreliminaryNames
-    });
+    var version : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RICommentVersion.content_type,
+        data: {},
+    };
     version.data[SIComment.nick] = new SIComment.Sheet({
         content: scope.data.content,
         refers_to: scope.refersTo
@@ -428,7 +435,14 @@ export var adhCreateOrShowCommentListing = (
                     } else {
                         var unwatch = scope.$watch(() => adhCredentials.loggedIn, (loggedIn) => {
                             if (loggedIn) {
-                                var externalResource = new RIExternalResource({preliminaryNames: adhPreliminaryNames, name: scope.key});
+                                var externalResource = {
+                                    path: adhPreliminaryNames.nextPreliminary(),
+                                    content_type: RIExternalResource.content_type,
+                                    data: {},
+                                };
+                                externalResource.data[SIName.nick] = new SIName.Sheet({
+                                    name: scope.key,
+                                });
                                 return adhHttp.post(scope.poolPath, externalResource).then((obj) => {
                                     if (obj.path !== commentablePath) {
                                         console.log("Created object has wrong path (internal error)");

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Comment/Comment.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Comment/Comment.ts
@@ -148,11 +148,11 @@ export var postCreate = (
         content_type: RICommentVersion.content_type,
         data: {},
     };
-    version.data[SIComment.nick] = new SIComment.Sheet({
+    SIComment.set(version, {
         content: scope.data.content,
         refers_to: scope.refersTo
     });
-    version.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(version, {
         follows: [item.first_version_path]
     });
     version.parent = item.path;
@@ -440,7 +440,7 @@ export var adhCreateOrShowCommentListing = (
                                     content_type: RIExternalResource.content_type,
                                     data: {},
                                 };
-                                externalResource.data[SIName.nick] = new SIName.Sheet({
+                                SIName.set(externalResource, {
                                     name: scope.key,
                                 });
                                 return adhHttp.post(scope.poolPath, externalResource).then((obj) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/DebateWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/DebateWorkbench.ts
@@ -178,7 +178,7 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide"
         })
         .specificVersionable(RIDocument, RIDocumentVersion, "", processType.content_type, context, [
-            () => (item : RIDocument, version : RIDocumentVersion) => {
+            () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return {
                     documentUrl: version.path
                 };
@@ -188,7 +188,7 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide"
         })
         .specificVersionable(RIDocument, RIDocumentVersion, "edit", processType.content_type, context, [
-            "adhHttp", (adhHttp : AdhHttp.Service) => (item : RIDocument, version : RIDocumentVersion) => {
+            "adhHttp", (adhHttp : AdhHttp.Service) => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
                     if (!options.POST) {
                         throw 401;
@@ -204,7 +204,7 @@ export var registerRoutes = (
             movingColumns: "is-collapse-show-show"
         })
         .specificVersionable(RIParagraph, RIParagraphVersion, "comments", processType.content_type, context, [
-            () => (item : RIParagraph, version : RIParagraphVersion) => {
+            () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 var documentUrl = _.last(_.sortBy(version.data[SIParagraph.nick].documents));
                 return {
                     commentableUrl: version.path,
@@ -229,7 +229,7 @@ export var registerRoutes = (
                 }
             };
 
-            return (item : RIComment, version : RICommentVersion) => {
+            return (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return getCommentableUrl(version).then((commentable) => {
                     var documentUrl = _.last(_.sortBy(commentable.data[SIParagraph.nick].documents));
                     return {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/DebateWorkbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/DebateWorkbench.ts
@@ -101,12 +101,12 @@ export var processDetailColumnDirective = (
             scope.$watch("processUrl", (value : string) => {
                 if (value) {
                     adhHttp.get(value).then((resource) => {
-                        var workflow = resource.data[SIWorkflow.nick];
-                        scope.data.picture = (resource.data[SIImageReference.nick] || {}).picture;
-                        scope.data.title = resource.data[SITitle.nick].title;
+                        var workflow = SIWorkflow.get(resource);
+                        scope.data.picture = (SIImageReference.get(resource) || {}).picture;
+                        scope.data.title = SITitle.get(resource).title;
                         scope.data.participationStartDate = AdhProcess.getStateData(workflow, "participate").start_date;
                         scope.data.participationEndDate = AdhProcess.getStateData(workflow, "evaluate").start_date;
-                        scope.data.shortDescription = resource.data[SIDescription.nick].short_description;
+                        scope.data.shortDescription = SIDescription.get(resource).short_description;
                     });
                 }
             });
@@ -205,7 +205,7 @@ export var registerRoutes = (
         })
         .specificVersionable(RIParagraph, RIParagraphVersion, "comments", processType.content_type, context, [
             () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
-                var documentUrl = _.last(_.sortBy(version.data[SIParagraph.nick].documents));
+                var documentUrl = _.last(_.sortBy(SIParagraph.get(version).documents));
                 return {
                     commentableUrl: version.path,
                     commentCloseUrl: documentUrl,
@@ -224,14 +224,14 @@ export var registerRoutes = (
                 if (resource.content_type !== RICommentVersion.content_type) {
                     return $q.when(resource);
                 } else {
-                    var url = resource.data[SIComment.nick].refers_to;
+                    var url = SIComment.get(resource).refers_to;
                     return adhHttp.get(url).then(getCommentableUrl);
                 }
             };
 
             return (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return getCommentableUrl(version).then((commentable) => {
-                    var documentUrl = _.last(_.sortBy(commentable.data[SIParagraph.nick].documents));
+                    var documentUrl = _.last(_.sortBy(SIParagraph.get(commentable).documents));
                     return {
                         commentableUrl: commentable.path,
                         commentCloseUrl: documentUrl,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
@@ -108,7 +108,7 @@ export var bindPath = (
     return scope.$watch(pathKey, (path : string) => {
         if (path) {
             adhHttp.get(path).then((documentVersion : ResourcesBase.IResource) => {
-                var paragraphPaths : string[] = documentVersion.data[SIDocument.nick].elements;
+                var paragraphPaths : string[] = SIDocument.get(documentVersion).elements;
                 var paragraphPromises = _.map(paragraphPaths, (path) => {
                     return adhHttp.get(path);
                 });
@@ -116,9 +116,9 @@ export var bindPath = (
                 return $q.all(paragraphPromises).then((paragraphVersions : ResourcesBase.IResource[]) => {
                     var paragraphs = _.map(paragraphVersions, (paragraphVersion) => {
                         return {
-                            body: paragraphVersion.data[SIParagraph.nick].text,
+                            body: SIParagraph.get(paragraphVersion).text,
                             deleted: false,
-                            commentCount: parseInt(paragraphVersion.data[SICommentable.nick].comments_count, 10),
+                            commentCount: parseInt(SICommentable.get(paragraphVersion).comments_count, 10),
                             path: paragraphVersion.path
                         };
                     });
@@ -127,18 +127,18 @@ export var bindPath = (
                     scope.paragraphVersions = paragraphVersions;
 
                     scope.data = {
-                        title: documentVersion.data[SITitle.nick].title,
+                        title: SITitle.get(documentVersion).title,
                         paragraphs: paragraphs,
                         // FIXME: DefinitelyTyped
                         commentCountTotal: (<any>_).sumBy(paragraphs, "commentCount"),
-                        modificationDate: documentVersion.data[SIMetadata.nick].modification_date,
-                        creationDate: documentVersion.data[SIMetadata.nick].creation_date,
-                        creator: documentVersion.data[SIMetadata.nick].creator,
-                        picture: documentVersion.data[SIImageReference.nick].picture
+                        modificationDate: SIMetadata.get(documentVersion).modification_date,
+                        creationDate: SIMetadata.get(documentVersion).creation_date,
+                        creator: SIMetadata.get(documentVersion).creator,
+                        picture: SIImageReference.get(documentVersion).picture
                     };
 
                     if (hasMap) {
-                        scope.data.coordinates = documentVersion.data[SIPoint.nick].coordinates;
+                        scope.data.coordinates = SIPoint.get(documentVersion).coordinates;
                     }
 
                     if (hasBadges) {
@@ -308,7 +308,7 @@ export var postEdit = (
             } else {
                 var oldParagraphVersion = oldParagraphVersions[index];
 
-                if (paragraph.body !== oldParagraphVersion.data[SIParagraph.nick].text) {
+                if (paragraph.body !== SIParagraph.get(oldParagraphVersion).text) {
                     paragraphVersion = {
                         path: adhPreliminaryNames.nextPreliminary(),
                         parent: AdhUtil.parentPath(oldParagraphVersion.path),
@@ -353,7 +353,7 @@ export var postEdit = (
         });
     }
     // FIXME: workaround for a backend bug
-    var oldImageReferenceSheet = oldVersion.data[SIImageReference.nick];
+    var oldImageReferenceSheet = SIImageReference.get(oldVersion);
     if (oldImageReferenceSheet.picture) {
         SIImageReference.set(documentVersion, oldImageReferenceSheet);
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
@@ -170,18 +170,31 @@ export var postCreate = (
     const documentClass = hasMap ? RIGeoDocument : RIDocument;
     const documentVersionClass = hasMap ? RIGeoDocumentVersion : RIDocumentVersion;
 
-    var doc = new documentClass({preliminaryNames: adhPreliminaryNames});
-    doc.parent = poolPath;
+    var doc : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        first_version_path: adhPreliminaryNames.nextPreliminary(),
+        parent: poolPath,
+        content_type: documentClass.content_type,
+        data: {},
+    };
 
     var paragraphItems = [];
     var paragraphVersions = [];
 
     _.forEach(scope.data.paragraphs, (paragraph) => {
         if (!paragraph.deleted) {
-            var item = new RIParagraph({preliminaryNames: adhPreliminaryNames});
+            var item : ResourcesBase.IResource = {
+                path: adhPreliminaryNames.nextPreliminary(),
+                content_type: RIParagraph.content_type,
+                data: {},
+            };
             item.parent = doc.path;
 
-            var version = new RIParagraphVersion({preliminaryNames: adhPreliminaryNames});
+            var version : ResourcesBase.IResource = {
+                path: adhPreliminaryNames.nextPreliminary(),
+                content_type: RIParagraphVersion.content_type,
+                data: {},
+            };
             version.parent = item.path;
             version.data[SIVersionable.nick] = new SIVersionable.Sheet({
                 follows: [item.first_version_path]
@@ -195,8 +208,12 @@ export var postCreate = (
         }
     });
 
-    var documentVersion = new documentVersionClass({preliminaryNames: adhPreliminaryNames});
-    documentVersion.parent = doc.path;
+    var documentVersion : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        parent: doc.path,
+        content_type: documentVersionClass.content_type,
+        data: {},
+    };
     documentVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
         follows: [doc.first_version_path]
     });
@@ -263,11 +280,19 @@ export var postEdit = (
         if (!paragraph.deleted) {
 
             if (index >= oldParagraphVersions.length) {
-                var item = new RIParagraph({preliminaryNames: adhPreliminaryNames});
-                item.parent = documentPath;
+                var item : ResourcesBase.IResource = {
+                    path: adhPreliminaryNames.nextPreliminary(),
+                    parent: documentPath,
+                    content_type: RIParagraph.content_type,
+                    data: {},
+                };
 
-                paragraphVersion = new RIParagraphVersion({preliminaryNames: adhPreliminaryNames});
-                paragraphVersion.parent = item.path;
+                paragraphVersion = {
+                    path: adhPreliminaryNames.nextPreliminary(),
+                    parent: item.path,
+                    content_type: RIParagraphVersion.content_type,
+                    data: {},
+                };
                 paragraphVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
                     follows: [item.first_version_path]
                 });
@@ -284,15 +309,19 @@ export var postEdit = (
                 var oldParagraphVersion = oldParagraphVersions[index];
 
                 if (paragraph.body !== oldParagraphVersion.data[SIParagraph.nick].text) {
-                    paragraphVersion = new RIParagraphVersion({preliminaryNames: adhPreliminaryNames});
-                    paragraphVersion.parent = AdhUtil.parentPath(oldParagraphVersion.path);
+                    paragraphVersion = {
+                        path: adhPreliminaryNames.nextPreliminary(),
+                        parent: AdhUtil.parentPath(oldParagraphVersion.path),
+                        root_versions: [oldVersion.path],
+                        content_type: RIParagraphVersion.content_type,
+                        data: {},
+                    };
                     paragraphVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
                         follows: [oldParagraphVersion.path]
                     });
                     paragraphVersion.data[SIParagraph.nick] = new SIParagraph.Sheet({
                         text: paragraph.body
                     });
-                    paragraphVersion.root_versions = [oldVersion.path];
 
                     paragraphVersions.push(paragraphVersion);
                     paragraphRefs.push(paragraphVersion.path);
@@ -303,8 +332,12 @@ export var postEdit = (
         }
     });
 
-    var documentVersion = new documentVersionClass({preliminaryNames: adhPreliminaryNames});
-    documentVersion.parent = documentPath;
+    var documentVersion = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        parent: documentPath,
+        content_type: documentVersionClass.content_type,
+        data: {},
+    };
     documentVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
         follows: [oldVersion.path]
     });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
@@ -196,10 +196,10 @@ export var postCreate = (
                 data: {},
             };
             version.parent = item.path;
-            version.data[SIVersionable.nick] = new SIVersionable.Sheet({
+            SIVersionable.set(version, {
                 follows: [item.first_version_path]
             });
-            version.data[SIParagraph.nick] = new SIParagraph.Sheet({
+            SIParagraph.set(version, {
                 text: paragraph.body
             });
 
@@ -214,17 +214,17 @@ export var postCreate = (
         content_type: documentVersionClass.content_type,
         data: {},
     };
-    documentVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(documentVersion, {
         follows: [doc.first_version_path]
     });
-    documentVersion.data[SIDocument.nick] = new SIDocument.Sheet({
+    SIDocument.set(documentVersion, {
         elements: <string[]>_.map(paragraphVersions, "path")
     });
-    documentVersion.data[SITitle.nick] = new SITitle.Sheet({
+    SITitle.set(documentVersion, {
         title: scope.data.title
     });
     if (hasMap && scope.data.coordinates && scope.data.coordinates[0] && scope.data.coordinates[1]) {
-        documentVersion.data[SIPoint.nick] = new SIPoint.Sheet({
+        SIPoint.set(documentVersion, {
             coordinates: scope.data.coordinates
         });
     }
@@ -236,7 +236,7 @@ export var postCreate = (
 
     if (scope.$flow && scope.$flow.support && scope.$flow.files.length > 0) {
         return adhUploadImage(poolPath, scope.$flow).then((imagePath : string) => {
-            documentVersion.data[SIImageReference.nick] = new SIImageReference.Sheet({
+            SIImageReference.set(documentVersion, {
                 picture: imagePath
             });
             return commit();
@@ -293,10 +293,10 @@ export var postEdit = (
                     content_type: RIParagraphVersion.content_type,
                     data: {},
                 };
-                paragraphVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+                SIVersionable.set(paragraphVersion, {
                     follows: [item.first_version_path]
                 });
-                paragraphVersion.data[SIParagraph.nick] = new SIParagraph.Sheet({
+                SIParagraph.set(paragraphVersion, {
                     text: paragraph.body
                 });
                 paragraphVersion.root_versions = [oldVersion.path];
@@ -316,10 +316,10 @@ export var postEdit = (
                         content_type: RIParagraphVersion.content_type,
                         data: {},
                     };
-                    paragraphVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+                    SIVersionable.set(paragraphVersion, {
                         follows: [oldParagraphVersion.path]
                     });
-                    paragraphVersion.data[SIParagraph.nick] = new SIParagraph.Sheet({
+                    SIParagraph.set(paragraphVersion, {
                         text: paragraph.body
                     });
 
@@ -338,24 +338,24 @@ export var postEdit = (
         content_type: documentVersionClass.content_type,
         data: {},
     };
-    documentVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(documentVersion, {
         follows: [oldVersion.path]
     });
-    documentVersion.data[SIDocument.nick] = new SIDocument.Sheet({
+    SIDocument.set(documentVersion, {
         elements: paragraphRefs
     });
-    documentVersion.data[SITitle.nick] = new SITitle.Sheet({
+    SITitle.set(documentVersion, {
         title: scope.data.title
     });
     if (hasMap && scope.data.coordinates && scope.data.coordinates[0] && scope.data.coordinates[1]) {
-        documentVersion.data[SIPoint.nick] = new SIPoint.Sheet({
+        SIPoint.set(documentVersion, {
             coordinates: scope.data.coordinates
         });
     }
     // FIXME: workaround for a backend bug
     var oldImageReferenceSheet = oldVersion.data[SIImageReference.nick];
     if (oldImageReferenceSheet.picture) {
-        documentVersion.data[SIImageReference.nick] = oldImageReferenceSheet;
+        SIImageReference.set(documentVersion, oldImageReferenceSheet);
     }
 
     var commit = () => {
@@ -365,7 +365,7 @@ export var postEdit = (
 
     if (scope.$flow && scope.$flow.support && scope.$flow.files.length > 0) {
         return adhUploadImage(poolPath, scope.$flow).then((imagePath : string) => {
-            documentVersion.data[SIImageReference.nick] = new SIImageReference.Sheet({
+            SIImageReference.set(documentVersion, {
                 picture: imagePath
             });
             return commit();

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
@@ -118,7 +118,7 @@ export var bindPath = (
                         return {
                             body: SIParagraph.get(paragraphVersion).text,
                             deleted: false,
-                            commentCount: parseInt(SICommentable.get(paragraphVersion).comments_count, 10),
+                            commentCount: SICommentable.get(paragraphVersion).comments_count,
                             path: paragraphVersion.path
                         };
                     });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Document.ts
@@ -60,8 +60,8 @@ export interface IScope extends angular.IScope {
     toggleCreateForm() : void;
     showCreateForm? : boolean;
 
-    documentVersion? : RIDocumentVersion;
-    paragraphVersions? : RIParagraphVersion[];
+    documentVersion? : ResourcesBase.IResource;
+    paragraphVersions? : ResourcesBase.IResource[];
 
     commentType? : string;
 }
@@ -107,13 +107,13 @@ export var bindPath = (
 ) : Function => {
     return scope.$watch(pathKey, (path : string) => {
         if (path) {
-            adhHttp.get(path).then((documentVersion : RIDocumentVersion) => {
+            adhHttp.get(path).then((documentVersion : ResourcesBase.IResource) => {
                 var paragraphPaths : string[] = documentVersion.data[SIDocument.nick].elements;
                 var paragraphPromises = _.map(paragraphPaths, (path) => {
                     return adhHttp.get(path);
                 });
 
-                return $q.all(paragraphPromises).then((paragraphVersions : RIParagraphVersion[]) => {
+                return $q.all(paragraphPromises).then((paragraphVersions : ResourcesBase.IResource[]) => {
                     var paragraphs = _.map(paragraphVersions, (paragraphVersion) => {
                         return {
                             body: paragraphVersion.data[SIParagraph.nick].text,
@@ -142,7 +142,7 @@ export var bindPath = (
                     }
 
                     if (hasBadges) {
-                        adhGetBadges(documentVersion).then((assignments) => {
+                        adhGetBadges(<RIDocumentVersion>documentVersion).then((assignments) => {
                             scope.data.assignments = assignments;
                         });
                     }
@@ -235,8 +235,8 @@ export var postEdit = (
     adhUploadImage
 ) => (
     scope : IFormScope,
-    oldVersion : RIDocumentVersion,
-    oldParagraphVersions : RIParagraphVersion[],
+    oldVersion : ResourcesBase.IResource,
+    oldParagraphVersions : ResourcesBase.IResource[],
     hasMap : boolean = false
 ) : angular.IPromise<RIDocumentVersion> => {
     // This function assumes the following:
@@ -252,11 +252,11 @@ export var postEdit = (
 
     const documentVersionClass = hasMap ? RIGeoDocumentVersion : RIDocumentVersion;
 
-    var paragraphItems : RIParagraph[] = [];
-    var paragraphVersions : RIParagraphVersion[] = [];
+    var paragraphItems : ResourcesBase.IResource[] = [];
+    var paragraphVersions : ResourcesBase.IResource[] = [];
     var paragraphRefs : string[] = [];
 
-    var paragraphVersion : RIParagraphVersion;
+    var paragraphVersion : ResourcesBase.IResource;
 
     _.forEach(scope.data.paragraphs, (paragraph : IParagraph, index : number) => {
         // currently, if a paragraph has been deleted, it doesn't get posted at all.
@@ -501,7 +501,7 @@ export var createDirective = (
             scope.submit = () => {
                 return adhSubmitIfValid(scope, element, scope.documentForm, () => {
                     return postCreate(adhHttp, adhPreliminaryNames, adhUploadImage)(scope, scope.path, scope.hasMap);
-                }).then((documentVersion : RIDocumentVersion) => {
+                }).then((documentVersion : ResourcesBase.IResource) => {
                     var itemPath = AdhUtil.parentPath(documentVersion.path);
                     $location.url(adhResourceUrlFilter(itemPath));
                 });
@@ -567,7 +567,7 @@ export var editDirective = (
                 return adhSubmitIfValid(scope, element, scope.documentForm, () => {
                     return postEdit(adhHttp, adhPreliminaryNames, adhUploadImage)(
                         scope, scope.documentVersion, scope.paragraphVersions, scope.hasMap);
-                }).then((documentVersion : RIDocumentVersion) => {
+                }).then((documentVersion : ResourcesBase.IResource) => {
                     var itemPath = AdhUtil.parentPath(documentVersion.path);
                     $location.url(adhResourceUrlFilter(itemPath));
                 });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Home/Home.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Home/Home.ts
@@ -18,9 +18,9 @@ export var homeDirective = (
         scope: {},
         link: (scope) => {
             adhHttp.get("/").then((root) => {
-                scope.picture = (root.data[SIImageReference.nick] || {}).picture;
-                scope.title = root.data[SITitle.nick].title;
-                scope.description = root.data[SIDescription.nick].description;
+                scope.picture = (SIImageReference.get(root) || {}).picture;
+                scope.title = SITitle.get(root).title;
+                scope.description = SIDescription.get(root).description;
             });
         }
     };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Http.ts
@@ -263,9 +263,9 @@ export class Service {
                 content_type: resource.content_type,
                 data: {}
             };
-            obj.data[SIMetadata.nick] = {
+            SIMetadata.set(obj, {
                 hidden: true
-            };
+            });
 
             return this.put(path, <any>obj, _.extend({}, config, {keepMetadata: true}));
         });
@@ -442,9 +442,9 @@ export class Service {
                 throw "Tried to post new version of " + dagPath + " " + timeoutRounds.toString() + " times, giving up.";
             }
 
-            _obj.data[SIVersionable.nick] = {
+            SIVersionable.set(_obj, {
                 follows: [nextOldVersionPath]
-            };
+            });
 
             var handleSuccess = (resource) => {
                 return { value: resource, parentChanged: parentChanged };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Http.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/Http.ts
@@ -338,7 +338,7 @@ export class Service {
     public getNewestVersionPathNoFork(path : string, config : IHttpGetConfig = {}) : angular.IPromise<string> {
         return this.get(path, undefined, config)
             .then((item) => {
-                var head = item.data[SITags.nick].LAST;
+                var head = SITags.get(item).LAST;
                 return head;
             });
     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/HttpSpec.ts
@@ -220,7 +220,7 @@ export var register = () => {
                         content_type: RIParagraph.content_type,
                         data: {},
                     };
-                    dag.data["adhocracy_core.sheets.tags.ITags"] = new SITags.Sheet({ LAST: returnPath1 });
+                    SITags.set(dag, { LAST: returnPath1 });
                     $httpMock.get.and.returnValue(q.when({ data: dag }));
 
                     adhHttp.getNewestVersionPathNoFork(path).then(
@@ -345,9 +345,10 @@ export var register = () => {
                         content_type: RIParagraph.content_type,
                         data: {},
                     };
-                    dag.data["adhocracy_core.sheets.tags.ITags"] = new SITags.Sheet({ FIRST: undefined,
-                                                                                      LAST: newHead
-                                                                                    });
+                    SITags.set(dag, {
+                        FIRST: undefined,
+                        LAST: newHead,
+                    });
 
 
                     var postResponses = [q.reject({ data: error }), q.when({ data: dag })].reverse();

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/HttpSpec.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Http/HttpSpec.ts
@@ -17,7 +17,11 @@ import * as Error from "./Error";
 var mkHttpMock = (adhPreliminaryNames : AdhPreliminaryNames.Service) => {
     var mock = jasmine.createSpy("$httpMock");
 
-    var response = new RIParagraph({ preliminaryNames: adhPreliminaryNames });
+    var response : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIParagraph.content_type,
+        data: {},
+    };
 
     (<any>mock).get = jasmine.createSpy("$httpMock.get").and.returnValue(q.when({ data: response }));
     (<any>mock).post = jasmine.createSpy("$httpMock.post").and.returnValue(q.when({ data: response }));
@@ -211,7 +215,11 @@ export var register = () => {
                     var path = "path/";
                     var returnPath1 = "path1/";
 
-                    var dag = new RIParagraph({ preliminaryNames: adhPreliminaryNames });
+                    var dag : ResourcesBase.IResource = {
+                        path: adhPreliminaryNames.nextPreliminary(),
+                        content_type: RIParagraph.content_type,
+                        data: {},
+                    };
                     dag.data["adhocracy_core.sheets.tags.ITags"] = new SITags.Sheet({ LAST: returnPath1 });
                     $httpMock.get.and.returnValue(q.when({ data: dag }));
 
@@ -332,7 +340,11 @@ export var register = () => {
                     };
 
                     var newHead = "new_head";
-                    var dag = new RIParagraph({ preliminaryNames: adhPreliminaryNames });
+                    var dag : ResourcesBase.IResource = {
+                        path: adhPreliminaryNames.nextPreliminary(),
+                        content_type: RIParagraph.content_type,
+                        data: {},
+                    };
                     dag.data["adhocracy_core.sheets.tags.ITags"] = new SITags.Sheet({ FIRST: undefined,
                                                                                       LAST: newHead
                                                                                     });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Process/Process.ts
@@ -55,20 +55,20 @@ export var detailDirective = (
             scope.$watch("path", (value : string) => {
                 if (value) {
                     adhHttp.get(value).then((resource) => {
-                        var workflow = resource.data[SIWorkflow.nick];
+                        var workflow = SIWorkflow.get(resource);
                         var stateName = workflow.workflow_state;
                         scope.currentPhase = AdhProcess.getStateData(workflow, stateName);
-                        scope.data.picture = (resource.data[SIImageReference.nick] || {}).picture;
-                        scope.data.title = resource.data[SITitle.nick].title;
+                        scope.data.picture = (SIImageReference.get(resource) || {}).picture;
+                        scope.data.title = SITitle.get(resource).title;
                         scope.data.participationStartDate = AdhProcess.getStateData(workflow, "participate").start_date;
                         scope.data.participationEndDate = AdhProcess.getStateData(workflow, "evaluate").start_date;
-                        scope.data.shortDescription = resource.data[SIDescription.nick].short_description;
+                        scope.data.shortDescription = SIDescription.get(resource).short_description;
 
-                        scope.hasLocation = scope.processProperties.hasLocation && resource.data[SILocationReference.nick].location;
+                        scope.hasLocation = scope.processProperties.hasLocation && SILocationReference.get(resource).location;
                         if (scope.hasLocation) {
-                            var locationUrl = resource.data[SILocationReference.nick].location;
+                            var locationUrl = SILocationReference.get(resource).location;
                             adhHttp.get(locationUrl).then((location) => {
-                                var polygon = location.data[SIMultiPolygon.nick].coordinates[0][0];
+                                var polygon = SIMultiPolygon.get(location).coordinates[0][0];
                                 scope.polygon =  polygon;
                             });
                         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
@@ -11,6 +11,8 @@ import * as AdhRate from "../../Rate/Rate";
 import * as AdhTopLevelState from "../../TopLevelState/TopLevelState";
 import * as AdhUtil from "../../Util/Util";
 
+import * as ResourcesBase from "../../../ResourcesBase";
+
 import RICommentVersion from "../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
 import RISystemUser from "../../../../Resources_/adhocracy_core/resources/principal/ISystemUser";
 import * as SICommentable from "../../../../Resources_/adhocracy_core/sheets/comment/ICommentable";
@@ -199,11 +201,20 @@ var postCreate = (
     var proposalClass = scope.processProperties.proposalClass;
     var proposalVersionClass = scope.processProperties.proposalVersionClass;
 
-    var proposal = new proposalClass({preliminaryNames: adhPreliminaryNames});
-    proposal.parent = poolPath;
-    var proposalVersion = new proposalVersionClass({preliminaryNames: adhPreliminaryNames});
+    var proposal : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        first_version_path: adhPreliminaryNames.nextPreliminary(),
+        parent: poolPath,
+        content_type: proposalClass.content_type,
+        data: {},
+    };
+    var proposalVersion : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        parent: proposal.path,
+        content_type: proposalVersionClass.content_type,
+        data: {},
+    };
 
-    proposalVersion.parent = proposal.path;
     proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
         follows: [proposal.first_version_path]
     });
@@ -223,8 +234,12 @@ var postEdit = (
 ) => {
     var proposalVersionClass = scope.processProperties.proposalVersionClass;
 
-    var proposalVersion = new proposalVersionClass({preliminaryNames: adhPreliminaryNames});
-    proposalVersion.parent = AdhUtil.parentPath(oldVersion.path);
+    var proposalVersion : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        parent: AdhUtil.parentPath(oldVersion.path),
+        content_type: proposalVersionClass.content_type,
+        data: {},
+    };
     proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
         follows: [oldVersion.path]
     });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
@@ -73,7 +73,7 @@ var bindPath = (
     var getPolygon = () => {
         if (scope.processProperties.hasLocation) {
             var processUrl = adhTopLevelState.get("processUrl");
-            return adhHttp.get(processUrl).then((process) => {
+            return adhHttp.get(processUrl).then((process) : angular.IPromise<void | number[][]> => {
                 var locationUrl = SILocationReference.get(process).location;
                 if (locationUrl) {
                     return adhHttp.get(locationUrl).then((location) => {
@@ -121,7 +121,7 @@ var bindPath = (
                         rateCount: ratesPro - ratesContra,
                         creator: metadataSheet.creator,
                         creationDate: metadataSheet.item_creation_date,
-                        commentCount: parseInt(SICommentable.get(resource).comments_count, 10),
+                        commentCount: SICommentable.get(resource).comments_count,
                         assignments: assignments
                     };
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
@@ -74,10 +74,10 @@ var bindPath = (
         if (scope.processProperties.hasLocation) {
             var processUrl = adhTopLevelState.get("processUrl");
             return adhHttp.get(processUrl).then((process) => {
-                var locationUrl = process.data[SILocationReference.nick].location;
+                var locationUrl = SILocationReference.get(process).location;
                 if (locationUrl) {
                     return adhHttp.get(locationUrl).then((location) => {
-                        return location.data[SIMultiPolygon.nick].coordinates[0][0];
+                        return SIMultiPolygon.get(location).coordinates[0][0];
                     });
                 }
                 return $q.when();
@@ -92,15 +92,15 @@ var bindPath = (
             adhHttp.get(value).then((resource) => {
                 scope.resource = resource;
 
-                var titleSheet : SITitle.Sheet = resource.data[SITitle.nick];
-                var descriptionSheet : SIDescription.Sheet = resource.data[SIDescription.nick];
-                var pointSheet : SIPoint.Sheet = resource.data[SIPoint.nick];
-                var metadataSheet : SIMetadata.Sheet = resource.data[SIMetadata.nick];
-                var rateableSheet : SIRateable.Sheet = resource.data[SIRateable.nick];
+                var titleSheet = SITitle.get(resource);
+                var descriptionSheet = SIDescription.get(resource);
+                var pointSheet = SIPoint.get(resource);
+                var metadataSheet = SIMetadata.get(resource);
+                var rateableSheet = SIRateable.get(resource);
 
                 var proposalSheetClass = scope.processProperties.proposalSheet;
                 if (proposalSheetClass) {
-                    var proposalSheet = resource.data[proposalSheetClass.nick];
+                    var proposalSheet = proposalSheetClass.get(resource);
                 }
 
                 $q.all([
@@ -121,7 +121,7 @@ var bindPath = (
                         rateCount: ratesPro - ratesContra,
                         creator: metadataSheet.creator,
                         creationDate: metadataSheet.item_creation_date,
-                        commentCount: parseInt(resource.data[SICommentable.nick].comments_count, 10),
+                        commentCount: parseInt(SICommentable.get(resource).comments_count, 10),
                         assignments: assignments
                     };
 
@@ -136,7 +136,7 @@ var bindPath = (
                         scope.data.polygon = polygon;
                     }
                     if (scope.processProperties.hasImage) {
-                        scope.data.picture = resource.data[SIImageReference.nick].picture;
+                        scope.data.picture = SIImageReference.get(resource).picture;
                     }
                     // WARNING: proposalSheet is not a regular feature of adhocracy,
                     // but a hack of Buergerhaushalt and Kiezkasse.
@@ -379,10 +379,10 @@ export var createDirective = (
 
             if (scope.processProperties.hasLocation) {
                 adhHttp.get(scope.poolPath).then((pool) => {
-                    var locationUrl = pool.data[SILocationReference.nick].location;
+                    var locationUrl = SILocationReference.get(pool).location;
                     if (locationUrl) {
                         adhHttp.get(locationUrl).then((location) => {
-                            var polygon = location.data[SIMultiPolygon.nick].coordinates[0][0];
+                            var polygon = SIMultiPolygon.get(location).coordinates[0][0];
                             scope.data.polygon = polygon;
                         });
                     }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
@@ -167,25 +167,25 @@ var fill = (
     var proposalSheet = scope.processProperties.proposalSheet;
     if (proposalSheet && scope.processProperties.hasCreatorParticipate
         && scope.processProperties.hasLocationText && scope.processProperties.maxBudget) {
-        proposalVersion.data[proposalSheet.nick] = new proposalSheet.Sheet({
+        proposalSheet.set(proposalVersion, {
             budget: scope.data.budget,
             creator_participate: scope.data.creatorParticipate,
             location_text: scope.data.locationText
         });
     } else if (proposalSheet && scope.processProperties.hasLocationText && scope.processProperties.maxBudget) {
-        proposalVersion.data[proposalSheet.nick] = new proposalSheet.Sheet({
+        proposalSheet.set(proposalVersion, {
             budget: scope.data.budget,
             location_text: scope.data.locationText
         });
     }
-    proposalVersion.data[SITitle.nick] = new SITitle.Sheet({
+    SITitle.set(proposalVersion, {
         title: scope.data.title
     });
-    proposalVersion.data[SIDescription.nick] = new SIDescription.Sheet({
+    SIDescription.set(proposalVersion, {
         description: scope.data.detail
     });
     if (scope.data.lng && scope.data.lat) {
-        proposalVersion.data[SIPoint.nick] = new SIPoint.Sheet({
+        SIPoint.set(proposalVersion, {
             coordinates: [scope.data.lng, scope.data.lat]
         });
     }
@@ -215,7 +215,7 @@ var postCreate = (
         data: {},
     };
 
-    proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(proposalVersion, {
         follows: [proposal.first_version_path]
     });
     fill(scope, proposalVersion);
@@ -240,7 +240,7 @@ var postEdit = (
         content_type: proposalVersionClass.content_type,
         data: {},
     };
-    proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(proposalVersion, {
         follows: [oldVersion.path]
     });
     fill(scope, proposalVersion);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Workbench/Workbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Workbench/Workbench.ts
@@ -34,7 +34,7 @@ export var workbenchDirective = (
             scope.$watch("processUrl", (processUrl) => {
                 if (processUrl) {
                     adhHttp.get(processUrl).then((resource) => {
-                        scope.currentPhase = resource.data[SIWorkflow.nick].workflow_state;
+                        scope.currentPhase = SIWorkflow.get(resource).workflow_state;
                     });
                 }
             });
@@ -130,7 +130,7 @@ export var addProposalButtonDirective = (
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             adhHttp.get(scope.processUrl).then((process) => {
-                var workflow = process.data[SIWorkflow.nick].workflow;
+                var workflow = SIWorkflow.get(process).workflow;
                 scope.workflowAllowsCreateProposal = (workflow !== "debate" && workflow !== "debate_private");
             });
 
@@ -249,7 +249,7 @@ export var registerRoutesFactory = (
                 if (resource.content_type !== RICommentVersion.content_type) {
                     return $q.when(resource);
                 } else {
-                    var url = resource.data[SIComment.nick].refers_to;
+                    var url = SIComment.get(resource).refers_to;
                     return adhHttp.get(url).then(getCommentableUrl);
                 }
             };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Workbench/Workbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Workbench/Workbench.ts
@@ -6,6 +6,8 @@ import * as AdhPermissions from "../../Permissions/Permissions";
 import * as AdhResourceArea from "../../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../TopLevelState/TopLevelState";
 
+import * as ResourcesBase from "../../../ResourcesBase";
+
 import RIComment from "../../../../Resources_/adhocracy_core/resources/comment/IComment";
 import RICommentVersion from "../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
 import * as SIComment from "../../../../Resources_/adhocracy_core/sheets/comment/IComment";
@@ -252,7 +254,7 @@ export var registerRoutesFactory = (
                 }
             };
 
-            return (item : RIComment, version : RICommentVersion) => {
+            return (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return getCommentableUrl(version).then((commentable) => {
                     return {
                         commentableUrl: commentable.path,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Image.ts
@@ -79,7 +79,7 @@ export var addImage = (
             data: {},
             content_type: resource.content_type
         };
-        patch.data[SIImageReference.nick] = new SIImageReference.Sheet({ picture: imagePath });
+        SIImageReference.set(patch, { picture: imagePath });
 
         // Versioned resources are on the way out, so they get the special treatment
         if (resource.data[SIVersionable.nick]) {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Image.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Image.ts
@@ -60,7 +60,7 @@ export var uploadImageFactory = (
 
     return adhHttp.get(poolPath)
         .then((pool) => {
-            var postPath : string = pool.data[SIHasAssetPool.nick].asset_pool;
+            var postPath : string = SIHasAssetPool.get(pool).asset_pool;
             return adhHttp.postRaw(postPath, formData)
                 .then((rsp) => rsp.data.path)
                 .catch(<any>AdhHttp.logBackendError);
@@ -82,7 +82,7 @@ export var addImage = (
         SIImageReference.set(patch, { picture: imagePath });
 
         // Versioned resources are on the way out, so they get the special treatment
-        if (resource.data[SIVersionable.nick]) {
+        if (SIVersionable.get(resource)) {
             var newVersion = _.clone(resource);
             _.merge(newVersion.data, patch.data);
             return adhHttp.postNewVersionNoFork(resourcePath, newVersion);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Listing/Listing.ts
@@ -241,10 +241,10 @@ export class Listing<Container extends ResourcesBase.IResource> {
                     return getElements($scope.currentLimit).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = $scope.container.path;
-                        $scope.totalCount = parseInt($scope.container.data[SIPool.nick].count, 10);
+                        $scope.totalCount = parseInt(SIPool.get($scope.container).count, 10);
 
                         // avoid modifying the cached result
-                        $scope.elements = _.clone($scope.container.data[SIPool.nick].elements);
+                        $scope.elements = _.clone(SIPool.get($scope.container).elements);
 
                         if (!$scope.sorts || $scope.sorts.length === 0) {
                             // If no backend based sorting is used, we
@@ -258,7 +258,7 @@ export class Listing<Container extends ResourcesBase.IResource> {
                 $scope.loadMore = () : void => {
                     if ($scope.currentLimit < $scope.totalCount) {
                         getElements($scope.initialLimit, $scope.currentLimit).then((container) => {
-                            var elements = _.clone(container.data[SIPool.nick].elements);
+                            var elements = _.clone(SIPool.get(container).elements);
                             $scope.elements = $scope.elements.concat(elements);
                             $scope.currentLimit += $scope.initialLimit;
                         });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Listing/Listing.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Listing/Listing.ts
@@ -241,7 +241,7 @@ export class Listing<Container extends ResourcesBase.IResource> {
                     return getElements($scope.currentLimit).then((container) => {
                         $scope.container = container;
                         $scope.poolPath = $scope.container.path;
-                        $scope.totalCount = parseInt(SIPool.get($scope.container).count, 10);
+                        $scope.totalCount = parseInt((<any>SIPool.get($scope.container)).count, 10);
 
                         // avoid modifying the cached result
                         $scope.elements = _.clone(SIPool.get($scope.container).elements);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Page/Page.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Page/Page.ts
@@ -3,6 +3,8 @@ import * as AdhHttp from "../Http/Http";
 import * as AdhResourceArea from "../ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RIPage from "../../../Resources_/adhocracy_core/resources/page/IPage";
 import * as SIDescription from "../../../Resources_/adhocracy_core/sheets/description/IDescription";
 import * as SITitle from "../../../Resources_/adhocracy_core/sheets/title/ITitle";
@@ -24,7 +26,7 @@ export var pageDirective = (
 
             scope.$watch("path", (path : string) => {
                 if (path) {
-                    adhHttp.get(path).then((page : RIPage) => {
+                    adhHttp.get(path).then((page : ResourcesBase.IResource) => {
                         scope.title = page.data[SITitle.nick].title;
                         scope.description = page.data[SIDescription.nick].description;
                     });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Page/Page.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Page/Page.ts
@@ -27,8 +27,8 @@ export var pageDirective = (
             scope.$watch("path", (path : string) => {
                 if (path) {
                     adhHttp.get(path).then((page : ResourcesBase.IResource) => {
-                        scope.title = page.data[SITitle.nick].title;
-                        scope.description = page.data[SIDescription.nick].description;
+                        scope.title = SITitle.get(page).title;
+                        scope.description = SIDescription.get(page).description;
                     });
                 }
             });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
@@ -40,7 +40,7 @@ export interface IProcessProperties {
     proposalVersionClass;
 }
 
-export var getStateData = (sheet : SIWorkflow.Sheet, name : string) : IStateData => {
+export var getStateData = (sheet : SIWorkflow.ISheet, name : string) : IStateData => {
     for (var i = 0; i < sheet.state_data.length; i++) {
         if (sheet.state_data[i].name === name) {
             return sheet.state_data[i];

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
@@ -120,10 +120,10 @@ export var workflowSwitchDirective = (
                         return;
                     }
                     adhHttp.get(scope.path).then((process) => {
-                        process.data[SIWorkflow.nick] = {
+                        SIWorkflow.set(process, {
                             workflow_state: newState
-                        };
-                        process.data[SIName.nick] = undefined;
+                        });
+                        SIName.set(process, undefined);
                         adhHttp.put(scope.path, process).then((response) => {
                             $window.parent.location.reload();
                         });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
@@ -111,7 +111,7 @@ export var workflowSwitchDirective = (
             });
 
             adhHttp.get(scope.path).then((process) => {
-                scope.workflowState = process.data[SIWorkflow.nick].workflow_state;
+                scope.workflowState = SIWorkflow.get(process).workflow_state;
             });
 
             scope.switchState = (newState) => {
@@ -168,20 +168,20 @@ export var listItemDirective = (
         },
         link: (scope) => {
             adhHttp.get(scope.path).then((process) => {
-                if (process.data[SIImageReference.nick] && process.data[SIImageReference.nick].picture) {
-                    scope.picture = process.data[SIImageReference.nick].picture;
+                if (SIImageReference.get(process) && SIImageReference.get(process).picture) {
+                    scope.picture = SIImageReference.get(process).picture;
                 }
-                scope.title = process.data[SITitle.nick].title;
+                scope.title = SITitle.get(process).title;
                 scope.processName = adhNames.getName(process.content_type, 1);
-                if (process.data[SILocationReference.nick] && process.data[SILocationReference.nick].location) {
-                    adhHttp.get(process.data[SILocationReference.nick].location).then((loc) => {
-                        scope.locationText = loc.data[SITitle.nick].title;
+                if (SILocationReference.get(process) && SILocationReference.get(process).location) {
+                    adhHttp.get(SILocationReference.get(process).location).then((loc) => {
+                        scope.locationText = SITitle.get(loc).title;
                     });
                 }
-                var workflow = process.data[SIWorkflow.nick];
+                var workflow = SIWorkflow.get(process);
                 scope.participationStartDate = getStateData(workflow, "participate").start_date;
                 scope.participationEndDate = getStateData(workflow, "evaluate").start_date;
-                scope.shortDesc = process.data[SIDescription.nick].short_description;
+                scope.shortDesc = SIDescription.get(process).short_description;
             });
         }
     };
@@ -213,7 +213,7 @@ export var currentProcessTitleDirective = (
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.on("processUrl", (processUrl) => {
                 adhHttp.get(processUrl).then((process) => {
-                    scope.processTitle = process.data[SITitle.nick].title;
+                    scope.processTitle = SITitle.get(process).title;
                 });
             }));
         }

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Rate/Rate.ts
@@ -14,10 +14,10 @@ import * as AdhUser from "../User/User";
 import * as AdhUtil from "../Util/Util";
 import * as AdhWebSocket from "../WebSocket/WebSocket";
 
-import RIProcess from "../../../Resources_/adhocracy_core/resources/process/IProcess";
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RIRate from "../../../Resources_/adhocracy_core/resources/rate/IRate";
 import RIRateVersion from "../../../Resources_/adhocracy_core/resources/rate/IRateVersion";
-import RIUser from "../../../Resources_/adhocracy_core/resources/principal/IUser";
 import * as SIPool from "../../../Resources_/adhocracy_core/sheets/pool/IPool";
 import * as SIRate from "../../../Resources_/adhocracy_core/sheets/rate/IRate";
 import * as SIUserBasic from "../../../Resources_/adhocracy_core/sheets/principal/IUserBasic";
@@ -73,7 +73,7 @@ export interface IRateScope extends angular.IScope {
 export var getWorkflowState = (
     adhResourceArea : AdhResourceArea.Service
 ) => (resourceUrl : string) : angular.IPromise<string> => {
-    return adhResourceArea.getProcess(resourceUrl, false).then((resource : RIProcess) => {
+    return adhResourceArea.getProcess(resourceUrl, false).then((resource : ResourcesBase.IResource) => {
         if (typeof resource !== "undefined") {
             var workflowSheet = resource.data[SIWorkflow.nick];
             if (typeof workflowSheet !== "undefined") {
@@ -166,8 +166,8 @@ export var directiveFactory = (template : string, sheetName : string) => (
         return adhHttp.get(poolPath, query)
             .then((poolRsp) => {
                 var ratePaths : string[] = poolRsp.data[SIPool.nick].elements;
-                var rates : RIRateVersion[] = [];
-                var users : RIUser[] = [];
+                var rates : ResourcesBase.IResource[] = [];
+                var users : ResourcesBase.IResource[] = [];
                 var auditTrail : { subject: string; rate: number }[] = [];
 
                 adhHttp.withTransaction((transaction) : angular.IPromise<void> => {
@@ -213,12 +213,12 @@ export var directiveFactory = (template : string, sheetName : string) => (
             disabled: "="
         },
         link: (scope : IRateScope) : void => {
-            var myRateResource : RIRateVersion;
+            var myRateResource : ResourcesBase.IResource;
             var webSocketOff : () => void;
             var postPoolPath : string;
             var rates : {[key : string]: number};
             var lock : boolean;
-            var storeMyRateResource : (resource : RIRateVersion) => void;
+            var storeMyRateResource : (resource : ResourcesBase.IResource) => void;
             var forceResult : boolean = false;
 
             var updateMyRate = () : angular.IPromise<void> => {
@@ -264,7 +264,7 @@ export var directiveFactory = (template : string, sheetName : string) => (
                 }
             };
 
-            storeMyRateResource = (resource : RIRateVersion) => {
+            storeMyRateResource = (resource : ResourcesBase.IResource) => {
                 myRateResource = resource;
 
                 if (typeof webSocketOff === "undefined") {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Rate/Rate.ts
@@ -251,7 +251,12 @@ export var directiveFactory = (template : string, sheetName : string) => (
                 } else {
                     return getAnonymizeInfo(postPoolPath, "POST").then((anonymizeInfo) => {
                         return adhHttp.withTransaction((transaction) => {
-                            var item = transaction.post(postPoolPath, new RIRate({preliminaryNames: adhPreliminaryNames}));
+                            var item = transaction.post(postPoolPath, {
+                                path: adhPreliminaryNames.nextPreliminary(),
+                                first_version_path: adhPreliminaryNames.nextPreliminary(),
+                                content_type: RIRate.content_type,
+                                data: {},
+                            });
                             var version = transaction.get(item.first_version_path);
 
                             return transaction.commit({ anonymize : anonymizeInfo.defaultValue })

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Rate/Rate.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Rate/Rate.ts
@@ -127,7 +127,7 @@ export class Service {
         query[SIRate.nick + ":object"] = object;
 
         return this.adhHttp.get(poolPath, query).then((pool) => {
-            return SIPool.get(pool).aggregateby.rate;
+            return (<any>SIPool.get(pool)).aggregateby.rate;
         });
     }
 }
@@ -196,7 +196,7 @@ export var directiveFactory = (template : string, sheetName : string) => (
                     _.forOwn(ratePaths, (ratePath, ix) => {
                         auditTrail[ix] = {
                             subject: SIUserBasic.get(users[ix]).name,
-                            rate: parseInt(SIRate.get(rates[ix]).rate, 10)
+                            rate: SIRate.get(rates[ix]).rate
                         };
                     });
                     return auditTrail;
@@ -225,7 +225,7 @@ export var directiveFactory = (template : string, sheetName : string) => (
                 if (adhCredentials.loggedIn) {
                     return adhRate.fetchRate(postPoolPath, scope.refersTo, adhCredentials.userPath).then((resource) => {
                         storeMyRateResource(resource);
-                        scope.myRate = parseInt(SIRate.get(resource).rate, 10);
+                        scope.myRate = SIRate.get(resource).rate;
                         scope.hasCast = true;
                     }, () => undefined);
                 } else {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/ResourceActions/ResourceActions.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/ResourceActions/ResourceActions.ts
@@ -192,7 +192,7 @@ export var assignBadgesActionDirective = (
             scope.$watch("resourcePath", (resourcePath) => {
                 if (resourcePath) {
                     adhHttp.get(resourcePath).then((badgeable) => {
-                        badgeAssignmentPoolPath = badgeable.data[SIBadgeable.nick].post_pool;
+                        badgeAssignmentPoolPath = SIBadgeable.get(badgeable).post_pool;
                     });
                 }
             });

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/ResourceArea/ResourceArea.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/ResourceArea/ResourceArea.ts
@@ -273,7 +273,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
         return self.adhHttp.get(resourceUrl).then((version) => {
             if (version.data.hasOwnProperty(SIVersionable.nick)) {
                 return self.adhHttp.get(AdhUtil.parentPath(resourceUrl)).then((item) => {
-                    var lastUrl = item.data[SITags.nick].LAST;
+                    var lastUrl = SITags.get(item).LAST;
                     if (lastUrl === resourceUrl) {
                         return false;
                     } else {
@@ -331,7 +331,7 @@ export class Service implements AdhTopLevelState.IAreaInput {
 
             var processType = process ? process.content_type : "";
             var processUrl = process ? process.path : "/";
-            var processState = process ? process.data[SIWorkflowAssignment.nick].workflow_state : "";
+            var processState = process ? SIWorkflowAssignment.get(process).workflow_state : "";
 
             if (hasRedirected) {
                 return;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/User.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/User.ts
@@ -59,8 +59,8 @@ export class Service {
         return _self.adhHttp.get(userPath)
             .then((resource) => {
                 _self.data = {
-                    name: resource.data[SIUserBasic.nick].name,
-                    anonymize: resource.data[SIAnonymizeDefault.nick].anonymize,
+                    name: SIUserBasic.get(resource).name,
+                    anonymize: SIAnonymizeDefault.get(resource).anonymize,
                 };
             }, (reason) => {
                 // The user resource that was returned by the server could not be accessed.

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/User.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/User.ts
@@ -112,20 +112,20 @@ export class Service {
             "content_type": "adhocracy_core.resources.principal.IUser",
             "data": {}
         };
-        resource.data[SIUserBasic.nick] = {
+        SIUserBasic.set(resource, {
             "name": username
-        };
-        resource.data[SIUserExtended.nick] = {
+        });
+        SIUserExtended.set(resource, {
             "email": email
-        };
-        resource.data[SIPasswordAuthentication.nick] = {
+        });
+        SIPasswordAuthentication.set(resource, {
             "password": password
-        };
+        });
         if (captchaId && captchaGuess) {
-            resource.data[SICaptcha.nick] = {
+            SICaptcha.set(resource, {
                 "id": captchaId,
                 "solution": captchaGuess
-            };
+            });
         }
 
         return _self.adhHttp.post("/principals/users/", resource, {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
@@ -915,7 +915,7 @@ export var adhUserActivityOverviewDirective = (
                 params[SIMetadata.nick + ":creator"] = scope.path;
 
                 adhHttp.get(adhConfig.rest_url, params)
-                    .then((pool) => { scope[scopeTarget] = parseInt(SIPool.get(pool).count, 10); });
+                    .then((pool) => { scope[scopeTarget] = parseInt((<any>SIPool.get(pool)).count, 10); });
             };
 
             requestCountInto(RIComment, "commentCount", attrs.showComments);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
@@ -16,6 +16,8 @@ import * as AdhUtil from "../Util/Util";
 import * as AdhCredentials from "./Credentials";
 import * as AdhUser from "./User";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RIComment from "../../../Resources_/adhocracy_core/resources/comment/IComment";
 import RIProposal from "../../../Resources_/adhocracy_core/resources/proposal/IProposal";
 import RIRate from "../../../Resources_/adhocracy_core/resources/rate/IRate";
@@ -823,7 +825,7 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
             modals: "="
         },
         link: (scope)  => {
-            adhHttp.get(scope.recipientUrl).then((recipient : RIUser) => {
+            adhHttp.get(scope.recipientUrl).then((recipient : ResourcesBase.IResource) => {
                 scope.recipientName = recipient.data[SIUserBasic.nick].name;
             });
 
@@ -1028,7 +1030,7 @@ export var registerRoutes = (
             space: "user",
             movingColumns: "is-show-hide-hide"
         })
-        .specific(RIUser, "", "", context, () => (resource : RIUser) => {
+        .specific(RIUser, "", "", context, () => (resource : ResourcesBase.IResource) => {
             return {
                 userUrl: resource.path
             };
@@ -1037,7 +1039,7 @@ export var registerRoutes = (
             space: "user",
             movingColumns: "is-show-hide-hide"
         })
-        .specific(RIUser, "edit", "", context, ["adhHttp", (adhHttp : AdhHttp.Service) => (resource : RIUser) => {
+        .specific(RIUser, "edit", "", context, ["adhHttp", (adhHttp : AdhHttp.Service) => (resource : ResourcesBase.IResource) => {
             return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                 if (!options.PUT) {
                     throw 401;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
@@ -717,7 +717,7 @@ export var userProfileDirective = (
                         content_type: oldUser.content_type,
                         data: {}
                     };
-                    patch.data[SIDescription.nick] = new SIDescription.Sheet({
+                    SIDescription.set(patch, {
                         description: scope.data.description,
                         short_description: scope.data.shortDescription,
                     });
@@ -745,16 +745,16 @@ var postEdit = (
             data: {}
         };
         if (oldUser.data[SIUserBasic.nick].name !== data.name) {
-            patch.data[SIUserBasic.nick] = new SIUserBasic.Sheet({
+            SIUserBasic.set(patch, {
                 name: data.name,
             });
         }
         if (data.password) {
-            patch.data[SIPasswordAuthentication.nick] = new SIPasswordAuthentication.Sheet({
+            SIPasswordAuthentication.set(patch, {
                 password: data.password,
             });
         }
-        patch.data[SIAnonymizeDefault.nick] = new SIAnonymizeDefault.Sheet({
+        SIAnonymizeDefault.set(patch, {
             anonymize: data.anonymize,
         });
         return adhHttp.put(oldUser.path, patch);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/Views.ts
@@ -604,7 +604,7 @@ export var metaDirective = (
             if ($scope.path) {
                 adhHttp.resolve($scope.path)
                     .then((res) => {
-                        $scope.userBasic = res.data[SIUserBasic.nick];
+                        $scope.userBasic = SIUserBasic.get(res);
                         // provide no link if either noLink is true or there are no user profiles enabled or user is anonymous
                         var usersEnabled = adhResourceArea.has(RIUser.content_type);
                         var userIsAnonymous = res.content_type === RISystemUser.content_type;
@@ -655,7 +655,7 @@ export var userListItemDirective = (adhConfig : AdhConfig.IService) => {
             if ($scope.path) {
                 adhHttp.resolve($scope.path)
                     .then((res) => {
-                        $scope.userBasic = res.data[SIUserBasic.nick];
+                        $scope.userBasic = SIUserBasic.get(res);
                         adhGetBadges(res).then((assignments) => {
                             $scope.assignments = assignments;
                         });
@@ -699,10 +699,10 @@ export var userProfileDirective = (
             scope.$watch("path", (path) => {
                 if (path) {
                     adhHttp.get(path).then((user) => {
-                        scope.userBasic = user.data[SIUserBasic.nick];
+                        scope.userBasic = SIUserBasic.get(user);
                         scope.data = {
-                            description: user.data[SIDescription.nick].description,
-                            shortDescription: user.data[SIDescription.nick].short_description,
+                            description: SIDescription.get(user).description,
+                            shortDescription: SIDescription.get(user).short_description,
                         };
                         adhGetBadges(user).then((assignments) => {
                             scope.assignments = assignments;
@@ -744,7 +744,7 @@ var postEdit = (
             content_type: oldUser.content_type,
             data: {}
         };
-        if (oldUser.data[SIUserBasic.nick].name !== data.name) {
+        if (SIUserBasic.get(oldUser).name !== data.name) {
             SIUserBasic.set(patch, {
                 name: data.name,
             });
@@ -786,9 +786,9 @@ export var userEditDirective = (
                 if (path) {
                     adhHttp.get(path).then((user) => {
                         scope.data = {
-                            name: user.data[SIUserBasic.nick].name,
+                            name: SIUserBasic.get(user).name,
                             password: "",
-                            anonymize: user.data[SIAnonymizeDefault.nick].anonymize,
+                            anonymize: SIAnonymizeDefault.get(user).anonymize,
                         };
                     });
                 }
@@ -826,7 +826,7 @@ export var userMessageDirective = (adhConfig : AdhConfig.IService, adhHttp : Adh
         },
         link: (scope)  => {
             adhHttp.get(scope.recipientUrl).then((recipient : ResourcesBase.IResource) => {
-                scope.recipientName = recipient.data[SIUserBasic.nick].name;
+                scope.recipientName = SIUserBasic.get(recipient).name;
             });
 
             scope.messageSend = () => {
@@ -915,7 +915,7 @@ export var adhUserActivityOverviewDirective = (
                 params[SIMetadata.nick + ":creator"] = scope.path;
 
                 adhHttp.get(adhConfig.rest_url, params)
-                    .then((pool) => { scope[scopeTarget] = parseInt(pool.data[SIPool.nick].count, 10); });
+                    .then((pool) => { scope[scopeTarget] = parseInt(SIPool.get(pool).count, 10); });
             };
 
             requestCountInto(RIComment, "commentCount", attrs.showComments);
@@ -949,8 +949,8 @@ export var adhUserProfileImageDirective = (
                 if ( ! path) { return; }
 
                 adhHttp.get(scope.path).then((user) => {
-                    scope.assetPath = user.data[SIImageReference.nick].picture;
-                    scope.userName = user.data[SIUserBasic.nick].name;
+                    scope.assetPath = SIImageReference.get(user).picture;
+                    scope.userName = SIUserBasic.get(user).name;
                     if ( ! scope.assetPath) {
                         scope.didFailToLoadImage();
                     }
@@ -974,7 +974,7 @@ export var adhUserProfileImageEditDirective = (
         link: (scope) => {
             scope.config = adhConfig;
             adhHttp.get(AdhUtil.parentPath(scope.path)).then((userPool) => {
-                scope.assetPool = userPool.data[SIHasAssetPool.nick].asset_pool;
+                scope.assetPool = SIHasAssetPool.get(userPool).asset_pool;
             });
             scope.triggerUpload = () => {
                 scope.isUploading = true;

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtil.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Util/ResourceUtil.ts
@@ -28,9 +28,9 @@ export var derive = (
         resource.data[key] = _.cloneDeep(sheet);
     });
 
-    resource.data[SIVersionable.nick] = {
+    SIVersionable.set(resource, {
         follows: [oldVersion.path]
-    };
+    });
 
     return resource;
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -275,7 +275,7 @@ renderSheet = (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IM
 mkFieldSignatures = (fields : MetaApi.ISheetField[], tab : string, separator : string) : string =>
     UtilR.mkThingList(
         fields,
-        (field) => field.name + " : " + mkFieldType(field).resultType,
+        (field) => field.name + (field.create_mandatory ? "" : "?") + " : " + mkFieldType(field).resultType,
         tab, separator
     );
 

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -326,8 +326,8 @@ enabledFields = (fields : MetaApi.ISheetField[], enableFlags? : string) : MetaAp
 
 mkSheetSetterGetter = () => {
     // FIXME: we could add types
-    return "export var get = (resource) => resource.data[nick];\n" +
-        "export var set = (resource, sheet) : void => {\n" +
+    return "export var get = (resource) : ISheet => resource.data[nick];\n" +
+        "export var set = (resource, sheet : ISheet) : void => {\n" +
         "    resource.data[nick] = sheet;\n" +
         "};\n";
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -115,7 +115,7 @@ interface FieldType {
 
 var compileAll : (metaApi : MetaApi.IMetaApi, outPath : string) => void;
 
-var renderSheet : (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IModuleDict, metaApi : MetaApi.IMetaApi) => void;
+var renderSheet : (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IModuleDict) => void;
 var mkFieldSignatures : (fields : MetaApi.ISheetField[], tab : string, separator : string) => string;
 var mkFieldSignaturesSheetCons : (fields : MetaApi.ISheetField[], tab : string, separator : string) => string;
 var mkFieldSignaturesSheetParse : (fields : MetaApi.ISheetField[], tab : string, separator : string) => string;
@@ -218,7 +218,7 @@ compileAll = (metaApi : MetaApi.IMetaApi, outPath : string) : void => {
 
     for (var sheetName in metaApi.sheets) {
         if (metaApi.sheets.hasOwnProperty(sheetName)) {
-            renderSheet(sheetName, metaApi.sheets[sheetName], modules, metaApi);
+            renderSheet(sheetName, metaApi.sheets[sheetName], modules);
         }
     }
 
@@ -255,7 +255,7 @@ compileAll = (metaApi : MetaApi.IMetaApi, outPath : string) : void => {
     })();
 };
 
-renderSheet = (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IModuleDict, metaApi : MetaApi.IMetaApi) : void => {
+renderSheet = (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IModuleDict) : void => {
     var sheetI : string = "";
 
     sheetI += "export var nick : string = \"" + sheet.nick + "\";\n\n";

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -254,51 +254,6 @@ compileAll = (metaApi : MetaApi.IMetaApi, outPath : string) : void => {
             }
         }
     })();
-
-    // generate root module Resources_.ts
-    (() => {
-        var rootModule = "";
-        var relativeRoot = "./Resources_/";
-        var imports : string[] = [];
-        (() => {
-            for (var modulePath in modules) {
-                if (modules.hasOwnProperty(modulePath)) {
-                    imports.push(mkImportStatement(modulePath, relativeRoot, metaApi));
-                }
-            }
-            imports.sort();
-            rootModule += imports.join("") + "\n";
-        })();
-
-        // resource registry.
-        (() => {
-            var dictEntries : string[] = [];
-            for (var modulePath in metaApi.resources) {
-                if (metaApi.resources.hasOwnProperty(modulePath)) {
-                    dictEntries.push("    \"" + modulePath + "\": " + mkModuleName(modulePath, metaApi));
-                }
-            }
-            dictEntries.sort();
-            rootModule += "export var resourceRegistry = {\n" + dictEntries.join(",\n") + "\n};\n\n";
-        })();
-
-        // sheet registry.
-        (() => {
-            var dictEntries : string[] = [];
-            for (var modulePath in metaApi.sheets) {
-                if (metaApi.sheets.hasOwnProperty(modulePath)) {
-                    dictEntries.push(
-                            "    \"" + modulePath + "\": "
-                            + mkModuleName(modulePath, metaApi) + ".Sheet");
-                }
-            }
-            dictEntries.sort();
-            rootModule += "export var sheetRegistry = {\n" + dictEntries.join(",\n") + "\n};\n";
-        })();
-
-        var absfp = outPath + "/Resources_.ts";
-        fs.writeFileSync(absfp, headerFooter(relativeRoot, rootModule));
-    })();
 };
 
 renderSheet = (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IModuleDict, metaApi : MetaApi.IMetaApi) : void => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/mkResources.ts
@@ -122,6 +122,7 @@ var mkFieldSignaturesSheetCons : (fields : MetaApi.ISheetField[], tab : string, 
 var mkFieldSignaturesSheetParse : (fields : MetaApi.ISheetField[], tab : string, separator : string) => string;
 var mkFieldAssignments : (fields : MetaApi.ISheetField[], tab : string) => string;
 var enabledFields : (fields : MetaApi.ISheetField[], enableFlags? : string) => MetaApi.ISheetField[];
+var mkSheetSetterGetter : () => string;
 
 var renderResource : (modulePath : string, resource : MetaApi.IResource, modules : MetaApi.IModuleDict, metaApi : MetaApi.IMetaApi) => void;
 
@@ -472,7 +473,7 @@ renderSheet = (modulePath : string, sheet : MetaApi.ISheet, modules : MetaApi.IM
     sheetI += "    content_type : string;\n";
     sheetI += "}\n\n";
 
-    modules[modulePath] = sheetI + hasSheetI;
+    modules[modulePath] = sheetI + hasSheetI + mkSheetSetterGetter();
 };
 
 mkFieldSignatures = (fields : MetaApi.ISheetField[], tab : string, separator : string) : string =>
@@ -525,6 +526,14 @@ enabledFields = (fields : MetaApi.ISheetField[], enableFlags? : string) : MetaAp
         });
         return enabledFields;
     }
+};
+
+mkSheetSetterGetter = () => {
+    // FIXME: we could add types
+    return "export var get = (resource) => resource.data[nick];\n" +
+        "export var set = (resource, sheet) : void => {\n" +
+        "    resource.data[nick] = sheet;\n" +
+        "};\n";
 };
 
 renderResource = (modulePath : string, resource : MetaApi.IResource, modules : MetaApi.IModuleDict, metaApi : MetaApi.IMetaApi) : void => {

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Workbench.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Workbench.ts
@@ -7,6 +7,8 @@ import * as AdhResourceArea from "../../../Core/ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../../Core/TopLevelState/TopLevelState";
 import * as AdhUtil from "../../../Core/Util/Util";
 
+import * as ResourcesBase from "../../../../ResourcesBase";
+
 import RIAlexanderplatzProcess from "../../../../Resources_/adhocracy_meinberlin/resources/alexanderplatz/IProcess";
 import RIGeoDocument from "../../../../Resources_/adhocracy_core/resources/document/IGeoDocument";
 import RIGeoDocumentVersion from "../../../../Resources_/adhocracy_core/resources/document/IGeoDocumentVersion";
@@ -206,7 +208,7 @@ export var registerRoutes = (
             tab: "documents"
         })
         .specific(RIAlexanderplatzProcess, "create_document", processType, context, [
-            "adhHttp", (adhHttp : AdhHttp.Service) => (resource : RIAlexanderplatzProcess) => {
+            "adhHttp", (adhHttp : AdhHttp.Service) => (resource : ResourcesBase.IResource) => {
                 return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                     if (!options.canPost(RIGeoDocument.content_type)) {
                         throw 401;
@@ -221,7 +223,7 @@ export var registerRoutes = (
             tab: "documents"
         })
         .specificVersionable(RIGeoDocument, RIGeoDocumentVersion, "", processType, context, [
-            () => (item : RIGeoDocument, version : RIGeoDocumentVersion) => {
+            () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return {
                     documentUrl: version.path
                 };
@@ -232,7 +234,7 @@ export var registerRoutes = (
             tab: "documents"
         })
         .specificVersionable(RIGeoDocument, RIGeoDocumentVersion, "edit", processType, context, [
-            "adhHttp", (adhHttp : AdhHttp.Service) => (item : RIGeoDocument, version : RIGeoDocumentVersion) => {
+            "adhHttp", (adhHttp : AdhHttp.Service) => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
                     if (!options.POST) {
                         throw 401;
@@ -249,7 +251,7 @@ export var registerRoutes = (
             tab: "documents"
         })
         .specificVersionable(RIParagraph, RIParagraphVersion, "comments", processType, context, [
-            () => (item : RIParagraph, version : RIParagraphVersion) => {
+            () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 var documentUrl = _.last(_.sortBy(version.data[SIParagraph.nick].documents));
                 return {
                     commentableUrl: version.path,
@@ -270,7 +272,7 @@ export var registerRoutes = (
             tab: "proposals"
         })
         .specific(RIAlexanderplatzProcess, "create_proposal", processType, context, [
-            "adhHttp", (adhHttp : AdhHttp.Service) => (resource : RIAlexanderplatzProcess) => {
+            "adhHttp", (adhHttp : AdhHttp.Service) => (resource : ResourcesBase.IResource) => {
                 return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                     if (!options.canPost(RIGeoProposal.content_type)) {
                         throw 401;
@@ -285,7 +287,7 @@ export var registerRoutes = (
             tab: "proposals"
         })
         .specificVersionable(RIGeoProposal, RIGeoProposalVersion, "", processType, context, [
-            () => (item : RIGeoProposal, version : RIGeoProposalVersion) => {
+            () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return {
                     proposalUrl: version.path
                 };
@@ -296,7 +298,7 @@ export var registerRoutes = (
             tab: "proposals"
         })
         .specificVersionable(RIGeoProposal, RIGeoProposalVersion, "edit", processType, context, [
-            "adhHttp", (adhHttp : AdhHttp.Service) => (item : RIGeoProposal, version : RIGeoProposalVersion) => {
+            "adhHttp", (adhHttp : AdhHttp.Service) => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
                     if (!options.POST) {
                         throw 401;
@@ -313,7 +315,7 @@ export var registerRoutes = (
             tab: "proposals"
         })
         .specificVersionable(RIGeoProposal, RIGeoProposalVersion, "comments", processType, context, [
-            () => (item : RIGeoProposal, version : RIGeoProposalVersion) => {
+            () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return {
                     commentableUrl: version.path,
                     commentCloseUrl: version.path,

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Workbench.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Alexanderplatz/Workbench/Workbench.ts
@@ -44,9 +44,9 @@ export var getProcessPolygon = (
     adhHttp : AdhHttp.Service
 ) => (processUrl : string) : angular.IPromise<any> => {
     return adhHttp.get(processUrl).then((resource) => {
-        var locationUrl = resource.data[SILocationReference.nick].location;
+        var locationUrl = SILocationReference.get(resource).location;
         return adhHttp.get(locationUrl).then((location) => {
-            return location.data[SIMultiPolygon.nick].coordinates[0][0];
+            return SIMultiPolygon.get(location).coordinates[0][0];
         });
     });
 };
@@ -252,7 +252,7 @@ export var registerRoutes = (
         })
         .specificVersionable(RIParagraph, RIParagraphVersion, "comments", processType, context, [
             () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
-                var documentUrl = _.last(_.sortBy(version.data[SIParagraph.nick].documents));
+                var documentUrl = _.last(_.sortBy(SIParagraph.get(version).documents));
                 return {
                     commentableUrl: version.path,
                     commentCloseUrl: documentUrl,

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Process/Process.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Process/Process.ts
@@ -44,20 +44,20 @@ var postCreate = (
     };
     process.parent = poolPath;
 
-    process.data[SIName.nick] = new SIName.Sheet({
+    SIName.set(process, {
         name: scope.data.title
     });
-    process.data[SITitle.nick] = new SITitle.Sheet({
+    SITitle.set(process, {
         title: "Bebauungsplan " + scope.data.title
     });
-    process.data[SIProcessSettings.nick] = new SIProcessSettings.Sheet({
+    SIProcessSettings.set(process, {
         participation_kind: scope.data.kind,
         plan_number: scope.data.title
     });
-    process.data[SIProcessPrivateSettings.nick] = new SIProcessPrivateSettings.Sheet({
+    SIProcessPrivateSettings.set(process, {
         office_worker_email: scope.data.officeWorkerEmail
     });
-    process.data[SIWorkflowAssignment.nick] = new SIWorkflowAssignment.Sheet({
+    SIWorkflowAssignment.set(process, {
         state_data: [{
             start_date: scope.data.startDate,
             name: "participate",

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Process/Process.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Process/Process.ts
@@ -4,6 +4,8 @@ import * as AdhConfig from "../../../Core/Config/Config";
 import * as AdhHttp from "../../../Core/Http/Http";
 import * as AdhPreliminaryNames from "../../../Core/PreliminaryNames/PreliminaryNames";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import * as SIName from "../../../../Resources_/adhocracy_core/sheets/name/IName";
 import * as SIProcessPrivateSettings from "../../../../Resources_/adhocracy_meinberlin/sheets/bplan/IProcessPrivateSettings";
 import * as SIProcessSettings from "../../../../Resources_/adhocracy_meinberlin/sheets/bplan/IProcessSettings";
@@ -35,7 +37,11 @@ var postCreate = (
     scope : IScope,
     poolPath : string
 ) => {
-    var process = new RIProcess({preliminaryNames: adhPreliminaryNames});
+    var process : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIProcess.content_type,
+        data: {},
+    };
     process.parent = poolPath;
 
     process.data[SIName.nick] = new SIName.Sheet({

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Proposal/Proposal.ts
@@ -130,7 +130,7 @@ export var embedDirective = (
             };
 
             adhHttp.get(scope.path).then((resource) => {
-                var sheet = resource.data[SIWorkflow.nick];
+                var sheet = SIWorkflow.get(resource);
                 scope.currentPhase = sheet.workflow_state;
                 scope.announceText = AdhProcess.getStateData(sheet, "announce").description;
                 scope.frozenText = AdhProcess.getStateData(sheet, "frozen").description;

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Proposal/Proposal.ts
@@ -53,10 +53,10 @@ var postCreate = (
         data: {},
     };
     proposalVersion.parent = proposal.path;
-    proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(proposalVersion, {
         follows: [proposal.first_version_path]
     });
-    proposalVersion.data[SIProposal.nick] = new SIProposal.Sheet({
+    SIProposal.set(proposalVersion, {
         name: scope.data.name,
         street_number: scope.data.street,
         postal_code_city: scope.data.city,

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Proposal/Proposal.ts
@@ -5,6 +5,8 @@ import * as AdhHttp from "../../../Core/Http/Http";
 import * as AdhPreliminaryNames from "../../../Core/PreliminaryNames/PreliminaryNames";
 import * as AdhProcess from "../../../Core/Process/Process";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RIProposal from "../../../../Resources_/adhocracy_meinberlin/resources/bplan/IProposal";
 import RIProposalVersion from "../../../../Resources_/adhocracy_meinberlin/resources/bplan/IProposalVersion";
 import * as SIProposal from "../../../../Resources_/adhocracy_meinberlin/sheets/bplan/IProposal";
@@ -38,10 +40,18 @@ var postCreate = (
     scope : IScope,
     poolPath : string
 ) : angular.IPromise<any> => {
-    var proposal = new RIProposal({preliminaryNames: adhPreliminaryNames});
+    var proposal : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIProposal.content_type,
+        data: {},
+    };
     proposal.parent = poolPath;
 
-    var proposalVersion = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
+    var proposalVersion : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIProposalVersion.content_type,
+        data: {},
+    };
     proposalVersion.parent = proposal.path;
     proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
         follows: [proposal.first_version_path]

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
@@ -40,7 +40,7 @@ export var workbenchDirective = (
             scope.$watch("processUrl", (processUrl) => {
                 if (processUrl) {
                     adhHttp.get(processUrl).then((resource) => {
-                        scope.currentPhase = resource.data[SIWorkflow.nick].workflow_state;
+                        scope.currentPhase = SIWorkflow.get(resource).workflow_state;
                     });
                 }
             });
@@ -141,8 +141,8 @@ export var detailDirective = (
             scope.$watch("path", (value : string) => {
                 if (value) {
                     adhHttp.get(value).then((resource) => {
-                        scope.data.title = resource.data[SITitle.nick].title;
-                        scope.data.shortDescription = resource.data[SIDescription.nick].short_description;
+                        scope.data.title = SITitle.get(resource).title;
+                        scope.data.shortDescription = SIDescription.get(resource).short_description;
                     });
                 }
             });

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
@@ -9,6 +9,8 @@ import * as AdhPermissions from "../../../Core/Permissions/Permissions";
 import * as AdhResourceArea from "../../../Core/ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../../Core/TopLevelState/TopLevelState";
 
+import * as ResourcesBase from "../../../../ResourcesBase";
+
 import RIPoll from "../../../../Resources_/adhocracy_meinberlin/resources/stadtforum/IPoll";
 import RIProposalVersion from "../../../../Resources_/adhocracy_core/resources/proposal/IProposalVersion";
 import RIStadtforumProcess from "../../../../Resources_/adhocracy_meinberlin/resources/stadtforum/IProcess";
@@ -166,7 +168,7 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide"
         })
         .specific(RIStadtforumProcess, "create_proposal", processType, context, [
-            "adhHttp", (adhHttp : AdhHttp.Service) => (resource : RIStadtforumProcess) => {
+            "adhHttp", (adhHttp : AdhHttp.Service) => (resource : ResourcesBase.IResource) => {
                 return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                     if (!options.canPost(RIPoll.content_type)) {
                         throw 401;
@@ -180,7 +182,7 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide"
         })
         .specificVersionable(RIPoll, RIProposalVersion, "", processType, context, [
-            () => (item : RIPoll, version : RIProposalVersion) => {
+            () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return {
                     proposalUrl: version.path
                 };
@@ -190,7 +192,7 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide"
         })
         .specificVersionable(RIPoll, RIProposalVersion, "edit", processType, context, [
-            "adhHttp", (adhHttp : AdhHttp.Service) => (item : RIPoll, version : RIProposalVersion) => {
+            "adhHttp", (adhHttp : AdhHttp.Service) => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return adhHttp.options(item.path).then((options : AdhHttp.IOptions) => {
                     if (!options.POST) {
                         throw 401;
@@ -206,7 +208,7 @@ export var registerRoutes = (
             movingColumns: "is-collapse-show-show"
         })
         .specificVersionable(RIPoll, RIProposalVersion, "comments", processType, context, [
-            () => (item : RIPoll, version : RIProposalVersion) => {
+            () => (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return {
                     commentableUrl: version.path,
                     commentCloseUrl: version.path,

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -81,7 +81,7 @@ var bindPath = (
                         rateCount: ratesPro - ratesContra,
                         creator: metadataSheet.creator,
                         creationDate: metadataSheet.item_creation_date,
-                        commentCount: parseInt(SICommentable.get(resource).comments_count, 10),
+                        commentCount: SICommentable.get(resource).comments_count,
                         assignments: assignments
                     };
                 });

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -95,10 +95,10 @@ var fill = (
     scope : IScope,
     proposalVersion : ResourcesBase.IResource
 ) : void => {
-    proposalVersion.data[SITitle.nick] = new SITitle.Sheet({
+    SITitle.set(proposalVersion, {
         title: scope.data.title
     });
-    proposalVersion.data[SIDescription.nick] = new SIDescription.Sheet({
+    SIDescription.set(proposalVersion, {
         description: ""
     });
 };
@@ -123,7 +123,7 @@ var postCreate = (
     };
 
     proposalVersion.parent = proposal.path;
-    proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(proposalVersion, {
         follows: [proposal.first_version_path]
     });
     fill(scope, proposalVersion);
@@ -144,7 +144,7 @@ var postEdit = (
         data: {},
     };
     proposalVersion.parent = AdhUtil.parentPath(oldVersion.path);
-    proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(proposalVersion, {
         follows: [oldVersion.path]
     });
     fill(scope, proposalVersion);

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -9,6 +9,8 @@ import * as AdhRate from "../../../Core/Rate/Rate";
 import * as AdhTopLevelState from "../../../Core/TopLevelState/TopLevelState";
 import * as AdhUtil from "../../../Core/Util/Util";
 
+import * as ResourcesBase from "../../../../ResourcesBase";
+
 import * as SICommentable from "../../../../Resources_/adhocracy_core/sheets/comment/ICommentable";
 import * as SIDescription from "../../../../Resources_/adhocracy_core/sheets/description/IDescription";
 import * as SIMetadata from "../../../../Resources_/adhocracy_core/sheets/metadata/IMetadata";
@@ -91,7 +93,7 @@ var bindPath = (
 
 var fill = (
     scope : IScope,
-    proposalVersion : RIProposalVersion
+    proposalVersion : ResourcesBase.IResource
 ) : void => {
     proposalVersion.data[SITitle.nick] = new SITitle.Sheet({
         title: scope.data.title
@@ -126,7 +128,7 @@ var postEdit = (
     adhPreliminaryNames : AdhPreliminaryNames.Service
 ) => (
     scope : IScope,
-    oldVersion : RIProposalVersion
+    oldVersion : ResourcesBase.IResource
 ) => {
     var proposalVersion = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
     proposalVersion.parent = AdhUtil.parentPath(oldVersion.path);

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -59,10 +59,10 @@ var bindPath = (
             adhHttp.get(value).then((resource) => {
                 scope.resource = resource;
 
-                var titleSheet : SITitle.Sheet = resource.data[SITitle.nick];
-                var descriptionSheet : SIDescription.Sheet = resource.data[SIDescription.nick];
-                var metadataSheet : SIMetadata.Sheet = resource.data[SIMetadata.nick];
-                var rateableSheet : SIRateable.Sheet = resource.data[SIRateable.nick];
+                var titleSheet = SITitle.get(resource);
+                var descriptionSheet = SIDescription.get(resource);
+                var metadataSheet = SIMetadata.get(resource);
+                var rateableSheet = SIRateable.get(resource);
 
                 $q.all([
                     adhRate.fetchAggregatedRates(rateableSheet.post_pool, resource.path),
@@ -81,7 +81,7 @@ var bindPath = (
                         rateCount: ratesPro - ratesContra,
                         creator: metadataSheet.creator,
                         creationDate: metadataSheet.item_creation_date,
-                        commentCount: parseInt(resource.data[SICommentable.nick].comments_count, 10),
+                        commentCount: parseInt(SICommentable.get(resource).comments_count, 10),
                         assignments: assignments
                     };
                 });

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Proposal/Proposal.ts
@@ -110,9 +110,17 @@ var postCreate = (
     scope : IScope,
     poolPath : string
 ) => {
-    var proposal = new RIPoll({preliminaryNames: adhPreliminaryNames});
+    var proposal : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIPoll.content_type,
+        data: {},
+    };
     proposal.parent = poolPath;
-    var proposalVersion = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
+    var proposalVersion : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIProposalVersion.content_type,
+        data: {},
+    };
 
     proposalVersion.parent = proposal.path;
     proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
@@ -130,7 +138,11 @@ var postEdit = (
     scope : IScope,
     oldVersion : ResourcesBase.IResource
 ) => {
-    var proposalVersion = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
+    var proposalVersion : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIProposalVersion.content_type,
+        data: {},
+    };
     proposalVersion.parent = AdhUtil.parentPath(oldVersion.path);
     proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
         follows: [oldVersion.path]

--- a/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
+++ b/src/mercator/mercator/static/js/Packages/Blog/Blog.ts
@@ -5,6 +5,8 @@ import * as AdhPermissions from "../Core/Permissions/Permissions";
 import * as AdhPreliminaryNames from "../Core/PreliminaryNames/PreliminaryNames";
 import * as AdhUtil from "../Core/Util/Util";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RIDocumentVersion from "../../Resources_/adhocracy_core/resources/document/IDocumentVersion";
 
 var pkgLocation = "/Blog";
@@ -127,7 +129,7 @@ export var detailDirective = (
                 return adhSubmitIfValid(scope, element, scope.documentForm, () => {
                     return AdhDocument.postEdit(adhHttp, adhPreliminaryNames, adhUploadImage)(
                         scope, scope.documentVersion, scope.paragraphVersions);
-                }).then((documentVersion : RIDocumentVersion) => {
+                }).then((documentVersion : ResourcesBase.IResource) => {
                     if (typeof scope.onChange !== "undefined") {
                         scope.onChange();
                     }
@@ -214,7 +216,7 @@ export var createDirective = (
             scope.submit = () => {
                 return adhSubmitIfValid(scope, element, scope.documentForm, () => {
                     return AdhDocument.postCreate(adhHttp, adhPreliminaryNames, adhUploadImage)(scope, scope.path);
-                }).then((documentVersion : RIDocumentVersion) => {
+                }).then((documentVersion : ResourcesBase.IResource) => {
 
                     scope.cancel();
 

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -1058,7 +1058,7 @@ export var registerRoutes = (
             space: "content",
             movingColumns: "is-show-show-hide"
         })
-        .specific(RIMercatorProposalVersion, "", processType, context, () => (resource : RIMercatorProposalVersion) => {
+        .specific(RIMercatorProposalVersion, "", processType, context, () => (resource : ResourcesBase.IResource) => {
             return {
                 proposalUrl: resource.path
             };
@@ -1068,7 +1068,7 @@ export var registerRoutes = (
             movingColumns: "is-collapse-show-hide"
         })
         .specific(RIMercatorProposalVersion, "edit", processType, context, ["adhHttp", (adhHttp : AdhHttp.Service) => {
-            return (resource : RIMercatorProposalVersion) => {
+            return (resource : ResourcesBase.IResource) => {
                 var poolPath = AdhUtil.parentPath(resource.path);
 
                 return adhHttp.options(poolPath).then((options : AdhHttp.IOptions) => {
@@ -1087,7 +1087,7 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide",
             proposalTab: "blog"
         })
-        .specific(RIMercatorProposalVersion, "blog", processType, context, () => (resource : RIMercatorProposalVersion) => {
+        .specific(RIMercatorProposalVersion, "blog", processType, context, () => (resource : ResourcesBase.IResource) => {
             return {
                 proposalUrl: resource.path
             };
@@ -1096,7 +1096,7 @@ export var registerRoutes = (
             space: "content",
             movingColumns: "is-collapse-show-show"
         })
-        .specific(RIMercatorProposalVersion, "comments", processType, context, () => (resource : RIMercatorProposalVersion) => {
+        .specific(RIMercatorProposalVersion, "comments", processType, context, () => (resource : ResourcesBase.IResource) => {
             return {
                 proposalUrl: resource.path,
                 commentableUrl: resource.path,
@@ -1112,7 +1112,7 @@ export var registerRoutes = (
                 movingColumns: "is-collapse-show-show"
             })
             .specific(RIMercatorProposalVersion, "comments:" + section, processType, context, () =>
-                (resource : RIMercatorProposalVersion) => {
+                (resource : ResourcesBase.IResource) => {
                     return {
                         proposalUrl: resource.path,
                         commentableUrl: resource.data[SIMercatorSubResources.nick][section],

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -200,7 +200,7 @@ export var countSupporters = (adhHttp : AdhHttp.Service, postPoolPath : string, 
     query[SIRate.nick + ":object"] = objectPath;
     return adhHttp.get(postPoolPath, query)
         .then((response) => {
-            var pool : SIPool.Sheet = response.data[SIPool.nick];
+            var pool = SIPool.get(response);
             return parseInt((<any>pool).count, 10);  // see #261
         });
 };
@@ -304,7 +304,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
         var data = this.initializeScope(instance.scope);
 
         instance.scope.subResourceSelectedState = (key : string) => {
-            var url = mercatorProposalVersion.data[SIMercatorSubResources.nick][key];
+            var url = SIMercatorSubResources.get(mercatorProposalVersion)[key];
             if (!instance.scope.commentableUrl) {
                 return "";
             } else if (instance.scope.commentableUrl === url) {
@@ -318,15 +318,15 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
             return instance.scope.data.winnerBadgeAssignment && instance.scope.data.currentPhase === "result";
         };
 
-        data.user_info.first_name = mercatorProposalVersion.data[SIMercatorUserInfo.nick].personal_name;
-        data.user_info.last_name = mercatorProposalVersion.data[SIMercatorUserInfo.nick].family_name;
-        data.user_info.country = mercatorProposalVersion.data[SIMercatorUserInfo.nick].country;
-        data.user_info.createtime = mercatorProposalVersion.data[SIMetaData.nick].item_creation_date;
-        data.user_info.path = mercatorProposalVersion.data[SIMetaData.nick].creator;
-        data.title = mercatorProposalVersion.data[SITitle.nick].title;
-        data.logbookPoolPath = mercatorProposalVersion.data[SILogbook.nick].logbook_pool;
+        data.user_info.first_name = SIMercatorUserInfo.get(mercatorProposalVersion).personal_name;
+        data.user_info.last_name = SIMercatorUserInfo.get(mercatorProposalVersion).family_name;
+        data.user_info.country = SIMercatorUserInfo.get(mercatorProposalVersion).country;
+        data.user_info.createtime = SIMetaData.get(mercatorProposalVersion).item_creation_date;
+        data.user_info.path = SIMetaData.get(mercatorProposalVersion).creator;
+        data.title = SITitle.get(mercatorProposalVersion).title;
+        data.logbookPoolPath = SILogbook.get(mercatorProposalVersion).logbook_pool;
 
-        var heardFrom : SIMercatorHeardFrom.Sheet = mercatorProposalVersion.data[SIMercatorHeardFrom.nick];
+        var heardFrom = SIMercatorHeardFrom.get(mercatorProposalVersion);
         if (typeof heardFrom !== "undefined") {
             data.heard_from = {
                 colleague: heardFrom.heard_from_colleague,
@@ -338,11 +338,11 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
             };
         }
 
-        data.commentCount = mercatorProposalVersion.data[SICommentable.nick].comments_count;
+        data.commentCount = SICommentable.get(mercatorProposalVersion).comments_count;
         data.commentCountTotal = data.commentCount;
 
         data.supporterCount = 0;
-        countSupporters(this.adhHttp, mercatorProposalVersion.data[SILikeable.nick].post_pool, mercatorProposalVersion.path)
+        countSupporters(this.adhHttp, SILikeable.get(mercatorProposalVersion).post_pool, mercatorProposalVersion.path)
             .then((count : number) => { data.supporterCount = count; });
 
         this.adhGetBadges(<any>mercatorProposalVersion).then((assignments : AdhBadge.IBadge[]) => {
@@ -354,7 +354,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
 
         instance.scope.$on("$destroy", <any>this.adhTopLevelState.bind("processState", data, "currentPhase"));
 
-        var subResourcePaths : SIMercatorSubResources.Sheet = mercatorProposalVersion.data[SIMercatorSubResources.nick];
+        var subResourcePaths = SIMercatorSubResources.get(mercatorProposalVersion);
         var subResourcePromises : angular.IPromise<ResourcesBase.IResource[]> = this.$q.all([
             this.adhHttp.get(subResourcePaths.organization_info),
             this.adhHttp.get(subResourcePaths.introduction),
@@ -374,7 +374,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                 switch (subResource.content_type) {
                     case RIMercatorOrganizationInfoVersion.content_type: (() => {
                         var scope = data.organization_info;
-                        var res : SIMercatorOrganizationInfo.Sheet = subResource.data[SIMercatorOrganizationInfo.nick];
+                        var res = SIMercatorOrganizationInfo.get(subResource);
 
                         scope.status_enum = res.status;
                         scope.name = res.name;
@@ -385,31 +385,31 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                         }
                         scope.how_can_we_help_you = res.help_request;
                         scope.status_other = res.status_other;
-                        scope.commentCount = subResource.data[SICommentable.nick].comments_count;
+                        scope.commentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += scope.commentCount;
                     })();
                     break;
                     case RIMercatorIntroductionVersion.content_type: (() => {
                         var scope = data.introduction;
-                        var res : SIMercatorIntroduction.Sheet = subResource.data[SIMercatorIntroduction.nick];
+                        var res = SIMercatorIntroduction.get(subResource);
                         scope.teaser = res.teaser;
                         scope.picture = res.picture;
-                        scope.commentCount = subResource.data[SICommentable.nick].comments_count;
+                        scope.commentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += scope.commentCount;
                     })();
                     break;
                     case RIMercatorDescriptionVersion.content_type: (() => {
                         var scope = data.description;
-                        var res : SIMercatorDescription.Sheet = subResource.data[SIMercatorDescription.nick];
+                        var res = SIMercatorDescription.get(subResource);
 
                         scope.description = res.description;
-                        scope.commentCount = subResource.data[SICommentable.nick].comments_count;
+                        scope.commentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += scope.commentCount;
                     })();
                     break;
                     case RIMercatorLocationVersion.content_type: (() => {
                         var scope = data.location;
-                        var res : SIMercatorLocation.Sheet = subResource.data[SIMercatorLocation.nick];
+                        var res = SIMercatorLocation.get(subResource);
 
                         scope.location_is_specific = res.location_is_specific;
                         scope.location_specific_1 = res.location_specific_1;
@@ -417,61 +417,61 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                         scope.location_specific_3 = res.location_specific_3;
                         scope.location_is_online = res.location_is_online;
                         scope.location_is_linked_to_ruhr = res.location_is_linked_to_ruhr;
-                        scope.commentCount = subResource.data[SICommentable.nick].comments_count;
+                        scope.commentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += scope.commentCount;
                     })();
                     break;
                     case RIMercatorStoryVersion.content_type: (() => {
-                        var res : SIMercatorStory.Sheet = subResource.data[SIMercatorStory.nick];
+                        var res = SIMercatorStory.get(subResource);
                         data.story = res.story;
-                        data.storyCommentCount = subResource.data[SICommentable.nick].comments_count;
+                        data.storyCommentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += data.storyCommentCount;
                     })();
                     break;
                     case RIMercatorOutcomeVersion.content_type: (() => {
-                        var res : SIMercatorOutcome.Sheet = subResource.data[SIMercatorOutcome.nick];
+                        var res = SIMercatorOutcome.get(subResource);
                         data.outcome = res.outcome;
-                        data.outcomeCommentCount = subResource.data[SICommentable.nick].comments_count;
+                        data.outcomeCommentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += data.outcomeCommentCount;
                     })();
                     break;
                     case RIMercatorStepsVersion.content_type: (() => {
-                        var res : SIMercatorSteps.Sheet = subResource.data[SIMercatorSteps.nick];
+                        var res = SIMercatorSteps.get(subResource);
                         data.steps = res.steps;
-                        data.stepsCommentCount = subResource.data[SICommentable.nick].comments_count;
+                        data.stepsCommentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += data.stepsCommentCount;
                     })();
                     break;
                     case RIMercatorValueVersion.content_type: (() => {
-                        var res : SIMercatorValue.Sheet = subResource.data[SIMercatorValue.nick];
+                        var res = SIMercatorValue.get(subResource);
                         data.value = res.value;
-                        data.valueCommentCount = subResource.data[SICommentable.nick].comments_count;
+                        data.valueCommentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += data.valueCommentCount;
                     })();
                     break;
                     case RIMercatorPartnersVersion.content_type: (() => {
-                        var res : SIMercatorPartners.Sheet = subResource.data[SIMercatorPartners.nick];
+                        var res = SIMercatorPartners.get(subResource);
                         data.partners = res.partners;
-                        data.partnersCommentCount = subResource.data[SICommentable.nick].comments_count;
+                        data.partnersCommentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += data.partnersCommentCount;
                     })();
                     break;
                     case RIMercatorFinanceVersion.content_type: (() => {
                         var scope = data.finance;
-                        var res : SIMercatorFinance.Sheet = subResource.data[SIMercatorFinance.nick];
+                        var res = SIMercatorFinance.get(subResource);
 
                         scope.budget = res.budget;
                         scope.requested_funding = res.requested_funding;
                         scope.other_sources = res.other_sources;
                         scope.granted = res.granted;
-                        scope.commentCount = subResource.data[SICommentable.nick].comments_count;
+                        scope.commentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += scope.commentCount;
                     })();
                     break;
                     case RIMercatorExperienceVersion.content_type: (() => {
-                        var res : SIMercatorExperience.Sheet = subResource.data[SIMercatorExperience.nick];
+                        var res = SIMercatorExperience.get(subResource);
                         data.experience = res.experience;
-                        data.experienceCommentCount = subResource.data[SICommentable.nick].comments_count;
+                        data.experienceCommentCount = SICommentable.get(subResource).comments_count;
                         data.commentCountTotal += data.experienceCommentCount;
                     })();
                     break;
@@ -657,7 +657,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                 });
 
                 this.fill(data, version);
-                mercatorProposalVersion.data[SIMercatorSubResources.nick][subresourceKey] = version.path;
+                SIMercatorSubResources.get(mercatorProposalVersion)[subresourceKey] = version.path;
 
                 return [item, version];
             });
@@ -695,17 +695,17 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
 
             this.cleanOrganizationInfo(data);
 
-            return AdhUtil.qFilter(_.map(old.data[SIMercatorSubResources.nick], (path : string, key : string) => {
+            return AdhUtil.qFilter(_.map(SIMercatorSubResources.get(old), (path : string, key : string) => {
                     var deferred = self.$q.defer();
                     self.adhHttp.get(path).then((oldSubresource) => {
                         var subresource = AdhResourceUtil.derive(oldSubresource, {preliminaryNames : self.adhPreliminaryNames});
                         subresource.parent = AdhUtil.parentPath(oldSubresource.path);
                         self.fill(data, subresource);
                         if (AdhResourceUtil.hasEqualContent(oldSubresource, subresource)) {
-                            mercatorProposalVersion.data[SIMercatorSubResources.nick][key] = oldSubresource.path;
+                            SIMercatorSubResources.get(mercatorProposalVersion)[key] = oldSubresource.path;
                             deferred.reject();
                         } else {
-                            mercatorProposalVersion.data[SIMercatorSubResources.nick][key] = subresource.path;
+                            SIMercatorSubResources.get(mercatorProposalVersion)[key] = subresource.path;
                             deferred.resolve(subresource);
                         }
                     });
@@ -877,28 +877,28 @@ export var listItem = (
             scope.data  = {};
             adhHttp.get(scope.path).then((proposal) => {
                 scope.data.user_info = {
-                    first_name: proposal.data[SIMercatorUserInfo.nick].personal_name,
-                    last_name: proposal.data[SIMercatorUserInfo.nick].family_name,
-                    createtime: proposal.data[SIMetaData.nick].item_creation_date,
-                    path: proposal.data[SIMetaData.nick].creator
+                    first_name: SIMercatorUserInfo.get(proposal).personal_name,
+                    last_name: SIMercatorUserInfo.get(proposal).family_name,
+                    createtime: SIMetaData.get(proposal).item_creation_date,
+                    path: SIMetaData.get(proposal).creator
                 };
                 scope.data.title = {
-                    title: proposal.data[SITitle.nick].title
+                    title: SITitle.get(proposal).title
                 };
-                adhHttp.get(proposal.data[SIMercatorSubResources.nick].introduction).then((introduction) => {
+                adhHttp.get(SIMercatorSubResources.get(proposal).introduction).then((introduction) => {
                     scope.data.introduction = {
-                        picture: introduction.data[SIMercatorIntroduction.nick].picture
+                        picture: SIMercatorIntroduction.get(introduction).picture
                     };
                 });
-                adhHttp.get(proposal.data[SIMercatorSubResources.nick].organization_info).then((organizationInfo) => {
+                adhHttp.get(SIMercatorSubResources.get(proposal).organization_info).then((organizationInfo) => {
                     scope.data.organization_info = {
-                        name: organizationInfo.data[SIMercatorOrganizationInfo.nick].name
+                        name: SIMercatorOrganizationInfo.get(organizationInfo).name
                     };
                 });
-                adhHttp.get(proposal.data[SIMercatorSubResources.nick].finance).then((finance) => {
+                adhHttp.get(SIMercatorSubResources.get(proposal).finance).then((finance) => {
                     scope.data.finance = {
-                        budget: finance.data[SIMercatorFinance.nick].budget,
-                        requested_funding: finance.data[SIMercatorFinance.nick].requested_funding
+                        budget: SIMercatorFinance.get(finance).budget,
+                        requested_funding: SIMercatorFinance.get(finance).requested_funding
                     };
                 });
 
@@ -922,7 +922,7 @@ export var listItem = (
                 }));
 
                 // FIXME: does not count comments to sub-resources
-                scope.data.commentCountTotal = proposal.data[SICommentable.nick].comments_count;
+                scope.data.commentCountTotal = SICommentable.get(proposal).comments_count;
             });
 
             countSupporters(adhHttp, AdhUtil.parentPath(scope.path) + "rates/", scope.path).then((count) => {
@@ -1124,7 +1124,7 @@ export var registerRoutes = (
                 (resource : ResourcesBase.IResource) => {
                     return {
                         proposalUrl: resource.path,
-                        commentableUrl: resource.data[SIMercatorSubResources.nick][section],
+                        commentableUrl: SIMercatorSubResources.get(resource)[section],
                         commentCloseUrl: resource.path
                     };
                 }

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -608,11 +608,20 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                 delete data.introduction.picture;
             }
 
-            var mercatorProposal = new RIMercatorProposal({preliminaryNames: this.adhPreliminaryNames});
+            var mercatorProposal = {
+                path: adhPreliminaryNames.nextPreliminary(),
+                first_version_path: adhPreliminaryNames.nextPreliminary(),
+                content_type: RIMercatorProposal.content_type,
+                data: {},
+            };
             mercatorProposal.parent = instance.scope.poolPath;
 
-            var mercatorProposalVersion = new RIMercatorProposalVersion({preliminaryNames: this.adhPreliminaryNames});
-            mercatorProposalVersion.parent = mercatorProposal.path;
+            var mercatorProposalVersion = {
+                path: adhPreliminaryNames.nextPreliminary(),
+                parent: mercatorProposal.path,
+                content_type: RIMercatorProposalVersion.content_type,
+                data: {},
+            };
             mercatorProposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
                 follows: [mercatorProposal.first_version_path]
             });

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Proposal/Proposal.ts
@@ -487,7 +487,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
 
         switch (resource.content_type) {
             case RIMercatorOrganizationInfoVersion.content_type:
-                resource.data[SIMercatorOrganizationInfo.nick] = new SIMercatorOrganizationInfo.Sheet({
+                SIMercatorOrganizationInfo.set(resource, {
                     status: data.organization_info.status_enum,
                     name: data.organization_info.name,
                     country: data.organization_info.country,
@@ -498,18 +498,18 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                 });
                 break;
             case RIMercatorIntroductionVersion.content_type:
-                resource.data[SIMercatorIntroduction.nick] = new SIMercatorIntroduction.Sheet({
+                SIMercatorIntroduction.set(resource, {
                     teaser: data.introduction.teaser,
                     picture: data.introduction.picture
                 });
                 break;
             case RIMercatorDescriptionVersion.content_type:
-                resource.data[SIMercatorDescription.nick] = new SIMercatorDescription.Sheet({
+                SIMercatorDescription.set(resource, {
                     description: data.description.description
                 });
                 break;
             case RIMercatorLocationVersion.content_type:
-                resource.data[SIMercatorLocation.nick] = new SIMercatorLocation.Sheet({
+                SIMercatorLocation.set(resource, {
                     location_is_specific: data.location.location_is_specific,
                     location_specific_1: data.location.location_specific_1,
                     location_specific_2: data.location.location_specific_2,
@@ -519,32 +519,32 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                 });
                 break;
             case RIMercatorStoryVersion.content_type:
-                resource.data[SIMercatorStory.nick] = new SIMercatorStory.Sheet({
+                SIMercatorStory.set(resource, {
                     story: data.story
                 });
                 break;
             case RIMercatorOutcomeVersion.content_type:
-                resource.data[SIMercatorOutcome.nick] = new SIMercatorOutcome.Sheet({
+                SIMercatorOutcome.set(resource, {
                     outcome: data.outcome
                 });
                 break;
             case RIMercatorStepsVersion.content_type:
-                resource.data[SIMercatorSteps.nick] = new SIMercatorSteps.Sheet({
+                SIMercatorSteps.set(resource, {
                     steps: data.steps
                 });
                 break;
             case RIMercatorValueVersion.content_type:
-                resource.data[SIMercatorValue.nick] = new SIMercatorValue.Sheet({
+                SIMercatorValue.set(resource, {
                     value: data.value
                 });
                 break;
             case RIMercatorPartnersVersion.content_type:
-                resource.data[SIMercatorPartners.nick] = new SIMercatorPartners.Sheet({
+                SIMercatorPartners.set(resource, {
                     partners: data.partners
                 });
                 break;
             case RIMercatorFinanceVersion.content_type:
-                resource.data[SIMercatorFinance.nick] = new SIMercatorFinance.Sheet({
+                SIMercatorFinance.set(resource, {
                     budget: data.finance.budget,
                     requested_funding: data.finance.requested_funding,
                     other_sources: data.finance.other_sources,
@@ -552,21 +552,21 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                 });
                 break;
             case RIMercatorExperienceVersion.content_type:
-                resource.data[SIMercatorExperience.nick] = new SIMercatorExperience.Sheet({
+                SIMercatorExperience.set(resource, {
                     experience: data.experience
                 });
                 break;
             case RIMercatorProposalVersion.content_type:
-                resource.data[SIMercatorUserInfo.nick] = new SIMercatorUserInfo.Sheet({
+                SIMercatorUserInfo.set(resource, {
                     personal_name: data.user_info.first_name,
                     family_name: data.user_info.last_name,
                     country: data.user_info.country
                 });
-                resource.data[SITitle.nick] = new SITitle.Sheet({
+                SITitle.set(resource, {
                     title: data.title
                 });
                 if (typeof data.heard_from !== "undefined") {
-                    resource.data[SIMercatorHeardFrom.nick] = new SIMercatorHeardFrom.Sheet({
+                    SIMercatorHeardFrom.set(resource, {
                         heard_from_colleague: data.heard_from.colleague,
                         heard_from_website: data.heard_from.website,
                         heard_from_newsletter: data.heard_from.newsletter,
@@ -574,7 +574,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                         heard_elsewhere: (data.heard_from.other ? data.heard_from.other_specify : "")
                     });
                 }
-                resource.data[SIMercatorSubResources.nick] = new SIMercatorSubResources.Sheet(<any>{});
+                SIMercatorSubResources.set(resource, <any>{});
                 break;
         }
 
@@ -622,7 +622,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
                 content_type: RIMercatorProposalVersion.content_type,
                 data: {},
             };
-            mercatorProposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+            SIVersionable.set(mercatorProposalVersion, {
                 follows: [mercatorProposal.first_version_path]
             });
 
@@ -652,7 +652,7 @@ export class Widget<R extends ResourcesBase.IResource> extends AdhResourceWidget
 
                 var version = new versionClass({preliminaryNames: this.adhPreliminaryNames});
                 version.parent = item.path;
-                version.data[SIVersionable.nick] = new SIVersionable.Sheet({
+                SIVersionable.set(version, {
                     follows: [item.first_version_path]
                 });
 

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
@@ -133,7 +133,7 @@ export var proposalListingColumnDirective = (
 
             var processUrl = adhTopLevelState.get("processUrl");
             adhHttp.get(processUrl).then((resource) => {
-                var currentPhase = resource.data[SIWorkflow.nick].workflow_state;
+                var currentPhase = SIWorkflow.get(resource).workflow_state;
 
                 if (typeof scope.facets === "undefined") {
                     scope.facets = [{
@@ -200,7 +200,7 @@ export var registerRoutes = (
                 if (resource.content_type !== RICommentVersion.content_type) {
                     return $q.when(resource);
                 } else {
-                    var url = resource.data[SIComment.nick].refers_to;
+                    var url = SIComment.get(resource).refers_to;
                     return adhHttp.get(url).then(getCommentableUrl);
                 }
             };

--- a/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2015/Workbench/Workbench.ts
@@ -8,6 +8,8 @@ import * as AdhResourceArea from "../../../Core/ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../../Core/TopLevelState/TopLevelState";
 import * as AdhUtil from "../../../Core/Util/Util";
 
+import * as ResourcesBase from "../../../../ResourcesBase";
+
 import RICommentVersion from "../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
 import RIMercatorProposalVersion from "../../../../Resources_/adhocracy_mercator/resources/mercator/IMercatorProposalVersion";
 import RIProcess from "../../../../Resources_/adhocracy_mercator/resources/mercator/IProcess";
@@ -190,7 +192,7 @@ export var registerRoutes = (
         .specific(RICommentVersion, "", processType, context, ["adhHttp", "$q", (
             adhHttp : AdhHttp.Service,
             $q : angular.IQService
-        ) => (resource : RICommentVersion) => {
+        ) => (resource : ResourcesBase.IResource) => {
             var specifics = {};
             specifics["commentUrl"] = resource.path;
 
@@ -232,7 +234,7 @@ export var registerRoutes = (
         })
         .specific(RIProcess, "create_proposal", processType, context, ["adhHttp",
             (adhHttp : AdhHttp.Service) => {
-                return (resource : RIProcess) => {
+                return (resource : ResourcesBase.IResource) => {
                     return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                         if (!options.POST) {
                             throw 401;

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -358,7 +358,11 @@ var create = (
 ) => (scope) => {
     var data : IFormData = scope.data;
     return adhHttp.withTransaction((transaction) => {
-        var proposal = new RIMercatorProposal({preliminaryNames: adhPreliminaryNames});
+        var proposal : ResourcesBase.IResource = {
+            path: adhPreliminaryNames.nextPreliminary(),
+            content_type: RIMercatorProposal.content_type,
+            data: {},
+        };
         fill(data, proposal);
         var proposalRequest = transaction.post(scope.poolPath, proposal);
 
@@ -383,7 +387,11 @@ var create = (
             subResourcesSheet[subresourceKey] = request.path;
         });
 
-        var proposal2 = new RIMercatorProposal({preliminaryNames: adhPreliminaryNames});
+        var proposal2 : ResourcesBase.IResource = {
+            path: adhPreliminaryNames.nextPreliminary(),
+            content_type: RIMercatorProposal.content_type,
+            data: {},
+        };
         proposal2.data[SIMercatorSubResources.nick] = subResourcesSheet;
         transaction.put(proposalRequest.path, proposal2);
 
@@ -402,7 +410,11 @@ var edit = (
         var subResourcesSheet : SIMercatorSubResources.Sheet = oldProposal.data[SIMercatorSubResources.nick];
 
         return adhHttp.withTransaction((transaction) => {
-            var proposal = new RIMercatorProposal({preliminaryNames: adhPreliminaryNames});
+            var proposal : ResourcesBase.IResource = {
+                path: adhPreliminaryNames.nextPreliminary(),
+                content_type: RIMercatorProposal.content_type,
+                data: {},
+            };
             fill(data, proposal);
             // ICommunity can and should not be changed on edit
             delete proposal.data[SICommunity.nick];

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -221,11 +221,11 @@ export interface IFormData extends IData {
 var fill = (data : IFormData, resource) => {
     switch (resource.content_type) {
         case RIMercatorProposal.content_type:
-            resource.data[SIUserInfo.nick] = new SIUserInfo.Sheet({
+            SIUserInfo.set(resource, {
                 first_name: data.userInfo.firstName,
                 last_name: data.userInfo.lastName
             });
-            resource.data[SIOrganizationInfo.nick] = new SIOrganizationInfo.Sheet({
+            SIOrganizationInfo.set(resource, {
                 name: data.organizationInfo.name,
                 city: data.organizationInfo.city,
                 country: data.organizationInfo.country,
@@ -235,7 +235,7 @@ var fill = (data : IFormData, resource) => {
                 status: data.organizationInfo.status,
                 status_other: data.organizationInfo.otherText
             });
-            resource.data[SITopic.nick] = new SITopic.Sheet({
+            SITopic.set(resource, {
                 topic: _.reduce(<any>data.topic, (result, include, topic) => {
                     if (include && (topic !== "otherText")) {
                         result.push(topic);
@@ -244,28 +244,28 @@ var fill = (data : IFormData, resource) => {
                 }, []),
                 topic_other: data.topic.otherText
             });
-            resource.data[SITitle.nick] = new SITitle.Sheet({
+            SITitle.set(resource, {
                 title: data.title
             });
-            resource.data[SILocation.nick] = new SILocation.Sheet({
+            SILocation.set(resource, {
                 location: data.location.location_specific,
                 is_online: !!data.location.location_is_online,
                 has_link_to_ruhr: !!data.location.location_is_linked_to_ruhr,
                 link_to_ruhr: data.location.location_is_linked_to_ruhr_text
             });
-            resource.data[SIStatus.nick] = new SIStatus.Sheet({
+            SIStatus.set(resource, {
                 status: data.status
             });
-            resource.data[SIFinancialPlanning.nick] = new SIFinancialPlanning.Sheet({
+            SIFinancialPlanning.set(resource, {
                 budget: data.finance.budget,
                 requested_funding: data.finance.requestedFunding,
                 major_expenses: data.finance.major
             });
-            resource.data[SIExtraFunding.nick] = new SIExtraFunding.Sheet({
+            SIExtraFunding.set(resource, {
                 other_sources: data.finance.otherSources,
                 secured: !!data.finance.secured
             });
-            resource.data[SICommunity.nick] = new SICommunity.Sheet({
+            SICommunity.set(resource, {
                 expected_feedback: data.experience,
                 heard_froms: _.reduce(<any>data.heardFrom, (result, include, item) => {
                     if (include && item !== "otherText" ) {
@@ -275,17 +275,17 @@ var fill = (data : IFormData, resource) => {
                 }, []),
                 heard_from_other: data.heardFrom.otherText
             });
-            resource.data[SIImageReference.nick] = new SIImageReference.Sheet({
+            SIImageReference.set(resource, {
                 picture: data.introduction.picture
             });
             break;
         case RIPitch.content_type:
-            resource.data[SIPitch.nick] = new SIPitch.Sheet({
+            SIPitch.set(resource, {
                 pitch: data.introduction.pitch
             });
             break;
         case RIPartners.content_type:
-            resource.data[SIPartners.nick] = new SIPartners.Sheet({
+            SIPartners.set(resource, {
                 has_partners: (<any>data.partners.hasPartners === "true" ? true : false),
                 partner1_name: data.partners.partner1.name,
                 partner1_website: data.partners.partner1.website,
@@ -300,52 +300,52 @@ var fill = (data : IFormData, resource) => {
             });
             break;
         case RIDuration.content_type:
-            resource.data[SIDuration.nick] = new SIDuration.Sheet({
+            SIDuration.set(resource, {
                 duration: data.duration
             });
             break;
         case RIChallenge.content_type:
-            resource.data[SIChallenge.nick] = new SIChallenge.Sheet({
+            SIChallenge.set(resource, {
                 challenge: data.impact.challenge
             });
             break;
         case RIGoal.content_type:
-            resource.data[SIGoal.nick] = new SIGoal.Sheet({
+            SIGoal.set(resource, {
                 goal: data.impact.goal
             });
             break;
         case RIPlan.content_type:
-            resource.data[SIPlan.nick] = new SIPlan.Sheet({
+            SIPlan.set(resource, {
                 plan: data.impact.plan
             });
             break;
         case RITarget.content_type:
-            resource.data[SITarget.nick] = new SITarget.Sheet({
+            SITarget.set(resource, {
                 target: data.impact.target
             });
             break;
         case RITeam.content_type:
-            resource.data[SITeam.nick] = new SITeam.Sheet({
+            SITeam.set(resource, {
                 team: data.impact.team
             });
             break;
         case RIExtraInfo.content_type:
-            resource.data[SIExtraInfo.nick] = new SIExtraInfo.Sheet({
+            SIExtraInfo.set(resource, {
                 extrainfo: data.impact.extraInfo
             });
             break;
         case RIConnectionCohesion.content_type:
-            resource.data[SIConnectionCohesion.nick] = new SIConnectionCohesion.Sheet({
+            SIConnectionCohesion.set(resource, {
                 connection_cohesion: data.criteria.strengthen
             });
             break;
         case RIDifference.content_type:
-            resource.data[SIDifference.nick] = new SIDifference.Sheet({
+            SIDifference.set(resource, {
                 difference: data.criteria.difference
             });
             break;
         case RIPracticalRelevance.content_type:
-            resource.data[SIPracticalRelevance.nick] = new SIPracticalRelevance.Sheet({
+            SIPracticalRelevance.set(resource, {
                 practicalrelevance: data.criteria.practical
             });
             break;
@@ -366,7 +366,7 @@ var create = (
         fill(data, proposal);
         var proposalRequest = transaction.post(scope.poolPath, proposal);
 
-        var subResourcesSheet = new SIMercatorSubResources.Sheet(<any>{});
+        var subResourcesSheet = <any>{};
         _.forEach({
             pitch: RIPitch,
             partners: RIPartners,
@@ -392,7 +392,7 @@ var create = (
             content_type: RIMercatorProposal.content_type,
             data: {},
         };
-        proposal2.data[SIMercatorSubResources.nick] = subResourcesSheet;
+        SIMercatorSubResources.set(proposal2, subResourcesSheet);
         transaction.put(proposalRequest.path, proposal2);
 
         return transaction.commit().then((responses) => {
@@ -462,7 +462,7 @@ var moderate = (
             content_type: oldProposal.content_type,
             data: {}
         };
-        clone.data[SIWinnerInfo.nick] = new SIWinnerInfo.Sheet({
+        SIWinnerInfo.set(clone, {
             funding: scope.data.winner.funding
         });
         var resourcePromise = adhHttp.put(scope.path, clone);

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -11,6 +11,8 @@ import * as AdhTopLevelState from "../../../Core/TopLevelState/TopLevelState";
 
 import * as AdhMercator2015Proposal from "../../2015/Proposal/Proposal";
 
+import * as ResourcesBase from "../../../../ResourcesBase";
+
 import * as SIBadgeable from "../../../../Resources_/adhocracy_core/sheets/badge/IBadgeable";
 import * as SIBadgeAssignment from "../../../../Resources_/adhocracy_core/sheets/badge/IBadgeAssignment";
 import * as SIChallenge from "../../../../Resources_/adhocracy_mercator/sheets/mercator2/IChallenge";
@@ -503,18 +505,18 @@ var get = (
 ) => (path : string) : ng.IPromise<IDetailData> => {
     return adhHttp.get(path).then((proposal) => {
         var subs : {
-            pitch : RIPitch;
-            partners : RIPartners;
-            duration : RIDuration;
-            challenge : RIChallenge;
-            goal : RIGoal;
-            plan : RIPlan;
-            target : RITarget;
-            team : RITeam;
-            extrainfo : RIExtraInfo;
-            connectioncohesion : RIConnectionCohesion;
-            difference : RIDifference;
-            practicalrelevance : RIPracticalRelevance;
+            pitch : ResourcesBase.IResource
+            partners : ResourcesBase.IResource
+            duration : ResourcesBase.IResource
+            challenge : ResourcesBase.IResource
+            goal : ResourcesBase.IResource
+            plan : ResourcesBase.IResource
+            target : ResourcesBase.IResource
+            team : ResourcesBase.IResource
+            extrainfo : ResourcesBase.IResource
+            connectioncohesion : ResourcesBase.IResource
+            difference : ResourcesBase.IResource
+            practicalrelevance : ResourcesBase.IResource
         } = <any>{};
 
         return $q.all(_.map(proposal.data[SIMercatorSubResources.nick], (path, key) => {

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Proposal/Proposal.ts
@@ -407,7 +407,7 @@ var edit = (
 ) => (scope) => {
     var data : IFormData = scope.data;
     return adhHttp.get(scope.path).then((oldProposal) => {
-        var subResourcesSheet : SIMercatorSubResources.Sheet = oldProposal.data[SIMercatorSubResources.nick];
+        var subResourcesSheet = SIMercatorSubResources.get(oldProposal);
 
         return adhHttp.withTransaction((transaction) => {
             var proposal : ResourcesBase.IResource = {
@@ -417,7 +417,7 @@ var edit = (
             };
             fill(data, proposal);
             // ICommunity can and should not be changed on edit
-            delete proposal.data[SICommunity.nick];
+            delete SICommunity.get(proposal);
             transaction.put(oldProposal.path, proposal);
 
             _.forEach({
@@ -467,14 +467,14 @@ var moderate = (
         });
         var resourcePromise = adhHttp.put(scope.path, clone);
 
-        var badgePoolPath = oldProposal.data[SIBadgeable.nick].post_pool;
-        var assignmentRequests = _.map(oldProposal.data[SIBadgeable.nick].assignments, (p : string) => adhHttp.get(p));
+        var badgePoolPath = SIBadgeable.get(oldProposal).post_pool;
+        var assignmentRequests = _.map(SIBadgeable.get(oldProposal).assignments, (p : string) => adhHttp.get(p));
         var badgePromise = $q.all(assignmentRequests).then((assignments) => {
             var communityAssignment = <any>_.find(assignments, (a : any) => {
-                return a.data[SIBadgeAssignment.nick].badge === badges.community;
+                return SIBadgeAssignment.get(a).badge === badges.community;
             });
             var winningAssignment = <any>_.find(assignments, (a : any) => {
-                return a.data[SIBadgeAssignment.nick].badge === badges.winning;
+                return SIBadgeAssignment.get(a).badge === badges.winning;
             });
             var badgeAssignment = communityAssignment || winningAssignment;
 
@@ -484,7 +484,7 @@ var moderate = (
                     content_type: RIBadgeAssignment.content_type,
                     data: {}
                 };
-                postdata.data[SIDescription.nick] = {
+                SIDescription.get(postdata) = {
                     description: scope.data.winner.description
                 };
                 return adhHttp.put(badgeAssignment.path, postdata);
@@ -493,10 +493,10 @@ var moderate = (
                     content_type: RIBadgeAssignment.content_type,
                     data: {}
                 };
-                postdata.data[SIDescription.nick] = {
+                SIDescription.get(postdata) = {
                     description: scope.data.winner.description
                 };
-                postdata.data[SIBadgeAssignment.nick] = {
+                SIBadgeAssignment.get(postdata) = {
                     badge: badges[scope.data.winner.name],
                     object: scope.path,
                     subject: adhCredentials.userPath
@@ -531,7 +531,7 @@ var get = (
             practicalrelevance : ResourcesBase.IResource
         } = <any>{};
 
-        return $q.all(_.map(proposal.data[SIMercatorSubResources.nick], (path, key) => {
+        return $q.all(_.map(SIMercatorSubResources.get(proposal), (path, key) => {
             return adhHttp.get(<string>path).then((subresource) => {
                 subs[key] = subresource;
             });
@@ -546,118 +546,118 @@ var get = (
             })
         ])).then((args : any[]) : IDetailData => {
             var commentCounts = {
-                proposal: proposal.data[SICommentable.nick].comments_count,
-                pitch: subs.pitch.data[SICommentable.nick].comments_count,
-                partners: subs.partners.data[SICommentable.nick].comments_count,
-                duration: subs.duration.data[SICommentable.nick].comments_count,
-                challenge: subs.challenge.data[SICommentable.nick].comments_count,
-                goal: subs.goal.data[SICommentable.nick].comments_count,
-                plan: subs.plan.data[SICommentable.nick].comments_count,
-                target: subs.target.data[SICommentable.nick].comments_count,
-                team: subs.team.data[SICommentable.nick].comments_count,
-                extrainfo: subs.extrainfo.data[SICommentable.nick].comments_count,
-                connectioncohesion: subs.connectioncohesion.data[SICommentable.nick].comments_count,
-                difference: subs.difference.data[SICommentable.nick].comments_count,
-                practicalrelevance: subs.practicalrelevance.data[SICommentable.nick].comments_count
+                proposal: SICommentable.get(proposal).comments_count,
+                pitch: SICommentable.get(subs.pitch).comments_count,
+                partners: SICommentable.get(subs.partners).comments_count,
+                duration: SICommentable.get(subs.duration).comments_count,
+                challenge: SICommentable.get(subs.challenge).comments_count,
+                goal: SICommentable.get(subs.goal).comments_count,
+                plan: SICommentable.get(subs.plan).comments_count,
+                target: SICommentable.get(subs.target).comments_count,
+                team: SICommentable.get(subs.team).comments_count,
+                extrainfo: SICommentable.get(subs.extrainfo).comments_count,
+                connectioncohesion: SICommentable.get(subs.connectioncohesion).comments_count,
+                difference: SICommentable.get(subs.difference).comments_count,
+                practicalrelevance: SICommentable.get(subs.practicalrelevance).comments_count
             };
 
             return {
                 supporterCount: args[0],
 
-                creationDate: proposal.data[SIMetaData.nick].item_creation_date,
-                creator: proposal.data[SIMetaData.nick].creator,
-                logbookPoolPath: proposal.data[SILogbook.nick].logbook_pool,
+                creationDate: SIMetaData.get(proposal).item_creation_date,
+                creator: SIMetaData.get(proposal).creator,
+                logbookPoolPath: SILogbook.get(proposal).logbook_pool,
 
                 userInfo: {
-                    firstName: proposal.data[SIMercatorUserInfo.nick].first_name,
-                    lastName: proposal.data[SIMercatorUserInfo.nick].last_name
+                    firstName: SIMercatorUserInfo.get(proposal).first_name,
+                    lastName: SIMercatorUserInfo.get(proposal).last_name
                 },
                 organizationInfo: {
-                    name: proposal.data[SIOrganizationInfo.nick].name,
-                    city: proposal.data[SIOrganizationInfo.nick].city,
-                    country: proposal.data[SIOrganizationInfo.nick].country,
-                    helpRequest: proposal.data[SIOrganizationInfo.nick].help_request,
-                    registrationDate: proposal.data[SIOrganizationInfo.nick].registration_date,
-                    website: proposal.data[SIOrganizationInfo.nick].website,
-                    status: proposal.data[SIOrganizationInfo.nick].status,
-                    otherText: proposal.data[SIOrganizationInfo.nick].status_other
+                    name: SIOrganizationInfo.get(proposal).name,
+                    city: SIOrganizationInfo.get(proposal).city,
+                    country: SIOrganizationInfo.get(proposal).country,
+                    helpRequest: SIOrganizationInfo.get(proposal).help_request,
+                    registrationDate: SIOrganizationInfo.get(proposal).registration_date,
+                    website: SIOrganizationInfo.get(proposal).website,
+                    status: SIOrganizationInfo.get(proposal).status,
+                    otherText: SIOrganizationInfo.get(proposal).status_other
                 },
                 topic: <any>_.reduce(<any>topics, (result, key : string) => {
-                    result[key] = _.indexOf(proposal.data[SITopic.nick].topic, key) !== -1;
+                    result[key] = _.indexOf(SITopic.get(proposal).topic, key) !== -1;
                     return result;
                 }, {
-                    otherText: proposal.data[SITopic.nick].topic_other
+                    otherText: SITopic.get(proposal).topic_other
                 }),
-                selectedTopics: _.map(proposal.data[SITopic.nick].topic, (topic : string) => {
+                selectedTopics: _.map(SITopic.get(proposal).topic, (topic : string) => {
                     if (topic === "other") {
-                        return proposal.data[SITopic.nick].topic_other;
+                        return SITopic.get(proposal).topic_other;
                     } else {
                         return topicTrString(topic);
                     }
                 }),
-                title: proposal.data[SITitle.nick].title,
+                title: SITitle.get(proposal).title,
                 location: {
-                    location_is_specific: !!proposal.data[SILocation.nick].location,
-                    location_specific: proposal.data[SILocation.nick].location,
-                    location_is_online: proposal.data[SILocation.nick].is_online,
-                    location_is_linked_to_ruhr: proposal.data[SILocation.nick].has_link_to_ruhr,
-                    location_is_linked_to_ruhr_text: proposal.data[SILocation.nick].link_to_ruhr
+                    location_is_specific: !!SILocation.get(proposal).location,
+                    location_specific: SILocation.get(proposal).location,
+                    location_is_online: SILocation.get(proposal).is_online,
+                    location_is_linked_to_ruhr: SILocation.get(proposal).has_link_to_ruhr,
+                    location_is_linked_to_ruhr_text: SILocation.get(proposal).link_to_ruhr
                 },
-                status: proposal.data[SIStatus.nick].status,
+                status: SIStatus.get(proposal).status,
                 finance: {
-                    budget: proposal.data[SIFinancialPlanning.nick].budget,
-                    requestedFunding: proposal.data[SIFinancialPlanning.nick].requested_funding,
-                    major: proposal.data[SIFinancialPlanning.nick].major_expenses,
-                    otherSources: (proposal.data[SIExtraFunding.nick] || {}).other_sources,
-                    secured: (proposal.data[SIExtraFunding.nick] || {}).secured
+                    budget: SIFinancialPlanning.get(proposal).budget,
+                    requestedFunding: SIFinancialPlanning.get(proposal).requested_funding,
+                    major: SIFinancialPlanning.get(proposal).major_expenses,
+                    otherSources: (SIExtraFunding.get(proposal) || {}).other_sources,
+                    secured: (SIExtraFunding.get(proposal) || {}).secured
                 },
-                experience: proposal.data[SICommunity.nick].expected_feedback,
-                heardFrom: _.reduce(proposal.data[SICommunity.nick].heard_froms, (result, item : string) => {
+                experience: SICommunity.get(proposal).expected_feedback,
+                heardFrom: _.reduce(SICommunity.get(proposal).heard_froms, (result, item : string) => {
                     result[item] = true;
                     return result;
                 }, {}),
                 winner: {
-                    funding: (proposal.data[SIWinnerInfo.nick] || {}).funding,
+                    funding: (SIWinnerInfo.get(proposal) || {}).funding,
                     description: (args[1] || {}).description,
                     name: (args[1] || {}).name
                 },
                 introduction: {
-                    pitch: subs.pitch.data[SIPitch.nick].pitch,
-                    picture: proposal.data[SIImageReference.nick].picture
+                    pitch: SIPitch.get(subs.pitch).pitch,
+                    picture: SIImageReference.get(proposal).picture
                 },
                 partners: {
-                    hasPartners: subs.partners.data[SIPartners.nick].has_partners,
+                    hasPartners: SIPartners.get(subs.partners).has_partners,
                     partner1: {
-                        name: subs.partners.data[SIPartners.nick].partner1_name,
-                        website: subs.partners.data[SIPartners.nick].partner1_website,
-                        country: subs.partners.data[SIPartners.nick].partner1_country
+                        name: SIPartners.get(subs.partners).partner1_name,
+                        website: SIPartners.get(subs.partners).partner1_website,
+                        country: SIPartners.get(subs.partners).partner1_country
                     },
                     partner2: {
-                        name: subs.partners.data[SIPartners.nick].partner2_name,
-                        website: subs.partners.data[SIPartners.nick].partner2_website,
-                        country: subs.partners.data[SIPartners.nick].partner2_country
+                        name: SIPartners.get(subs.partners).partner2_name,
+                        website: SIPartners.get(subs.partners).partner2_website,
+                        country: SIPartners.get(subs.partners).partner2_country
                     },
                     partner3: {
-                        name: subs.partners.data[SIPartners.nick].partner3_name,
-                        website: subs.partners.data[SIPartners.nick].partner3_website,
-                        country: subs.partners.data[SIPartners.nick].partner3_country
+                        name: SIPartners.get(subs.partners).partner3_name,
+                        website: SIPartners.get(subs.partners).partner3_website,
+                        country: SIPartners.get(subs.partners).partner3_country
                     },
-                    hasOther: !!subs.partners.data[SIPartners.nick].other_partners,
-                    otherText: subs.partners.data[SIPartners.nick].other_partners
+                    hasOther: !!SIPartners.get(subs.partners).other_partners,
+                    otherText: SIPartners.get(subs.partners).other_partners
                 },
-                duration: subs.duration.data[SIDuration.nick].duration,
+                duration: SIDuration.get(subs.duration).duration,
                 impact: {
-                    challenge: subs.challenge.data[SIChallenge.nick].challenge,
-                    goal: subs.goal.data[SIGoal.nick].goal,
-                    plan: subs.plan.data[SIPlan.nick].plan,
-                    target: subs.target.data[SITarget.nick].target,
-                    team: subs.team.data[SITeam.nick].team,
-                    extraInfo: subs.extrainfo.data[SIExtraInfo.nick].extrainfo
+                    challenge: SIChallenge.get(subs.challenge).challenge,
+                    goal: SIGoal.get(subs.goal).goal,
+                    plan: SIPlan.get(subs.plan).plan,
+                    target: SITarget.get(subs.target).target,
+                    team: SITeam.get(subs.team).team,
+                    extraInfo: SIExtraInfo.get(subs.extrainfo).extrainfo
                 },
                 criteria: {
-                    strengthen: subs.connectioncohesion.data[SIConnectionCohesion.nick].connection_cohesion,
-                    difference: subs.difference.data[SIDifference.nick].difference,
-                    practical: subs.practicalrelevance.data[SIPracticalRelevance.nick].practicalrelevance
+                    strengthen: SIConnectionCohesion.get(subs.connectioncohesion).connection_cohesion,
+                    difference: SIDifference.get(subs.difference).difference,
+                    practical: SIPracticalRelevance.get(subs.practicalrelevance).practicalrelevance
                 },
                 commentCounts: commentCounts,
                 commentCountTotal: _.sum(_.values(commentCounts))

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
@@ -166,7 +166,7 @@ export var proposalListingColumnDirective = (
 
             var processUrl = adhTopLevelState.get("processUrl");
             adhHttp.get(processUrl).then((resource) => {
-                var currentPhase = resource.data[SIWorkflow.nick].workflow_state;
+                var currentPhase = SIWorkflow.get(resource).workflow_state;
 
                 scope.sort = "item_creation_date";
                 scope.setSort = (sort : string) => {
@@ -263,7 +263,7 @@ export var registerRoutes = (
                 if (resource.content_type !== RICommentVersion.content_type) {
                     return $q.when(resource);
                 } else {
-                    var url = resource.data[SIComment.nick].refers_to;
+                    var url = SIComment.get(resource).refers_to;
                     return adhHttp.get(url).then(getCommentableUrl);
                 }
             };
@@ -393,7 +393,7 @@ export var registerRoutes = (
                 (resource : ResourcesBase.IResource) => {
                     return {
                         proposalUrl: resource.path,
-                        commentableUrl: resource.data[SIMercatorSubResources.nick][section],
+                        commentableUrl: SIMercatorSubResources.get(resource)[section],
                         commentCloseUrl: resource.path
                     };
                 }

--- a/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
+++ b/src/mercator/mercator/static/js/Packages/Mercator/2016/Workbench/Workbench.ts
@@ -11,6 +11,8 @@ import * as AdhUtil from "../../../Core/Util/Util";
 
 import * as AdhMercator2015Workbench from "../../2015/Workbench/Workbench";
 
+import * as ResourcesBase from "../../../../ResourcesBase";
+
 import RICommentVersion from "../../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
 import RIProcess from "../../../../Resources_/adhocracy_mercator/resources/mercator2/IProcess";
 import RIProposal from "../../../../Resources_/adhocracy_mercator/resources/mercator2/IMercatorProposal";
@@ -253,7 +255,7 @@ export var registerRoutes = (
         .specific(RICommentVersion, "", processType, context, ["adhHttp", "$q", (
             adhHttp : AdhHttp.Service,
             $q : angular.IQService
-        ) => (resource : RICommentVersion) => {
+        ) => (resource : ResourcesBase.IResource) => {
             var specifics = {};
             specifics["commentUrl"] = resource.path;
 
@@ -295,7 +297,7 @@ export var registerRoutes = (
         })
         .specific(RIProcess, "create_proposal", processType, context, ["adhHttp",
             (adhHttp : AdhHttp.Service) => {
-                return (resource : RIProcess) => {
+                return (resource : ResourcesBase.IResource) => {
                     return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                         if (!options.POST) {
                             throw 401;
@@ -310,7 +312,7 @@ export var registerRoutes = (
             space: "content",
             movingColumns: "is-show-show-hide"
         })
-        .specific(RIProposal, "", processType, context, () => (resource : RIProposal) => {
+        .specific(RIProposal, "", processType, context, () => (resource : ResourcesBase.IResource) => {
             return {
                 proposalUrl: resource.path
             };
@@ -319,7 +321,7 @@ export var registerRoutes = (
             space: "content",
             movingColumns: "is-show-show-hide"
         })
-        .specific(RIProposal, "blog", processType, context, () => (resource : RIProposal) => {
+        .specific(RIProposal, "blog", processType, context, () => (resource : ResourcesBase.IResource) => {
             return {
                 proposalUrl: resource.path
             };
@@ -329,7 +331,7 @@ export var registerRoutes = (
             movingColumns: "is-collapse-show-hide"
         })
         .specific(RIProposal, "moderate", processType, context, ["adhHttp", (adhHttp : AdhHttp.Service) => {
-            return (resource : RIProposal) => {
+            return (resource : ResourcesBase.IResource) => {
                 return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                     if (!options.canPut(SIWinnerInfo.nick)) {
                         throw 401;
@@ -346,7 +348,7 @@ export var registerRoutes = (
             movingColumns: "is-collapse-show-hide"
         })
         .specific(RIProposal, "edit", processType, context, ["adhHttp", (adhHttp : AdhHttp.Service) => {
-            return (resource : RIProposal) => {
+            return (resource : ResourcesBase.IResource) => {
                 return adhHttp.options(resource.path).then((options : AdhHttp.IOptions) => {
                     if (!options.POST) {
                         throw 401;
@@ -363,7 +365,7 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide",
             proposalTab: "blog"
         })
-        .specific(RIProposal, "blog", processType, context, () => (resource : RIProposal) => {
+        .specific(RIProposal, "blog", processType, context, () => (resource : ResourcesBase.IResource) => {
             return {
                 proposalUrl: resource.path
             };
@@ -372,7 +374,7 @@ export var registerRoutes = (
             space: "content",
             movingColumns: "is-collapse-show-show"
         })
-        .specific(RIProposal, "comments", processType, context, () => (resource : RIProposal) => {
+        .specific(RIProposal, "comments", processType, context, () => (resource : ResourcesBase.IResource) => {
             return {
                 proposalUrl: resource.path,
                 commentableUrl: resource.path,
@@ -388,7 +390,7 @@ export var registerRoutes = (
                 movingColumns: "is-collapse-show-show"
             })
             .specific(RIProposal, "comments:" + section, processType, context, () =>
-                (resource : RIProposal) => {
+                (resource : ResourcesBase.IResource) => {
                     return {
                         proposalUrl: resource.path,
                         commentableUrl: resource.data[SIMercatorSubResources.nick][section],

--- a/src/s1/s1/static/js/Packages/S1/Context/Context.ts
+++ b/src/s1/s1/static/js/Packages/S1/Context/Context.ts
@@ -3,7 +3,8 @@ import * as AdhHttp from "../../Core/Http/Http";
 import * as AdhPermissions from "../../Core/Permissions/Permissions";
 import * as AdhTopLevelState from "../../Core/TopLevelState/TopLevelState";
 
-import RIS1Process from "../../../Resources_/adhocracy_s1/resources/s1/IProcess";
+import * as ResourcesBase from "../../../ResourcesBase";
+
 import * as SIWorkflowAssignment from "../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
 
 export var pkgLocation = "/S1/Context";
@@ -40,7 +41,7 @@ export var stateIndicatorDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/StateIndicator.html",
         link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.on("processUrl", (processUrl) => {
-                adhHttp.get(processUrl).then((process : RIS1Process) => {
+                adhHttp.get(processUrl).then((process : ResourcesBase.IResource) => {
                     scope.workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
                 });
             }));
@@ -66,7 +67,7 @@ export var meetingSelectorDirective = (
         },
         link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("meeting", scope));
-            adhHttp.get(scope.processUrl).then((process : RIS1Process) => {
+            adhHttp.get(scope.processUrl).then((process : ResourcesBase.IResource) => {
                 scope.workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
             });
         }

--- a/src/s1/s1/static/js/Packages/S1/Context/Context.ts
+++ b/src/s1/s1/static/js/Packages/S1/Context/Context.ts
@@ -42,7 +42,7 @@ export var stateIndicatorDirective = (
         link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.on("processUrl", (processUrl) => {
                 adhHttp.get(processUrl).then((process : ResourcesBase.IResource) => {
-                    scope.workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
+                    scope.workflowState = SIWorkflowAssignment.get(process).workflow_state;
                 });
             }));
         }
@@ -68,7 +68,7 @@ export var meetingSelectorDirective = (
         link: (scope) => {
             scope.$on("$destroy", adhTopLevelState.bind("meeting", scope));
             adhHttp.get(scope.processUrl).then((process : ResourcesBase.IResource) => {
-                scope.workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
+                scope.workflowState = SIWorkflowAssignment.get(process).workflow_state;
             });
         }
     };

--- a/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
+++ b/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
@@ -82,11 +82,11 @@ var bindPath = (
 
                 scope.resource = version;
 
-                var titleSheet : SITitle.Sheet = version.data[SITitle.nick];
-                var descriptionSheet : SIDescription.Sheet = version.data[SIDescription.nick];
-                var metadataSheet : SIMetadata.Sheet = version.data[SIMetadata.nick];
-                var rateableSheet : SIRateable.Sheet = version.data[SIRateable.nick];
-                var workflowAssignmentSheet : SIWorkflowAssignment.Sheet = item.data[SIWorkflowAssignment.nick];
+                var titleSheet = SITitle.get(version);
+                var descriptionSheet = SIDescription.get(version);
+                var metadataSheet = SIMetadata.get(version);
+                var rateableSheet = SIRateable.get(version);
+                var workflowAssignmentSheet = SIWorkflowAssignment.get(item);
 
                 $q.all([
                     adhGetBadges(version),
@@ -104,7 +104,7 @@ var bindPath = (
                         create: false,
                         creator: metadataSheet.creator,
                         creationDate: metadataSheet.item_creation_date,
-                        commentCount: parseInt(version.data[SICommentable.nick].comments_count, 10),
+                        commentCount: parseInt(SICommentable.get(version).comments_count, 10),
                         assignments: badgeAssignments,
                         workflowState: workflowAssignmentSheet.workflow_state,
                         decisionDate: AdhProcess.getStateData(workflowAssignmentSheet, workflowAssignmentSheet.workflow_state).start_date
@@ -376,7 +376,7 @@ export var renominateProposalDirective = (
         link: (scope) => {
             scope.$watch("proposalUrl", (proposalUrl) => {
                 adhHttp.get(proposalUrl).then((proposal) => {
-                    var workflow = proposal.data[SIWorkflowAssignment.nick];
+                    var workflow = SIWorkflowAssignment.get(proposal);
                     scope.isRejected = "rejected" === workflow.workflow_state;
                 });
             });

--- a/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
+++ b/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
@@ -10,6 +10,8 @@ import * as AdhRate from "../../Core/Rate/Rate";
 import * as AdhTopLevelState from "../../Core/TopLevelState/TopLevelState";
 import * as AdhUtil from "../../Core/Util/Util";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RICommentVersion from "../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
 import RISystemUser from "../../../Resources_/adhocracy_core/resources/principal/ISystemUser";
 import RIProposal from "../../../Resources_/adhocracy_s1/resources/s1/IProposal";
@@ -27,7 +29,7 @@ var pkgLocation = "/S1/Proposal";
 
 export interface IScope extends angular.IScope {
     path : string;
-    resource : RIProposalVersion;
+    resource : ResourcesBase.IResource;
     selectedState? : string;
     data : {
         title : string;
@@ -75,8 +77,8 @@ var bindPath = (
                 adhHttp.get(AdhUtil.parentPath(value)),
                 adhHttp.get(value)
             ]).then((args : any) => {
-                var item : RIProposal = args[0];
-                var version : RIProposalVersion = args[1];
+                var item : ResourcesBase.IResource = args[0];
+                var version : ResourcesBase.IResource = args[1];
 
                 scope.resource = version;
 
@@ -159,7 +161,7 @@ var postEdit = (
     adhPreliminaryNames : AdhPreliminaryNames.Service
 ) => (
     scope : IScope,
-    oldVersion : RIProposalVersion
+    oldVersion : ResourcesBase.IResource
 ) => {
     var proposalVersion = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
     proposalVersion.parent = AdhUtil.parentPath(oldVersion.path);

--- a/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
+++ b/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
@@ -126,10 +126,10 @@ var fill = (
     scope : IScope,
     proposalVersion
 ) : void => {
-    proposalVersion.data[SITitle.nick] = new SITitle.Sheet({
+    SITitle.set(proposalVersion, {
         title: scope.data.title
     });
-    proposalVersion.data[SIDescription.nick] = new SIDescription.Sheet({
+    SIDescription.set(proposalVersion, {
         description: scope.data.description
     });
 };
@@ -154,7 +154,7 @@ var postCreate = (
     };
 
     proposalVersion.parent = proposal.path;
-    proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(proposalVersion, {
         follows: [proposal.first_version_path]
     });
     fill(scope, proposalVersion);
@@ -177,7 +177,7 @@ var postEdit = (
         data: {},
     };
     proposalVersion.parent = AdhUtil.parentPath(oldVersion.path);
-    proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
+    SIVersionable.set(proposalVersion, {
         follows: [oldVersion.path]
     });
     fill(scope, proposalVersion);
@@ -390,9 +390,9 @@ export var renominateProposalDirective = (
                             content_type: proposal.content_type,
                             data: {}
                         };
-                        patch.data[SIWorkflowAssignment.nick] = {
+                        SIWorkflowAssignment.set(patch, {
                             workflow_state: "proposed"
-                        };
+                        });
                         return adhHttp.put(proposal.path, patch).then(() => {
                             $window.parent.location.reload();
                         });

--- a/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
+++ b/src/s1/s1/static/js/Packages/S1/Proposal/Proposal.ts
@@ -141,9 +141,17 @@ var postCreate = (
     scope : IScope,
     poolPath : string
 ) => {
-    var proposal = new RIProposal({preliminaryNames: adhPreliminaryNames});
+    var proposal : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIProposal.content_type,
+        data: {},
+    };
     proposal.parent = poolPath;
-    var proposalVersion = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
+    var proposalVersion : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIProposalVersion.content_type,
+        data: {},
+    };
 
     proposalVersion.parent = proposal.path;
     proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
@@ -163,7 +171,11 @@ var postEdit = (
     scope : IScope,
     oldVersion : ResourcesBase.IResource
 ) => {
-    var proposalVersion = new RIProposalVersion({preliminaryNames: adhPreliminaryNames});
+    var proposalVersion : ResourcesBase.IResource = {
+        path: adhPreliminaryNames.nextPreliminary(),
+        content_type: RIProposalVersion.content_type,
+        data: {},
+    };
     proposalVersion.parent = AdhUtil.parentPath(oldVersion.path);
     proposalVersion.data[SIVersionable.nick] = new SIVersionable.Sheet({
         follows: [oldVersion.path]

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
@@ -8,6 +8,8 @@ import * as AdhResourceArea from "../../Core/ResourceArea/ResourceArea";
 import * as AdhTopLevelState from "../../Core/TopLevelState/TopLevelState";
 import * as AdhUtil from "../../Core/Util/Util";
 
+import * as ResourcesBase from "../../ResourcesBase";
+
 import RIComment from "../../../Resources_/adhocracy_core/resources/comment/IComment";
 import RICommentVersion from "../../../Resources_/adhocracy_core/resources/comment/ICommentVersion";
 import RIS1Process from "../../../Resources_/adhocracy_s1/resources/s1/IProcess";
@@ -51,7 +53,7 @@ export var s1CurrentColumnDirective = (
             scope.contentType = RIProposalVersion.content_type;
 
             scope.$watch("processUrl", (processUrl : string) => {
-                adhHttp.get(processUrl).then((process : RIS1Process) => {
+                adhHttp.get(processUrl).then((process : ResourcesBase.IResource) => {
                     var workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
                     var decisionDate = AdhUtil.deepPluck(
                         AdhProcess.getStateData(process.data[SIWorkflowAssignment.nick], "result"), ["start_date"]);
@@ -106,7 +108,7 @@ export var s1NextColumnDirective = (
             scope.contentType = RIProposalVersion.content_type;
 
             scope.$watch("processUrl", (processUrl : string) => {
-                adhHttp.get(processUrl).then((process : RIS1Process) => {
+                adhHttp.get(processUrl).then((process : ResourcesBase.IResource) => {
                     scope.processState = process.data[SIWorkflowAssignment.nick].workflow_state;
 
                     if (scope.processState === "propose") {
@@ -156,7 +158,7 @@ export var s1ArchiveColumnDirective = (
             scope.contentType = RIProposalVersion.content_type;
 
             scope.$watch("processUrl", (processUrl : string) => {
-                adhHttp.get(processUrl).then((process : RIS1Process) => {
+                adhHttp.get(processUrl).then((process : ResourcesBase.IResource) => {
                     scope.proposalState = "[\"any\", [\"selected\", \"rejected\"]]";
 
                     var workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
@@ -276,7 +278,7 @@ export var s1LandingDirective = (
  * select  | next     | current  | archive  | archive
  * result  | next     | -        | cur/arc  | cur/arc
  */
-var getMeeting = (proposal : RIProposal, process : RIS1Process) => {
+var getMeeting = (proposal : ResourcesBase.IResource, process : ResourcesBase.IResource) => {
     var processState = process.data[SIWorkflowAssignment.nick].workflow_state;
     var proposalState = proposal.data[SIWorkflowAssignment.nick].workflow_state;
 
@@ -317,7 +319,7 @@ export var registerRoutes = (
         })
         .specific(RIS1Process, "create-proposal", processType, context,
             ["adhHttp", (adhHttp : AdhHttp.Service) => {
-                return (resource : RIS1Process) => {
+                return (resource : ResourcesBase.IResource) => {
                     return adhHttp.options(resource.path).then((options) => {
                         if (options.POST) {
                             var processState = resource.data[SIWorkflowAssignment.nick].workflow_state;
@@ -346,7 +348,12 @@ export var registerRoutes = (
             movingColumns: "is-show-show-hide"
         })
         .specificVersionable(RIProposal, RIProposalVersion, "", processType, context, () => {
-            return (item : RIProposal, version : RIProposalVersion, isVersion : boolean, process : RIS1Process) => {
+            return (
+                item : ResourcesBase.IResource,
+                version : ResourcesBase.IResource,
+                isVersion : boolean,
+                process : ResourcesBase.IResource
+            ) => {
                 return {
                     proposalUrl: version.path,
                     meeting: getMeeting(item, process)
@@ -359,7 +366,12 @@ export var registerRoutes = (
         })
         .specificVersionable(RIProposal, RIProposalVersion, "edit", processType, context,
             ["adhHttp", (adhHttp : AdhHttp.Service) => {
-                return (item : RIProposal, version : RIProposalVersion, isVersion : boolean, process : RIS1Process) => {
+                return (
+                    item : ResourcesBase.IResource,
+                    version : ResourcesBase.IResource,
+                    isVersion : boolean,
+                    process : ResourcesBase.IResource
+                ) => {
                     return adhHttp.options(item.path).then((options) => {
                         if (options.POST) {
                             return {
@@ -377,7 +389,12 @@ export var registerRoutes = (
             movingColumns: "is-collapse-show-show"
         })
         .specificVersionable(RIProposal, RIProposalVersion, "comments", processType, context, () => {
-            return (item : RIProposal, version : RIProposalVersion, isVersion : boolean, process : RIS1Process) => {
+            return (
+                item : ResourcesBase.IResource,
+                version : ResourcesBase.IResource,
+                isVersion : boolean,
+                process : ResourcesBase.IResource
+            ) => {
                 return {
                     proposalUrl: version.path,
                     commentableUrl: version.path,
@@ -403,7 +420,7 @@ export var registerRoutes = (
                 }
             };
 
-            return (item : RIComment, version : RICommentVersion) => {
+            return (item : ResourcesBase.IResource, version : ResourcesBase.IResource) => {
                 return getCommentableUrl(version).then((commentable) => {
                     return {
                         commentableUrl: commentable.path,

--- a/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
+++ b/src/s1/s1/static/js/Packages/S1/Workbench/Workbench.ts
@@ -54,9 +54,9 @@ export var s1CurrentColumnDirective = (
 
             scope.$watch("processUrl", (processUrl : string) => {
                 adhHttp.get(processUrl).then((process : ResourcesBase.IResource) => {
-                    var workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
+                    var workflowState = SIWorkflowAssignment.get(process).workflow_state;
                     var decisionDate = AdhUtil.deepPluck(
-                        AdhProcess.getStateData(process.data[SIWorkflowAssignment.nick], "result"), ["start_date"]);
+                        AdhProcess.getStateData(SIWorkflowAssignment.get(process), "result"), ["start_date"]);
 
                     if (workflowState === "propose") {
                         scope.proposalState = "proposed";
@@ -109,7 +109,7 @@ export var s1NextColumnDirective = (
 
             scope.$watch("processUrl", (processUrl : string) => {
                 adhHttp.get(processUrl).then((process : ResourcesBase.IResource) => {
-                    scope.processState = process.data[SIWorkflowAssignment.nick].workflow_state;
+                    scope.processState = SIWorkflowAssignment.get(process).workflow_state;
 
                     if (scope.processState === "propose") {
                         scope.proposalState = "none";
@@ -161,10 +161,10 @@ export var s1ArchiveColumnDirective = (
                 adhHttp.get(processUrl).then((process : ResourcesBase.IResource) => {
                     scope.proposalState = "[\"any\", [\"selected\", \"rejected\"]]";
 
-                    var workflowState = process.data[SIWorkflowAssignment.nick].workflow_state;
+                    var workflowState = SIWorkflowAssignment.get(process).workflow_state;
                     if (workflowState === "result") {
                         var decisionDate = AdhUtil.deepPluck(
-                            AdhProcess.getStateData(process.data[SIWorkflowAssignment.nick], "result"), ["start_date"]);
+                            AdhProcess.getStateData(SIWorkflowAssignment.get(process), "result"), ["start_date"]);
                         scope.decisionDate = "[\"lt\",  \"" + decisionDate + "\"]";
                     }
                 });
@@ -261,9 +261,9 @@ export var s1LandingDirective = (
             scope.$on("$destroy", adhTopLevelState.bind("processUrl", scope));
             scope.$on("$destroy", adhTopLevelState.on("processUrl", (processUrl) => {
                 adhHttp.get(processUrl).then((process) => {
-                    scope.processTitle = process.data[SITitle.nick].title;
-                    scope.processShortDescription = process.data[SIDescription.nick].short_description;
-                    scope.processDescription = process.data[SIDescription.nick].description;
+                    scope.processTitle = SITitle.get(process).title;
+                    scope.processShortDescription = SIDescription.get(process).short_description;
+                    scope.processDescription = SIDescription.get(process).description;
                 });
             }));
         }
@@ -279,8 +279,8 @@ export var s1LandingDirective = (
  * result  | next     | -        | cur/arc  | cur/arc
  */
 var getMeeting = (proposal : ResourcesBase.IResource, process : ResourcesBase.IResource) => {
-    var processState = process.data[SIWorkflowAssignment.nick].workflow_state;
-    var proposalState = proposal.data[SIWorkflowAssignment.nick].workflow_state;
+    var processState = SIWorkflowAssignment.get(process).workflow_state;
+    var proposalState = SIWorkflowAssignment.get(proposal).workflow_state;
 
     if (proposalState === "proposed") {
         return processState === "propose" ? "current" : "next";
@@ -290,9 +290,9 @@ var getMeeting = (proposal : ResourcesBase.IResource, process : ResourcesBase.IR
         return "archive";
     } else {
         var processDecisionDate = AdhUtil.deepPluck(
-            AdhProcess.getStateData(process.data[SIWorkflowAssignment.nick], "result"), ["start_date"]);
+            AdhProcess.getStateData(SIWorkflowAssignment.get(process), "result"), ["start_date"]);
         var proposalDecisionDate = AdhUtil.deepPluck(
-            AdhProcess.getStateData(proposal.data[SIWorkflowAssignment.nick], proposalState), ["start_date"]);
+            AdhProcess.getStateData(SIWorkflowAssignment.get(proposal), proposalState), ["start_date"]);
 
         return (processDecisionDate === proposalDecisionDate) ? "current" : "archive";
     }
@@ -322,7 +322,7 @@ export var registerRoutes = (
                 return (resource : ResourcesBase.IResource) => {
                     return adhHttp.options(resource.path).then((options) => {
                         if (options.POST) {
-                            var processState = resource.data[SIWorkflowAssignment.nick].workflow_state;
+                            var processState = SIWorkflowAssignment.get(resource).workflow_state;
                             return {
                                 targetMeeting: processState === "propose" ? "current" : "next"
                             };
@@ -415,7 +415,7 @@ export var registerRoutes = (
                 if (resource.content_type !== RICommentVersion.content_type) {
                     return $q.when(resource);
                 } else {
-                    var url = resource.data[SIComment.nick].refers_to;
+                    var url = SIComment.get(resource).refers_to;
                     return adhHttp.get(url).then(getCommentableUrl);
                 }
             };


### PR DESCRIPTION
This is basically a raw dump of my continued work on #2206, so it is a bit unstructured.

I wanted to implement the "create resources as plain objects instead of class instances" part. But somehow I got deep into "change mkResources.ts to only generated interfaces and constants", although it is not complete yet. The results:

- `RIFoo` is still a class, but only because it was simpler to leave it that way.
- `SIFoo.Sheet` is now an interface.
- Instead of `resource[SIFoo.nick]` you use `SIFoo.get(resource)` / `SIFoo.set(resource, ...)`. The benefit of this is that the correct sheet type is used, so it is easier to spot errors.
- Size of the generated files is down to 107KB (see https://github.com/liqd/adhocracy3/pull/2806#discussion_r84033504 for previous values). About 50% of that is UMD code that could be stripped.

Still to do:

- Make `ResourcesBase.IResource` generic to allow even better type checking
- Further simplify `mkResources` to improve maintainability and performance