### PR TITLE
stadtforum: show process resource header

### DIFF
--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Process/Process.ts
@@ -149,7 +149,7 @@ export var detailDirective = (
             adhPermissions.bindScope(scope, () => scope.path);
 
             var context = adhEmbed.getContext();
-            scope.hasResourceHeader = (context === "mein.bärlin.de");
+            scope.hasResourceHeader = (context === "");
         }
     };
 };


### PR DESCRIPTION
Shows this resource header whenever a3 is not embedded.

Analogous to #2741.