### PR TITLE
mitmachen wieder verboten

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Workbench/Workbench.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Workbench/Workbench.ts
@@ -131,7 +131,7 @@ export var addProposalButtonDirective = (
             adhPermissions.bindScope(scope, () => scope.processUrl, "processOptions");
             adhHttp.get(scope.processUrl).then((process) => {
                 var workflow = SIWorkflow.get(process).workflow;
-                scope.workflowAllowsCreateProposal = (workflow !== "debate" && workflow !== "debate_private");
+                scope.workflowAllowsCreateProposal = (workflow !== "debate" && workflow !== "debate_private" && workflow !== "stadtforum");
             });
 
             scope.setCameFrom = () => {


### PR DESCRIPTION
In #2744, the add-proposal-button was disabled in "debate" workflows by using a quickfix. This PR extends the quickfix in order to disable the button in Stadtforums as well. I'm happy to discuss other ways to do this - probably we should find a cleaner solution for both problems.

Ceterum censeo: We'd have none of the problems if we didn't have the "what's a standard user allowed to do now?" problem ( = #1347).
