### PR TITLE
provide new image size 'original'

### DIFF
--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -47,7 +47,7 @@ class ImageDownload(File, AssetDownload):
         """
         if self._is_resized():
             return self._get_response()
-        elif self.name != '0000002':
+        elif self.dimensions:
             original = self._get_asset_file_in_lineage(registry)
             self._upload(original)
             transaction.commit()  # to avoid BlobError: Uncommitted changes

--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -78,9 +78,12 @@ class ImageDownload(File, AssetDownload):
                 resized = cropped.resize(self.dimensions, Image.ANTIALIAS)
             else:
                 if image.size[0] * image.size[1] > 1000000:
-                    ratio = image.size[1] / image.size[0]
-                    dimensions = (1000, int(1000 * ratio))
-                    resized = image.resize(dimensions, Image.ANTIALIAS)
+                    if image.size[0] < 10 or image.size[1] < 10:
+                        raise ValueError('Image is too slim!')
+                    else:
+                        ratio = image.size[1] / image.size[0]
+                        dimensions = (1000, int(1000 * ratio))
+                        resized = image.resize(dimensions, Image.ANTIALIAS)
                 else:
                     resized = image
             bytestream = io.BytesIO()

--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -47,12 +47,14 @@ class ImageDownload(File, AssetDownload):
         """
         if self._is_resized():
             return self._get_response()
-        elif self.dimensions or self.dimensions is None:
+        elif self.name != '0000002':
             original = self._get_asset_file_in_lineage(registry)
-            if self.dimensions is None:
-                self._upload(original)
-            else:
-                self._upload_crop_and_resize(original)
+            self._upload_crop_and_resize(original)
+            transaction.commit()  # to avoid BlobError: Uncommitted changes
+            return self._get_response()
+        elif self.name == '0000002':
+            original = self._get_asset_file_in_lineage(registry)
+            self._upload(original)
             transaction.commit()  # to avoid BlobError: Uncommitted changes
             return self._get_response()
         else:

--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -77,7 +77,12 @@ class ImageDownload(File, AssetDownload):
                 cropped = crop(image, self.dimensions)
                 resized = cropped.resize(self.dimensions, Image.ANTIALIAS)
             else:
-                resized = image
+                if image.size[0] * image.size[1] > 1000000:
+                    ratio = image.size[1] / image.size[0]
+                    dimensions = (1000, int(1000 * ratio))
+                    resized = image.resize(dimensions, Image.ANTIALIAS)
+                else:
+                    resized = image
             bytestream = io.BytesIO()
             if image.format == 'PNG':
                 reduced_colors = resized.convert('P',

--- a/src/adhocracy_core/adhocracy_core/resources/image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/image.py
@@ -77,13 +77,12 @@ class ImageDownload(File, AssetDownload):
                 cropped = crop(image, self.dimensions)
                 resized = cropped.resize(self.dimensions, Image.ANTIALIAS)
             else:
-                if image.size[0] * image.size[1] > 1000000:
-                    if image.size[0] < 10 or image.size[1] < 10:
-                        raise ValueError('Image is too slim!')
-                    else:
-                        ratio = image.size[1] / image.size[0]
-                        dimensions = (1000, int(1000 * ratio))
-                        resized = image.resize(dimensions, Image.ANTIALIAS)
+                if image.size[0] < 10 or image.size[1] < 10:
+                    raise ValueError('Image is too slim!')
+                elif image.size[0] * image.size[1] > 1000000:
+                    ratio = image.size[1] / image.size[0]
+                    dimensions = (1000, int(1000 * ratio))
+                    resized = image.resize(dimensions, Image.ANTIALIAS)
                 else:
                     resized = image
             bytestream = io.BytesIO()

--- a/src/adhocracy_core/adhocracy_core/resources/test_image.py
+++ b/src/adhocracy_core/adhocracy_core/resources/test_image.py
@@ -94,12 +94,13 @@ class TestImageDownload:
         asset['download'] = inst
         original = Mock()
         mock_sheet.get.return_value = {'data': original}
-        inst._upload_crop_and_resize = Mock()
+        inst._upload = Mock()
         inst.dimensions = dimensions
         inst._get_response = Mock(return_value='FileResponse')
+        import bpdb;bpdb.set_trace()
         response = inst.get_response(registry)
         assert response is inst._get_response.return_value
-        inst._upload_crop_and_resize.assert_called_with(original)
+        inst._upload.assert_called_with(original)
 
     def test_allow_view_everyone(context, registry, mocker):
         from . import image
@@ -156,7 +157,7 @@ class TestImageDownload:
         from PIL.Image import ANTIALIAS
         inst.upload = Mock()
         inst.dimensions = (1, 1)
-        inst._upload_crop_and_resize(mock_file)
+        inst._upload(mock_file, True)
         assert mock_crop.call_args[0] == (mock_original, inst.dimensions)
         assert mock_cropped.resize.call_args(dimensions, ANTIALIAS)
         file_resized = mock_resized.save.call_args[0][0]
@@ -169,7 +170,7 @@ class TestImageDownload:
                                          mock_resized, mock_file):
         mock_original.format = 'JPEG'
         inst.upload = Mock()
-        inst._upload_crop_and_resize(mock_file)
+        inst._upload(mock_file, True)
         assert mock_resized.save.call_args[0][1] == 'JPEG'
 
     def test_upload_crop_and_resize_png(self, inst, mock_crop, mock_original,
@@ -178,7 +179,7 @@ class TestImageDownload:
         mock_converted = copy(mock_original)
         mock_resized.convert.return_value = mock_converted
         inst.upload = Mock()
-        inst._upload_crop_and_resize(mock_file)
+        inst._upload(mock_file, True)
         assert mock_resized.convert.call_args[0][0] == 'P'
         assert mock_converted.save.call_args[0][1] == 'PNG'
 

--- a/src/adhocracy_core/adhocracy_core/sheets/image.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/image.py
@@ -44,6 +44,8 @@ class ImageMetadataSchema(AssetMetadataSchema):
                       readonly=True)
     thumbnail = Resource(dimensions=Dimensions(width=100, height=100),
                          readonly=True)
+    original = Resource(dimensions=None,
+                        readonly=True)
 
 
 image_metadata_meta = asset_metadata_meta._replace(

--- a/src/adhocracy_core/adhocracy_core/sheets/test_image.py
+++ b/src/adhocracy_core/adhocracy_core/sheets/test_image.py
@@ -27,7 +27,8 @@ class TestImageMetadataSheet:
                               'mime_type': '',
                               'size': 0,
                               'detail': None,
-                              'thumbnail': None}
+                              'thumbnail': None,
+                              'original': None}
 
     @mark.usefixtures('integration')
     def test_includeme_register(self, meta, registry):


### PR DESCRIPTION
Adds a new image format called 'original' besides 'detail' and 'thumbnail'.

Tests pass as before, but I haven't written a new one for the new logic yet.