### PR TITLE
simple activity ui

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Activity.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Activity.html
@@ -1,0 +1,3 @@
+<div class="activity">
+    {{name}}
+</div>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Activity.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Activity.ts
@@ -1,0 +1,53 @@
+import * as AdhConfig from "../Core/Config/Config";
+import * as AdhHttp from "../Core/Http/Http";
+
+import * as SIActivity from "../../../Resources_/adhocracy_core/sheets/activity/IActivity";
+import * as SIPool from "../../../Resources_/adhocracy_core/sheets/pool/IPool";
+
+var pkgLocation = "/Core/Activity";
+
+
+export var streamDirective = (
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Stream.html",
+        scope: {
+            path: "@"
+        },
+        link: (scope) => {
+            scope.$watch("path", (path) => {
+                if (path) {
+                    adhHttp.get(path, {elements: "paths"}).then((stream) => {
+                        scope.elements = SIPool.get(stream).elements;
+                    });
+                }
+            });
+        }
+    };
+};
+
+
+export var activityDirective = (
+    adhConfig : AdhConfig.IService,
+    adhHttp : AdhHttp.Service
+) => {
+    return {
+        restrict: "E",
+        templateUrl: adhConfig.pkg_path + pkgLocation + "/Activity.html",
+        scope: {
+            path: "@"
+        },
+        link: (scope) => {
+            scope.$watch("path", (path) => {
+                if (path) {
+                    adhHttp.get(path).then((stream) => {
+                        scope.name = SIActivity.get(stream).name;
+                    });
+                }
+            });
+        }
+    };
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Module.ts
@@ -1,4 +1,7 @@
+import * as AdhEmbedModule from "../Embed/Module";
 import * as AdhHttpModule from "../Http/Module";
+
+import * as AdhEmbed from "../Embed/Embed";
 
 import * as Activity from "./Activity";
 
@@ -8,8 +11,12 @@ export var moduleName = "adhActivity";
 export var register = (angular) => {
     angular
         .module(moduleName, [
+            AdhEmbedModule.moduleName,
             AdhHttpModule.moduleName
         ])
+        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
+            adhEmbedProvider.registerDirective("activity-stream");
+        }])
         .directive("adhActivityStream", ["adhConfig", "adhHttp", Activity.streamDirective])
         .directive("adhActivity", ["adhConfig", "adhHttp", Activity.activityDirective]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Module.ts
@@ -1,0 +1,15 @@
+import * as AdhHttpModule from "../Http/Module";
+
+import * as Activity from "./Activity";
+
+
+export var moduleName = "adhActivity";
+
+export var register = (angular) => {
+    angular
+        .module(moduleName, [
+            AdhHttpModule.moduleName
+        ])
+        .directive("adhActivityStream", ["adhConfig", "adhHttp", Activity.streamDirective])
+        .directive("adhActivity", ["adhConfig", "adhHttp", Activity.activityDirective]);
+};

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Stream.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Activity/Stream.html
@@ -1,0 +1,5 @@
+<ul class="activity-stream">
+    <li class="activity-stream-item" data-ng-repeat="element in elements">
+        <adh-activity data-path="{{element}}"></adh-activity>
+    </li>
+</ul>

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Module.ts
@@ -1,4 +1,5 @@
 import * as AdhAbuseModule from "./Abuse/Module";
+import * as AdhActivityModule from "./Activity/Module";
 import * as AdhAngularHelpersModule from "./AngularHelpers/Module";
 import * as AdhAnonymizeModule from "./Anonymize/Module";
 import * as AdhBadgeModule from "./Badge/Module";
@@ -42,6 +43,7 @@ export var moduleName = "adhCore";
 
 export var register = (angular, config, metaApi) => {
     AdhAbuseModule.register(angular);
+    AdhActivityModule.register(angular);
     AdhAngularHelpersModule.register(angular);
     AdhAnonymizeModule.register(angular);
     AdhBadgeModule.register(angular);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Module.ts
@@ -85,6 +85,7 @@ export var register = (angular, config, metaApi) => {
 
     angular
         .module(moduleName, [
+            AdhActivityModule.moduleName,
             AdhCommentModule.moduleName,
             AdhConfigModule.moduleName,
             AdhCrossWindowMessagingModule.moduleName,


### PR DESCRIPTION
This adds some initial boilerplate required for the activity stream UI. It requires #2830.

The second commit is only for development and should be reverted later on.

I thought about using `adhListing` for the stream but decided against it. The stream probably does not need listing features like filter/sort, but may need live support. So it is significantly different.