### PR TITLE
fixup #2810

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Module.ts
@@ -28,7 +28,15 @@ export var register = (angular) => {
             AdhTopLevelStateModule.moduleName
         ])
         .directive("adhIdeaCollectionProposalDetail", [
-            "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhGetBadges", "$q", Proposal.detailDirective])
+            "adhConfig",
+            "adhHttp",
+            "adhPermissions",
+            "adhProcess",
+            "adhRate",
+            "adhTopLevelState",
+            "adhGetBadges",
+            "$q",
+            Proposal.detailDirective])
         .directive("adhIdeaCollectionProposalListItem", [
             "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhGetBadges", "$q", Proposal.listItemDirective])
         .directive("adhIdeaCollectionProposalMapListItem", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Module.ts
@@ -36,7 +36,7 @@ export var register = (angular) => {
             "adhTopLevelState",
             "adhGetBadges",
             "$q",
-            Proposal.detailDirective])
+            Proposal.detailDirective()])
         .directive("adhIdeaCollectionProposalListItem", [
             "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhGetBadges", "$q", Proposal.listItemDirective])
         .directive("adhIdeaCollectionProposalMapListItem", [

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
@@ -26,7 +26,7 @@ import * as SIRateable from "../../../../Resources_/adhocracy_core/sheets/rate/I
 import * as SITitle from "../../../../Resources_/adhocracy_core/sheets/title/ITitle";
 import * as SIVersionable from "../../../../Resources_/adhocracy_core/sheets/versions/IVersionable";
 
-var pkgLocation = "/Core/IdeaCollection/Proposal";
+export var pkgLocation = "/Core/IdeaCollection/Proposal";
 
 
 export interface IScope extends angular.IScope {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
@@ -259,6 +259,7 @@ export var detailDirective = (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service,
     adhPermissions : AdhPermissions.Service,
+    adhProcess : AdhProcess.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
     adhGetBadges : AdhBadge.IGetBadgeAssignments,

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
@@ -256,6 +256,8 @@ var postEdit = (
 };
 
 export var detailDirective = (
+    processType? : string
+) => (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service,
     adhPermissions : AdhPermissions.Service,
@@ -270,9 +272,13 @@ export var detailDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Detail.html",
         scope: {
             path: "@",
-            processProperties: "="
+            processProperties: "=?"
         },
         link: (scope : IScope) => {
+            if (!scope.processProperties && processType) {
+                scope.processProperties = adhProcess.getProperties(processType);
+            }
+
             bindPath(adhConfig, adhHttp, adhPermissions, adhRate, adhTopLevelState, adhGetBadges, $q)(
                 scope, undefined);
             scope.commentType = RICommentVersion.content_type;

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Module.ts
@@ -47,6 +47,7 @@ export var register = (angular) => {
             "adhConfig",
             "adhHttp",
             "adhPermissions",
+            "adhProcess",
             "adhRate",
             "adhTopLevelState",
             "adhGetBadges",

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Module.ts
@@ -52,7 +52,7 @@ export var register = (angular) => {
             "adhTopLevelState",
             "adhGetBadges",
             "$q",
-            AdhIdeaCollectionProposal.detailDirective])
+            AdhIdeaCollectionProposal.detailDirective(processType)])
         .config(["adhResourceAreaProvider", "adhConfig", (adhResourceAreaProvider : AdhResourceArea.Provider, adhConfig) => {
             var registerRoutes = AdhIdeaCollectionWorkbench.registerRoutesFactory(
                 RIStadtforumProcess, RIPoll, RIProposalVersion, false);


### PR DESCRIPTION
Since #2810 the attribute `processProperties` is required for some directives. Unfortunately, this breaks embedding of these directives.

This branch contains a fix for `meinberlin-stadtforum-proposal-detail`. The following embeds may also be broken:

- `meinberlin-stadtforum-proposal-create`
- `meinberlin-proposal-detail`
- `meinberlin-proposal-list-item`
- `meinberlin-proposal-create`
- `meinberlin-proposal-edit`
- `meinberlin-proposal-list`

It is not clear whether these are used though.