### PR TITLE
fix stadtforum embed

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Poll/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Poll/Module.ts
@@ -2,6 +2,7 @@ import * as AdhBadgeModule from "../../Badge/Module";
 import * as AdhHttpModule from "../../Http/Module";
 import * as AdhPermissionsModule from "../../Permissions/Module";
 import * as AdhPreliminaryNamesModule from "../../PreliminaryNames/Module";
+import * as AdhProcessModule from "../../Process/Module";
 import * as AdhRateModule from "../../Rate/Module";
 import * as AdhTopLevelStateModule from "../../TopLevelState/Module";
 
@@ -16,11 +17,20 @@ export var register = (angular) => {
             AdhBadgeModule.moduleName,
             AdhHttpModule.moduleName,
             AdhPermissionsModule.moduleName,
+            AdhProcessModule.moduleName,
             AdhPreliminaryNamesModule.moduleName,
             AdhRateModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
         .directive("adhPollDetailColumn", ["adhConfig", "adhTopLevelState", Poll.pollDetailColumnDirective])
         .directive("adhPollDetail", [
-            "adhConfig", "adhHttp", "adhPermissions", "adhRate", "adhTopLevelState", "adhGetBadges", "$q", Poll.detailDirective]);
+            "adhConfig",
+            "adhHttp",
+            "adhPermissions",
+            "adhProcess",
+            "adhRate",
+            "adhTopLevelState",
+            "adhGetBadges",
+            "$q",
+            Poll.detailDirective()]);
 };

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Poll/Poll.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Poll/Poll.ts
@@ -5,6 +5,7 @@ import * as AdhConfig from "../../Config/Config";
 import * as AdhHttp from "../../Http/Http";
 import * as AdhIdeaCollectionProposal from "../Proposal/Proposal";
 import * as AdhPermissions from "../../Permissions/Permissions";
+import * as AdhProcess from "../../Process/Process";
 import * as AdhRate from "../../Rate/Rate";
 import * as AdhTopLevelState from "../../TopLevelState/TopLevelState";
 
@@ -33,9 +34,12 @@ export var pollDetailColumnDirective = (
 };
 
 export var detailDirective = (
+    processType? : string
+) => (
     adhConfig : AdhConfig.IService,
     adhHttp : AdhHttp.Service,
     adhPermissions : AdhPermissions.Service,
+    adhProcess : AdhProcess.Service,
     adhRate : AdhRate.Service,
     adhTopLevelState : AdhTopLevelState.Service,
     adhGetBadges : AdhBadge.IGetBadgeAssignments,
@@ -46,9 +50,12 @@ export var detailDirective = (
         templateUrl: adhConfig.pkg_path + pkgLocation + "/Detail.html",
         scope: {
             path: "@",
-            processProperties: "="
+            processProperties: "=?",
         },
         link: (scope) => {
+            if (!scope.processProperties && processType) {
+                scope.processProperties = adhProcess.getProperties(processType);
+            }
             AdhIdeaCollectionProposal.bindPath(adhConfig, adhHttp, adhPermissions, adhRate, adhTopLevelState, adhGetBadges, $q)(scope);
 
             scope.goToLogin = () => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Proposal.ts
@@ -26,7 +26,7 @@ import * as SIRateable from "../../../../Resources_/adhocracy_core/sheets/rate/I
 import * as SITitle from "../../../../Resources_/adhocracy_core/sheets/title/ITitle";
 import * as SIVersionable from "../../../../Resources_/adhocracy_core/sheets/versions/IVersionable";
 
-var pkgLocation = "/Core/IdeaCollection/Proposal";
+export var pkgLocation = "/Core/IdeaCollection/Proposal";
 
 
 export interface IScope extends angular.IScope {

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Stadtforum/Module.ts
@@ -4,7 +4,7 @@ import * as AdhProcessModule from "../../Core/Process/Module";
 import * as AdhResourceAreaModule from "../../Core/ResourceArea/Module";
 
 import * as AdhEmbed from "../../Core/Embed/Embed";
-import * as AdhIdeaCollectionProposal from "../../Core/IdeaCollection/Proposal/Proposal";
+import * as AdhIdeaCollectionPoll from "../../Core/IdeaCollection/Poll/Poll";
 import * as AdhIdeaCollectionWorkbench from "../../Core/IdeaCollection/Workbench/Workbench";
 import * as AdhNames from "../../Core/Names/Names";
 import * as AdhPoll from "../../Core/IdeaCollection/Poll/Poll";
@@ -29,29 +29,18 @@ export var register = (angular) => {
         ])
         .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
             adhEmbedProvider
-                .registerDirective("meinberlin-stadtforum-proposal-detail")
-                .registerDirective("meinberlin-stadtforum-proposal-create");
+                .registerDirective("meinberlin-stadtforum-proposal-detail");
         }])
-        .directive("adhMeinberlinStadtforumProposalCreate", [
-            "adhConfig",
-            "adhHttp",
-            "adhPreliminaryNames",
-            "adhTopLevelState",
-            "adhShowError",
-            "adhSubmitIfValid",
-            "adhResourceUrlFilter",
-            "$location",
-            AdhIdeaCollectionProposal.createDirective
-        ])
         .directive("adhMeinberlinStadtforumProposalDetail", [
             "adhConfig",
             "adhHttp",
             "adhPermissions",
+            "adhProcess",
             "adhRate",
             "adhTopLevelState",
             "adhGetBadges",
             "$q",
-            AdhIdeaCollectionProposal.detailDirective])
+            AdhIdeaCollectionPoll.detailDirective(processType)])
         .config(["adhResourceAreaProvider", "adhConfig", (adhResourceAreaProvider : AdhResourceArea.Provider, adhConfig) => {
             var registerRoutes = AdhIdeaCollectionWorkbench.registerRoutesFactory(
                 RIStadtforumProcess, RIPoll, RIProposalVersion, false);


### PR DESCRIPTION
(replaces #2838.) Since #2810 the attribute `processProperties` is required for some directives. Unfortunately, this breaks embedding of these directives.

This branch contains a fix for `meinberlin-stadtforum-proposal-detail`. The following embeds may also be broken:

- `meinberlin-stadtforum-proposal-create`
- `meinberlin-proposal-detail`
- `meinberlin-proposal-list-item`
- `meinberlin-proposal-create`
- `meinberlin-proposal-edit`
- `meinberlin-proposal-list`
It is not clear whether these are used though.