### PR TITLE
rm unused embeddable directives

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Badge/Module.ts
@@ -1,10 +1,7 @@
 import * as AdhCredentialsModule from "../User/Module";
 import * as AdhHttpModule from "../Http/Module";
-import * as AdhEmbedModule from "../Embed/Module";
 import * as AdhMovingColumnsModule from "../MovingColumns/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
-
-import * as AdhEmbed from "../Embed/Embed";
 
 import * as AdhBadge from "./Badge";
 
@@ -15,16 +12,10 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhCredentialsModule.moduleName,
-            AdhEmbedModule.moduleName,
             AdhHttpModule.moduleName,
             AdhMovingColumnsModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
-            adhEmbedProvider
-                .registerDirective("badge-assignment-create")
-                .registerDirective("badge-assignment-edit");
-        }])
         .factory("adhGetBadges", ["adhHttp", "$q", AdhBadge.getBadgesFactory])
         .directive("adhBadgeAssignment", [
             "adhConfig",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Comment/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Comment/Module.ts
@@ -43,7 +43,6 @@ export var register = (angular) => {
         ])
         .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
             adhEmbedProvider
-                .registerDirective("comment-listing")
                 .registerDirective("create-or-show-comment-listing");
         }])
         .config(["adhNamesProvider", (adhNamesProvider : AdhNames.Provider) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/DebateWorkbench/Module.ts
@@ -9,8 +9,6 @@ import * as AdhResourceActionsModule from "../ResourceActions/Module";
 import * as AdhResourceAreaModule from "../ResourceArea/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 
-import * as AdhEmbed from "../Embed/Embed";
-
 import * as DebateWorkbench from "./DebateWorkbench";
 
 
@@ -30,10 +28,6 @@ export var register = (angular) => {
             AdhResourceAreaModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
-            adhEmbedProvider
-                .registerDirective("debate-workbench");
-        }])
         .directive("adhDebateWorkbench", ["adhConfig", "adhTopLevelState", DebateWorkbench.debateWorkbenchDirective])
         .directive("adhDocumentDetailColumn", [
             "adhConfig", "adhPermissions", "adhTopLevelState", DebateWorkbench.documentDetailColumnDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Document/Module.ts
@@ -1,6 +1,5 @@
 import * as AdhAngularHelpersModule from "../AngularHelpers/Module";
 import * as AdhBadgeModule from "../Badge/Module";
-import * as AdhEmbedModule from "../Embed/Module";
 import * as AdhHttpModule from "../Http/Module";
 import * as AdhImageModule from "../Image/Module";
 import * as AdhInjectModule from "../Inject/Module";
@@ -11,7 +10,6 @@ import * as AdhPreliminaryNamesModule from "../PreliminaryNames/Module";
 import * as AdhStickyModule from "../Sticky/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
 
-import * as AdhEmbed from "../Embed/Embed";
 import * as AdhNames from "../Names/Names";
 
 import * as AdhDocument from "./Document";
@@ -27,7 +25,6 @@ export var register = (angular) => {
             "ngMessages",
             AdhAngularHelpersModule.moduleName,
             AdhBadgeModule.moduleName,
-            AdhEmbedModule.moduleName,
             AdhHttpModule.moduleName,
             AdhImageModule.moduleName,
             AdhInjectModule.moduleName,
@@ -38,13 +35,6 @@ export var register = (angular) => {
             AdhStickyModule.moduleName,
             AdhTopLevelStateModule.moduleName
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
-            adhEmbedProvider
-                .registerDirective("document-detail")
-                .registerDirective("document-create")
-                .registerDirective("document-edit")
-                .registerDirective("document-list-item");
-        }])
         .config(["adhNamesProvider", (adhNamesProvider : AdhNames.Provider) => {
             adhNamesProvider.names[RIGeoDocumentVersion.content_type] = "TR__RESOURCE_DOCUMENT";
         }])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Image/Module.ts
@@ -1,8 +1,5 @@
-import * as AdhEmbedModule from "../Embed/Module";
 import * as AdhHttpModule from "../Http/Module";
 import * as AdhTopLevelStateModule from "../TopLevelState/Module";
-
-import * as AdhEmbed from "../Embed/Embed";
 
 import * as AdhImage from "./Image";
 
@@ -12,13 +9,9 @@ export var moduleName = "adhImage";
 export var register = (angular) => {
     angular
         .module(moduleName, [
-            AdhEmbedModule.moduleName,
             AdhTopLevelStateModule.moduleName,
             AdhHttpModule.moduleName
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
-            adhEmbedProvider.registerDirective("upload-image");
-        }])
         .factory("adhUploadImage", ["adhHttp", AdhImage.uploadImageFactory])
         .directive("adhUploadImage", ["adhConfig", "adhHttp", "adhTopLevelState", "adhUploadImage",
             "flowFactory", "adhResourceUrlFilter", AdhImage.uploadImageDirective])

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Mapping/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Mapping/Module.ts
@@ -1,13 +1,10 @@
 import * as AdhAngularHelpersModule from "../AngularHelpers/Module";
-import * as AdhEmbedModule from "../Embed/Module";
 import * as AdhHttpModule from "../Http/Module";
 import * as AdhInjectModule from "../Inject/Module";
 import * as AdhListingModule from "../Listing/Module";
 import * as AdhPermissionsModule from "../Permissions/Module";
 import * as AdhPreliminaryNamesModule from "../PreliminaryNames/Module";
 import * as AdhWebSocketModule from "../WebSocket/Module";
-
-import * as AdhEmbed from "../Embed/Embed";
 
 import * as AdhMapping from "./Mapping";
 
@@ -18,7 +15,6 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhAngularHelpersModule.moduleName,
-            AdhEmbedModule.moduleName,
             AdhHttpModule.moduleName,
             AdhInjectModule.moduleName,
             AdhListingModule.moduleName,
@@ -28,12 +24,6 @@ export var register = (angular) => {
             "duScroll"
         ])
         .provider("adhMapData", AdhMapping.MapDataProvider)
-        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
-            adhEmbedProvider
-                .registerDirective("map-input")
-                .registerDirective("map-detail")
-                .registerDirective("map-listing-internal");
-        }])
         .config(["adhMapDataProvider", (adhMapDataProvider : AdhMapping.MapDataProvider) => {
             adhMapDataProvider.style = {
                 fillColor: "#000",

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Markdown/Module.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Markdown/Module.ts
@@ -1,7 +1,3 @@
-import * as AdhEmbedModule from "../Embed/Module";
-
-import * as AdhEmbed from "../Embed/Embed";
-
 import * as AdhMarkdown from "./Markdown";
 
 
@@ -9,12 +5,7 @@ export var moduleName = "adhMarkdown";
 
 export var register = (angular) => {
     angular
-        .module(moduleName, [
-            AdhEmbedModule.moduleName
-        ])
-        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
-            adhEmbedProvider.registerDirective("test-parse-markdown");
-        }])
+        .module(moduleName, [])
         .directive("adhParseMarkdown", ["adhConfig", "markdownit", AdhMarkdown.parseMarkdown])
         .directive("adhInlineEditableMarkdown", ["adhConfig", AdhMarkdown.inlineEditableMarkdownDirective])
         .directive("adhTestParseMarkdown", ["adhConfig", AdhMarkdown.testMarkdown]);

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/ViewsModule.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/User/ViewsModule.ts
@@ -18,7 +18,6 @@ import * as AdhCredentialsModule from "./CredentialsModule";
 import * as AdhUserModule from "./Module";
 import * as AdhImageModule from "../Image/Module";
 
-import * as AdhEmbed from "../Embed/Embed";
 import * as AdhHttp from "../Http/Http";
 import * as AdhNames from "../Names/Names";
 import * as AdhTopLevelState from "../TopLevelState/TopLevelState";
@@ -93,12 +92,6 @@ export var register = (angular) => {
         .config(["adhResourceAreaProvider", AdhUserViews.registerRoutes()])
         .config(["adhNamesProvider", (adhNamesProvider : AdhNames.Provider) => {
             adhNamesProvider.names[RIUser.content_type] = "TR__RESOURCE_USER";
-        }])
-        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
-            adhEmbedProvider
-                .registerDirective("login")
-                .registerDirective("register")
-                .registerDirective("user-indicator");
         }])
         .filter("adhTranslateUsername", ["translateFilter", AdhUserViews.translateUsernameFilter])
         .directive("adhListUsers", ["adhCredentials", "adhConfig", AdhUserViews.userListDirective])

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Process/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Bplan/Process/Module.ts
@@ -1,9 +1,6 @@
 import * as AdhHttpModule from "../../../Core/Http/Module";
 import * as AdhPreliminaryNamesModule from "../../../Core/PreliminaryNames/Module";
-import * as AdhEmbedModule from "../../../Core/Embed/Module";
 import * as AdhAngularHelpers from "../../../Core/AngularHelpers/Module";
-
-import * as AdhEmbed from "../../../Core/Embed/Embed";
 
 import * as Process from "./Process";
 
@@ -14,14 +11,9 @@ export var register = (angular) => {
     angular
         .module(moduleName, [
             AdhAngularHelpers.moduleName,
-            AdhEmbedModule.moduleName,
             AdhHttpModule.moduleName,
             AdhPreliminaryNamesModule.moduleName
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
-            adhEmbedProvider
-                .registerDirective("meinberlin-bplan-process-create");
-        }])
         .directive("adhMeinberlinBplanProcessCreate", [
             "adhConfig", "adhHttp", "adhPreliminaryNames", "adhShowError", "adhSubmitIfValid", "$window", Process.createDirective]);
 };

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
@@ -1,4 +1,3 @@
-import * as AdhEmbedModule from "../../Core/Embed/Module";
 import * as AdhIdeaCollectionModule from "../../Core/IdeaCollection/Module";
 import * as AdhNamesModule from "../../Core/Names/Module";
 import * as AdhProcessModule from "../../Core/Process/Module";
@@ -14,8 +13,6 @@ import RIGeoProposal from "../../../Resources_/adhocracy_core/resources/proposal
 import RIGeoProposalVersion from "../../../Resources_/adhocracy_core/resources/proposal/IGeoProposalVersion";
 import RIIdeaCollectionProcess from "../../../Resources_/adhocracy_meinberlin/resources/idea_collection/IProcess";
 
-import * as AdhEmbed from "../../Core/Embed/Embed";
-
 
 export var moduleName = "adhMeinberlinIdeaCollection";
 
@@ -24,20 +21,11 @@ export var register = (angular) => {
 
     angular
         .module(moduleName, [
-            AdhEmbedModule.moduleName,
             AdhIdeaCollectionModule.moduleName,
             AdhNamesModule.moduleName,
             AdhProcessModule.moduleName,
             AdhResourceAreaModule.moduleName,
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider : AdhEmbed.Provider) => {
-            adhEmbedProvider
-                .registerDirective("meinberlin-proposal-detail")
-                .registerDirective("meinberlin-proposal-list-item")
-                .registerDirective("meinberlin-proposal-create")
-                .registerDirective("meinberlin-proposal-edit")
-                .registerDirective("meinberlin-proposal-list");
-        }])
         .config(["adhResourceAreaProvider", "adhConfig", (adhResourceAreaProvider: AdhResourceArea.Provider, adhConfig) => {
             var registerRoutes = AdhIdeaCollectionWorkbench.registerRoutesFactory(
                 RIIdeaCollectionProcess, RIGeoProposal, RIGeoProposalVersion, true);

--- a/src/mercator/mercator/static/js/Packages/Blog/Module.ts
+++ b/src/mercator/mercator/static/js/Packages/Blog/Module.ts
@@ -1,4 +1,3 @@
-import * as AdhEmbedModule from "../Core/Embed/Module";
 import * as AdhHttpModule from "../Core/Http/Module";
 import * as AdhImageModule from "../Core/Image/Module";
 import * as AdhListingModule from "../Core/Listing/Module";
@@ -7,7 +6,6 @@ import * as AdhNamesModule from "../Core/Names/Module";
 import * as AdhPermissionsModule from "../Core/Permissions/Module";
 import * as AdhPreliminaryNamesModule from "../Core/PreliminaryNames/Module";
 
-import * as AdhEmbed from "../Core/Embed/Embed";
 import * as AdhNames from "../Core/Names/Names";
 
 import * as Blog from "./Blog";
@@ -20,7 +18,6 @@ export var moduleName = "adhBlog";
 export var register = (angular) => {
     angular
         .module(moduleName, [
-            AdhEmbedModule.moduleName,
             AdhHttpModule.moduleName,
             AdhImageModule.moduleName,
             AdhListingModule.moduleName,
@@ -29,12 +26,6 @@ export var register = (angular) => {
             AdhPermissionsModule.moduleName,
             AdhPreliminaryNamesModule.moduleName
         ])
-        .config(["adhEmbedProvider", (adhEmbedProvider: AdhEmbed.Provider) => {
-            adhEmbedProvider
-                .registerDirective("blog-post")
-                .registerDirective("blog-post-create")
-                .registerDirective("blog");
-        }])
         .config(["adhNamesProvider", (adhNamesProvider : AdhNames.Provider) => {
             adhNamesProvider.names[RIDocumentVersion.content_type] = "TR__RESOURCE_DOCUMENT";
         }])


### PR DESCRIPTION
Adhocracy generally allows to mark directives as embeddable. This may be done for any of the following reasons:

1. The directive should be embedded on a 3rd party website
2. The directive should be tested on its own through protractor
3. The directive should be tested on its own by developers

In the past we marked many directives as embeddable mainly because of (3): It made development simpler.

When a directive becomes embeddable, the directive, including its interface, become part of the public embedding API which needs to maintain backwards compatibility. This is a strong reason not to mark directives as embeddable by default. (Issues like #2839 may occur)

In an effort to reduce the size of our public API I tried to find out which directives are actually used. Piwik gave me the following results:

- `mein-berlin-bplaene-proposal-embed`
- `meinberlin-stadtforum-proposal-detail`

In addition to that, the following directives are used in acceptance tests:

- `create-or-show-comment-listing`
- `social-share`
- `mercator-2016-proposal-create`

In this pull request I am removing all other embeddable directives.