### PR TITLE
update protractor to next major release 4

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/EmbeddedCommentsPage.js
@@ -27,6 +27,7 @@ var EmbeddedCommentsPage = function(referer) {
     };
 
     this.fillComment = function(content) {
+        browser.wait(this.listingCreateForm.isDisplayed());
         browser.wait(this.commentInput.isDisplayed());
         this.commentInput.sendKeys(content);
     };

--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -151,7 +151,7 @@ inline =
             "tslint": "3.15.1",
             "bower": "1.7.9",
             "jasmine": "2.4.1",
-            "protractor": "3.3.0",
+            "protractor": "4.0.11",
             "sync-exec": "0.6.2",
             "q": "1.4.1",
             "lodash": "4.15.0",


### PR DESCRIPTION
Manual update steps needed:

- `bin/buildout`
- `bin/webdriver-manager update`
- make sure google-chrome version >= 53