### PR TITLE
update bower to 3.8.0

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -149,7 +149,7 @@ inline =
         "devDependencies": {
             "typescript": "1.8.10",
             "tslint": "3.15.1",
-            "bower": "1.7.9",
+            "bower": "1.8.0",
             "jasmine": "2.4.1",
             "protractor": "3.3.0",
             "sync-exec": "0.6.2",


### PR DESCRIPTION
small stability improvement:

- Download tar archives from GitHub when possible (https://github.com/bower/bower/pull/2263)
- Change default shorthand resolver for github from git:// to https://
- Fix ssl handling by not setting GIT_SSL_NO_VERIFY=false (https://github.com/bower/bower/pull/2361)