### PR TITLE
transition acitivity && quick fix not to notify user about changed workflow assignments data

### DIFF
--- a/src/adhocracy_core/adhocracy_core/activity/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/activity/__init__.py
@@ -116,17 +116,20 @@ def _get_content_sheets(change: ChangelogMetadata, request: Request) -> []:
         resource = change.last_version
     else:
         resource = change.resource
+    content = request.registry.content
     if change.created:
-        sheets = request.registry.content.get_sheets_create(resource,
-                                                            request=request)
+        sheets = content.get_sheets_create(resource, request=request)
+    elif change.modified:
+        appstructs = change.modified_appstructs or dict()
+        sheets = [content.get_sheet(resource, s, request=request)
+                  for s in appstructs]
     else:
-        sheets = request.registry.content.get_sheets_edit(resource,
-                                                          request=request)
+        sheets = content.get_sheets_edit(resource, request=request)
     disabled = [IMetadata]
     return [s for s in sheets if s.meta.isheet not in disabled]
 
 
-def _get_sheet_data(sheets: [ISheet]) -> {}:
+def _get_sheet_data(sheets: [ISheet]) -> []:
     sheet_data = []
     for sheet in sheets:
             sheet_data.append({sheet.meta.isheet:

--- a/src/adhocracy_core/adhocracy_core/activity/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/activity/__init__.py
@@ -26,6 +26,7 @@ from adhocracy_core.interfaces import VisibilityChange
 from adhocracy_core.interfaces import ActivityType
 from adhocracy_core.interfaces import Activity
 from adhocracy_core.resources.comment import IComment
+from adhocracy_core.sheets.workflow import IWorkflowAssignment
 from adhocracy_core.utils import get_iresource
 
 logger = getLogger(__name__)
@@ -106,9 +107,20 @@ def _get_entry_name(change: ChangelogMetadata) -> str:
     elif change.visibility == VisibilityChange.concealed:
         return ActivityType.remove
     elif change.modified:
-        return ActivityType.update
+        if _is_workflow_state_change(change):
+            return ActivityType.transition
+        else:
+            return ActivityType.update
     else:  # pragma: no cover
         raise ValueError('Invalid change state', change)
+
+
+def _is_workflow_state_change(change: ChangelogMetadata) -> bool:
+    appstructs = change.modified_appstructs or dict()
+    assignment_change = [x for x in appstructs.keys()] == [IWorkflowAssignment]
+    state_change = appstructs.get(IWorkflowAssignment,
+                                  {}).get('workflow_state')
+    return assignment_change and state_change
 
 
 def _get_content_sheets(change: ChangelogMetadata, request: Request) -> []:
@@ -194,6 +206,11 @@ def generate_activity_name(activity: Activity,
                  mapping=mapping,
                  default=u'${subject_name} removed a ${object_type_name} from '
                          '${target_title}.')
+    elif activity.type == ActivityType.transition:
+        name = _('activity_name_transition',
+                 mapping=mapping,
+                 default=u'${subject_name} changed workflow state of '
+                         '${object_type_name}.')
     else:
         name = _('activity_missing', mapping=mapping)
     return name
@@ -235,6 +252,11 @@ def generate_activity_description(activity: Activity,
                  default=u'${subject_name} removed the ${object_type_name} '
                          '"${object_title}" from ${target_type_name} '
                          '"${target_title}".')
+    elif activity.type == ActivityType.transition:
+        name = _('activity_description_transition',
+                 mapping=mapping,
+                 default=u'${subject_name} changed workfow state of '
+                         '"${object_title}".')
     else:
         name = _('activity_missing', mapping=mapping)
     return name

--- a/src/adhocracy_core/adhocracy_core/activity/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/activity/test_init.py
@@ -114,6 +114,19 @@ class TestUpdateActicityCallback:
         assert added_activity.type == ActivityType.update
         assert added_activity.object == context
 
+    def test_add_transition_activity_if_state_modified_and_state_changed(
+            self, request_, add_to, changelog, context, mock_sheet):
+        from adhocracy_core.interfaces import ActivityType
+        from adhocracy_core.sheets.workflow import IWorkflowAssignment
+        appstructs = {IWorkflowAssignment: {'workflow_state': 'draft'}}
+        changelog['/'] = changelog['']._replace(modified=True,
+                                                modified_appstructs=appstructs,
+                                                resource=context)
+        request_.registry.content.get_sheet.return_value = mock_sheet
+        self.call_fut(request_, None)
+        added_activity = add_to.call_args[0][0][0]
+        assert added_activity.type == ActivityType.transition
+
     def test_add_update_item_activity_if_version_created(
         self, request_, registry, add_to, changelog, item, version):
         from adhocracy_core.interfaces import ActivityType
@@ -299,6 +312,14 @@ class TestGenerateActivityName:
         assert name.default.format_map(name.mapping)
         assert name == 'activity_name_update'
 
+    def test_create_add_translation_if_transition_activity(self, activity,
+                                                           request_):
+        from adhocracy_core.interfaces import ActivityType
+        activity = activity._replace(type=ActivityType.transition)
+        name = self.call_fut(activity, request_)
+        assert name.default.format_map(name.mapping)
+        assert name == 'activity_name_transition'
+
 
 @mark.usefixtures('get_subject_name', 'get_resource_type', 'get_title')
 class TestGenerateActivityDescription:
@@ -348,6 +369,14 @@ class TestGenerateActivityDescription:
         name = self.call_fut(activity, request_)
         assert name.default.format_map(name.mapping)
         assert name == 'activity_description_update'
+
+    def test_create_add_translation_if_transition_activity(self, activity,
+                                                           request_):
+        from adhocracy_core.interfaces import ActivityType
+        activity = activity._replace(type=ActivityType.transition)
+        name = self.call_fut(activity, request_)
+        assert name.default.format_map(name.mapping)
+        assert name == 'activity_description_transition'
 
 
 def test_get_subject_name_return_user_name(context, registry):

--- a/src/adhocracy_core/adhocracy_core/activity/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/activity/test_init.py
@@ -189,12 +189,16 @@ class TestUpdateActicityCallback:
 
     def test_add_sheet_data_if_modified(self, request_, add_to, changelog,
                                         context, mock_sheet, registry):
-        registry.content.get_sheets_edit.return_value = [mock_sheet]
-        changelog['/'] = changelog['']._replace(modified=True, resource=context)
+        registry.content.get_sheet.return_value = mock_sheet
+        appstructs = {mock_sheet.isheet: {}}
+        changelog['/'] = changelog['']._replace(modified=True,
+                                                modified_appstructs=appstructs,
+                                                resource=context)
         self.call_fut(request_, None)
         added_activity = add_to.call_args[0][0][0]
-        registry.content.get_sheets_edit.assert_called_with(context,
-                                                            request=request_)
+        registry.content.get_sheet.assert_called_with(context,
+                                                      mock_sheet.isheet,
+                                                      request=request_)
         assert added_activity.sheet_data == [{mock_sheet.meta.isheet:
                                               mock_sheet.serialize()}]
 

--- a/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
+++ b/src/adhocracy_core/adhocracy_core/changelog/test_subscriber.py
@@ -60,8 +60,7 @@ def test_add_changelog_followed_with_has_follows(event, changelog):
     assert changelog['/'].followed_by is event.new_version
 
 
-
-class TestAddChangelogModified:
+class TestAddChangelogModifiedSheet:
 
     @fixture
     def context(self, context):
@@ -73,21 +72,32 @@ class TestAddChangelogModified:
         root['parent']['child'] = context
         return context
 
+    @fixture
+    def event(self, event):
+        from adhocracy_core.interfaces import ISheet
+        event.new_appstruct = {}
+        event.isheet = ISheet
+        return event
+
     def call_fut(self, event):
-        from .subscriber import add_changelog_modified_and_descendants
-        return add_changelog_modified_and_descendants(event)
+        from .subscriber import add_changelog_modified_sheet
+        return add_changelog_modified_sheet(event)
 
     def test_set_modified_changelog(self, event, changelog):
         self.call_fut(event)
         assert changelog['/parent/child'].modified is True
 
-    def test_set_modified_changelog_with_missing_registry(
-            self, event, changelog, registry):
-        """Get threadlocal registry for ACLModified events."""
-        delattr(event, 'registry')
-        registry.changelog = changelog
+    def test_update_modified_appstructs_changelog(self, event, changelog):
+        from adhocracy_core.interfaces import ISheet
+        from adhocracy_core.interfaces import IPredicateSheet
+        changelog['/parent/child'] = changelog['/parent/child']\
+            ._replace(modified_appstructs={ISheet: {}})
+        event.isheet = IPredicateSheet
+        event.new_appstruct = {'f': 'v'}
         self.call_fut(event)
-        assert changelog['/parent/child'].modified is True
+        assert changelog['/parent/child'].modified_appstructs ==\
+               {ISheet: {},
+                event.isheet: event.new_appstruct}
 
     def test_dont_set_changed_descendants_for_context(self, event, changelog):
         self.call_fut(event)
@@ -106,6 +116,50 @@ class TestAddChangelogModified:
         self.call_fut(event)
         assert changelog['/parent'].changed_descendants is True
         assert changelog['/'].changed_descendants is False
+
+    def test_increment_changed_descendants_counter_for_parents(self, event,
+                                                               changelog):
+        self.call_fut(event)
+        assert changelog['/parent'].resource.\
+                   __changed_descendants_counter__() == 1
+        assert changelog['/'].resource.__changed_descendants_counter__() == 1
+
+
+class TestAddChangelogModifiedACL:
+
+    @fixture
+    def context(self, context):
+        from BTrees.Length import Length
+        root = testing.DummyResource()
+        root.__changed_descendants_counter__ = Length()
+        root['parent'] = testing.DummyResource()
+        root['parent'].__changed_descendants_counter__ = Length()
+        root['parent']['child'] = context
+        return context
+
+    @fixture
+    def event(self, event):
+        del event.registry
+        return event
+
+    @fixture
+    def changelog(self, registry, changelog):
+        registry.changelog = changelog
+        return changelog
+
+    def call_fut(self, event):
+        from .subscriber import add_changelog_modified_acl
+        return add_changelog_modified_acl(event)
+
+    def test_set_modified_changelog(self, event, changelog):
+        self.call_fut(event)
+        assert changelog['/parent/child'].modified is True
+
+    def test_set_changed_descendants_changelog_for_parents(self, event,
+                                                           changelog):
+        self.call_fut(event)
+        assert changelog['/parent'].changed_descendants is True
+        assert changelog['/'].changed_descendants is True
 
     def test_increment_changed_descendants_counter_for_parents(self, event,
                                                                changelog):
@@ -199,7 +253,8 @@ def test_register_subscriber(registry):
     handlers = [x.handler.__name__ for x in registry.registeredHandlers()]
     assert subscriber.add_changelog_created.__name__ in handlers
     assert subscriber.add_changelog_followed.__name__ in handlers
-    assert subscriber.add_changelog_modified_and_descendants.__name__ in handlers
+    assert subscriber.add_changelog_modified_sheet.__name__ in handlers
+    assert subscriber.add_changelog_modified_acl.__name__ in handlers
     assert subscriber.add_changelog_backrefs.__name__ in handlers
     assert subscriber.add_changelog_visibility.__name__ in handlers
     assert subscriber.add_changelog_autoupdated.__name__ in handlers

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -743,7 +743,7 @@ class Activity(namedtuple('Activity', ['subject',
         simple, humane readable description of the activity.
     sheet_data (list):
         List of sheet appstruct data when changing or deleting resources,
-        not part of the actvity stream ontology
+        not part of the activity stream ontology
     published (datetime.DateTime):
         the date/time the activity was published, required
     """
@@ -779,6 +779,8 @@ class ActivityType(Enum):
     add = 'Add'
     update = 'Update'
     remove = 'Remove'
+    transition = 'Transition'
+    """Transition to new workflow state."""
 
 
 class SerializedActivity(namedtuple('SerializedActivity', ['subject_path',

--- a/src/adhocracy_core/adhocracy_core/interfaces.py
+++ b/src/adhocracy_core/adhocracy_core/interfaces.py
@@ -616,6 +616,7 @@ class VisibilityChange(Enum):
 
 class ChangelogMetadata(namedtuple('ChangelogMetadata',
                                    ['modified',
+                                    'modified_appstructs',
                                     'created',
                                     'autoupdated',
                                     'followed_by',
@@ -626,6 +627,7 @@ class ChangelogMetadata(namedtuple('ChangelogMetadata',
                                     'visibility'])):
     def __new__(cls,
                 modified: bool=False,
+                modified_appstructs: list=None,
                 created: bool=False,
                 autoupdated: bool=False,
                 followed_by: IResource=None,
@@ -635,7 +637,8 @@ class ChangelogMetadata(namedtuple('ChangelogMetadata',
                 changed_backrefs: bool=False,
                 visibility: str=VisibilityChange.visible,
                 ):
-        return super().__new__(cls, modified, created, autoupdated,
+        return super().__new__(cls, modified, modified_appstructs,
+                               created, autoupdated,
                                followed_by, resource, last_version,
                                changed_descendants, changed_backrefs,
                                visibility)
@@ -647,6 +650,7 @@ class ChangelogMetadata(namedtuple('ChangelogMetadata',
     modified (bool):
         Resource sheets (:class:`adhocracy_core.interfaces.IResourceSheet`) are
         modified.
+    modified_appstructs {Interface: dict} or None: new sheet appstructs
     created (bool):
         This resource is created and added to a pool.
     autoupdated (bool):

--- a/src/adhocracy_core/adhocracy_core/notification/test_subscribers.py
+++ b/src/adhocracy_core/adhocracy_core/notification/test_subscribers.py
@@ -129,6 +129,34 @@ class TestSendActivityNotificationEmails:
         self.call_fut(event)
         assert not mock_messenger.send_activity_mail.called
 
+    def test_ignore_if_transition(self, event, activity, mock_catalogs,
+                                  mock_messenger, search_result, followable):
+        from adhocracy_core.interfaces import ActivityType
+        activity = activity._replace(object=followable,
+                                     type=ActivityType.transition)
+        event.activities = [activity]
+        user = testing.DummyResource()
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[user])
+        self.call_fut(event)
+        assert not mock_messenger.send_activity_mail.called
+
+    def test_ignore_if_workflow_assignment_update(
+            self, event, activity, mock_catalogs, mock_messenger,
+            search_result, followable):
+        from adhocracy_core.interfaces import ActivityType
+        from adhocracy_core.sheets.workflow import IWorkflowAssignment
+        sheet_data = [{IWorkflowAssignment: {}}]
+        activity = activity._replace(object=followable,
+                                     type=ActivityType.update,
+                                     sheet_data=sheet_data)
+        event.activities = [activity]
+        user = testing.DummyResource()
+        mock_catalogs.search.return_value = search_result._replace(
+            elements=[user])
+        self.call_fut(event)
+        assert not mock_messenger.send_activity_mail.called
+
 
 @fixture
 def integration(config) -> Configurator:

--- a/src/adhocracy_core/adhocracy_core/websockets/client.py
+++ b/src/adhocracy_core/adhocracy_core/websockets/client.py
@@ -130,7 +130,9 @@ class Client:
                            ' try again later')
 
     def _send_messages(self, changelog_metadata: list):
-        self.changelog_metadata_messages_to_send.update(changelog_metadata)
+        metadata = [x._replace(modified_appstructs=None)  # remove non hashable
+                    for x in changelog_metadata]
+        self.changelog_metadata_messages_to_send.update(metadata)
         while self.changelog_metadata_messages_to_send:
             meta = self.changelog_metadata_messages_to_send.pop()
             events = extract_events_from_changelog_metadata(meta)


### PR DESCRIPTION
refactoring:

- add modified_appstructs to transaction changelog metadata 		
- add only changed sheet data to auditlog 		

Internal API extension:	

- add activity type "transition" (changed workflow state),  fixes #2475	

Bugs:

- dont notify user about changed workflow assignment data and transitions, fixes #2847