### PR TITLE
quickfix: hide process header of IdeaCollection on berlin.de

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Process/Process.ts
@@ -74,6 +74,10 @@ export var detailDirective = (
                         }
 
                         scope.contentType = scope.processProperties.versionClass.content_type;
+                        var context = adhEmbed.getContext();
+                        var notIdeaColl = resource.content_type !== "adhocracy_meinberlin.resources.idea_collection.IProcess";
+                        // show the resource header if there is no embed context and the process type is not idea collection.
+                        scope.hasResourceHeader = (context === "" && notIdeaColl);
                     });
                 }
             });
@@ -82,9 +86,6 @@ export var detailDirective = (
             scope.showMap = (isShowMap) => {
                 scope.data.isShowMap = isShowMap;
             };
-
-            var context = adhEmbed.getContext();
-            scope.hasResourceHeader = (context === "");
         }
     };
 };


### PR DESCRIPTION
this is ugly, but fast.