### PR TITLE
Disable unreliable tests

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/CommentSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/CommentSpec.js
@@ -55,7 +55,7 @@ describe("comments", function() {
         expect(page.getCommentText(comment)).toEqual("comment 0b1");
     });
 
-    it("can be edited after child edit", function() {
+    xit("can be edited after child edit", function() {
         var page = new EmbeddedCommentsPage("c10").get();
         var parent = page.createComment("comment 1");
         var reply = page.createReply(parent, "comment 1.1");

--- a/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/RateSpec.js
+++ b/src/adhocracy_frontend/adhocracy_frontend/tests/acceptance/RateSpec.js
@@ -51,7 +51,7 @@ describe("ratings", function() {
         expect(rate.element(by.css(".rate-contra")).getText()).toEqual("1");
     });
 
-    it("is not affected by the edition of the comment", function() {
+    xit("is not affected by the edition of the comment", function() {
         var page = new EmbeddedCommentsPage("c2").get();
         var comment = page.createComment("c4");
         var rate = page.getRateWidget(comment);


### PR DESCRIPTION
These two tests tend to fail a lot. To make travis more reliable I propose to disable them.