### PR TITLE
treat all links in markdown as external

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Markdown/Markdown.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Markdown/Markdown.ts
@@ -19,6 +19,10 @@ export var parseMarkdown = (adhConfig : AdhConfig.IService, markdownit) => {
             scope.$watch("parsetext", (newValue : string) => {
                 if (newValue) {
                     wrapper.html(md.render(newValue));
+                    wrapper.find("[href]").attr({
+                        rel: "external",
+                        target: "_blank",
+                    });
                 } else {
                     wrapper.html("");
                 }


### PR DESCRIPTION
This solves two issues:

- angular seems hijack the routing to some static files if they are under the same domain
- links "oben" in iframe if embedded

I think it is fair to assume that all links in markdown are external. Even if they link to adhocracy content it should be treated as reference rather than navigation.