### PR TITLE
two quickfixes for collaborative text editing

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
@@ -16,6 +16,7 @@ import * as SIMultiPolygon from "../../../Resources_/adhocracy_core/sheets/geo/I
 import * as SIName from "../../../Resources_/adhocracy_core/sheets/name/IName";
 import * as SITitle from "../../../Resources_/adhocracy_core/sheets/title/ITitle";
 import * as SIWorkflow from "../../../Resources_/adhocracy_core/sheets/workflow/IWorkflowAssignment";
+import RIDocument from "../../../Resources_/adhocracy_core/resources/document/IDocument";
 import RIProcess from "../../../Resources_/adhocracy_core/resources/process/IProcess";
 
 var pkgLocation = "/Core/Process";
@@ -257,7 +258,7 @@ export var detailDirective = (
 
             scope.data = {};
 
-            if (scope.processProperties.itemClass.content_type === "adhocracy_core.resources.document.IDocument") {
+            if (scope.processProperties.itemClass.content_type === RIDocument.content_type) {
                 scope.sorts = [{
                     key: "title",
                     index: "title"

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
@@ -259,10 +259,8 @@ export var detailDirective = (
 
             if (scope.processProperties.itemClass.content_type === "adhocracy_core.resources.document.IDocument") {
                 scope.sorts = [{
-                    key: "item_creation_date",
-                    name: "TR__CREATION_DATE",
-                    index: "item_creation_date",
-                    reverse: false
+                    key: "title",
+                    index: "title"
                 }];
             } else {
                 scope.sorts = [{

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
@@ -275,6 +275,7 @@ export var detailDirective = (
                     index: "item_creation_date",
                     reverse: true
                 }];
+                scope.sort = "item_creation_date";
             }
 
             scope.$watch("path", (value : string) => {

--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/Process/Process.ts
@@ -257,18 +257,26 @@ export var detailDirective = (
 
             scope.data = {};
 
-            scope.sorts = [{
-                key: "rates",
-                name: "TR__RATES",
-                index: "rates",
-                reverse: true
-            }, {
-                key: "item_creation_date",
-                name: "TR__CREATION_DATE",
-                index: "item_creation_date",
-                reverse: true
-            }];
-            scope.sort = "item_creation_date";
+            if (scope.processProperties.itemClass.content_type === "adhocracy_core.resources.document.IDocument") {
+                scope.sorts = [{
+                    key: "item_creation_date",
+                    name: "TR__CREATION_DATE",
+                    index: "item_creation_date",
+                    reverse: false
+                }];
+            } else {
+                scope.sorts = [{
+                    key: "rates",
+                    name: "TR__RATES",
+                    index: "rates",
+                    reverse: true
+                }, {
+                    key: "item_creation_date",
+                    name: "TR__CREATION_DATE",
+                    index: "item_creation_date",
+                    reverse: true
+                }];
+            }
 
             scope.$watch("path", (value : string) => {
                 if (value) {

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Buergerhaushalt/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Buergerhaushalt/Module.ts
@@ -56,7 +56,6 @@ export var register = (angular) => {
                 hasAuthorInListItem: true,
                 hasCommentColumn: true,
                 hasDescription: true,
-                hasImage: true,
                 hasLocation: true,
                 hasLocationText: true,
                 itemClass: RIBuergerhaushaltProposal,

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/CollaborativeText/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/CollaborativeText/Module.ts
@@ -44,7 +44,6 @@ export var register = (angular) => {
                 detailSlot: adhConfig.pkg_path + AdhDocument.pkgLocation + "/DetailSlot.html",
                 editSlot: adhConfig.pkg_path + AdhDocument.pkgLocation + "/EditSlot.html",
                 hasCommentColumn: true,
-                hasImage: true,
                 itemClass: RIDocument,
                 versionClass: RIDocumentVersion
             });

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/IdeaCollection/Module.ts
@@ -47,7 +47,6 @@ export var register = (angular) => {
                 hasAuthorInListItem: true,
                 hasCommentColumn: true,
                 hasDescription: true,
-                hasImage: true,
                 hasLocation: true,
                 itemClass: RIGeoProposal,
                 versionClass: RIGeoProposalVersion

--- a/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Kiezkasse/Module.ts
+++ b/src/meinberlin_lib/meinberlin_lib/static/js/Packages/Meinberlin/Kiezkasse/Module.ts
@@ -57,7 +57,6 @@ export var register = (angular) => {
                 hasCommentColumn: true,
                 hasCreatorParticipate: true,
                 hasDescription: true,
-                hasImage: true,
                 hasLocation: true,
                 hasLocationText: true,
                 itemClass: RIKiezkasseProposal,

--- a/src/spd/spd/static/js/Packages/spd/CollaborativeText/Module.ts
+++ b/src/spd/spd/static/js/Packages/spd/CollaborativeText/Module.ts
@@ -51,7 +51,6 @@ export var register = (angular) => {
                 detailSlot: adhConfig.pkg_path + AdhDocument.pkgLocation + "/DetailSlot.html",
                 editSlot: adhConfig.pkg_path + AdhDocument.pkgLocation + "/EditSlot.html",
                 hasCommentColumn: true,
-                hasImage: true,
                 itemClass: RIDocument,
                 versionClass: RIDocumentVersion
             });


### PR DESCRIPTION
#2842 broke a property we weren't conscious of: documents were previously presented alphabetically. This PR restores the old order this way: the process detail view controller just asks if the items to be displayed are documents. If so, it sorts them by title. Otherwise, the usual facets are generated.

Besides that, the image thumbnail is eliminated from the list item.