### PR TITLE
increase padding to leave room for osx scrollbars

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/stylesheets/scss/general/_variables.scss
@@ -48,7 +48,7 @@ $moving-column-border-width: 5px;
 $annotation-width: 34%;
 
 // Padding
-$padding: 0.8rem;
+$padding: 1.5rem;
 
 // Other
 $moving-column-single-width-max: 55rem;


### PR DESCRIPTION
OSX has the strange habit to draw scrollbars on top of content, blocking its use. To work around that, I increased the general padding.

![image](https://cloud.githubusercontent.com/assets/202576/20711404/d3d91a82-b63f-11e6-80ec-a33956964687.png)
