### PR TITLE
update python dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ src/meinberlin/meinberlin/build/
 src/s1/s1/build/
 src/spd/spd/build/
 src/demo/demo/build/
+src/hypatia
+src/sphinxcontrib-programoutput
+src/bpython/
 /tmp
 /wheelhouse
 /share

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ branches:
   only:
     - master
 python:
-  - "3.4"
+  - "3.5"
 install:
   - "git fetch --unshallow"
-  - "python bootstrap.py --setuptools-version=12.0.4"
+  - "python bootstrap.py --setuptools-version=32.0.0"
   - "PATH=${TRAVIS_BUILD_DIR}/bin:${PATH} ./bin/buildout -c buildout-${BUILDOUT_TARGET}.cfg 2>/dev/null"
 before_script:
   # setup xvfb for protractor tests

--- a/src/adhocracy_core/adhocracy_core/catalog/test_index.py
+++ b/src/adhocracy_core/adhocracy_core/catalog/test_index.py
@@ -227,14 +227,16 @@ class TestReference:
         with raises(KeyError):
             inst.apply(query)
 
-    def test_apply_intersect_reference_not_exists(self, mock_objectmap):
+    def test_apply_intersect_reference_not_exists(self, mock_objectmap, mock_graph):
         # actually we test the default implementation in hypatia.util
         import BTrees
         from adhocracy_core.interfaces import ISheet
         from adhocracy_core.interfaces import Reference
         mock_objectmap.sourceids.return_value = set()
         inst = self.make_one()
-        inst._mock_objectmap = mock_objectmap
+        inst._objectmap = mock_objectmap
+        mock_graph.get_reftypes.return_value = []
+        inst.__graph__ = mock_graph
         target = testing.DummyResource()
         reference = Reference(None, ISheet, '', target)
         query = {'reference': reference}

--- a/src/adhocracy_core/adhocracy_core/graph/test_init.py
+++ b/src/adhocracy_core/adhocracy_core/graph/test_init.py
@@ -412,7 +412,7 @@ class TestGraphSetReferencesForIsheet:
     def test_with_references_is_none(self, context, mock_graph, registry):
         references = {'references': None}
         self.call_fut(mock_graph, context, ISheet, references, registry)
-        mock_graph.set_references.assert_called is False
+        mock_graph.set_references.called is False
 
     def test_with_references_is_one_resource(self, context, mock_graph, registry):
         from adhocracy_core.interfaces import IResource

--- a/src/adhocracy_core/adhocracy_core/rest/test_schemas.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_schemas.py
@@ -1374,7 +1374,7 @@ class TestDeferredValidateResetPasswordEmail:
                                      activate=Mock())
         mock_user_locator.get_user_by_email.return_value = user
         validator(node, 'test@email.de')
-        user.activate.assert_called
+        assert user.activate.called
         assert request_.validated['user'] is user
 
 

--- a/src/adhocracy_core/adhocracy_core/rest/test_views.py
+++ b/src/adhocracy_core/adhocracy_core/rest/test_views.py
@@ -1301,7 +1301,7 @@ class TestPasswordResetView:
         mock_remember.return_value = [('X-User-Token', 'token')]
         inst = self.make_one(context, request_)
         result = inst.post()
-        mock_reset.reset_password.assert_called()
+        assert mock_reset.reset_password.called
         mock_remember.assert_called_with(request_, '/')
         mock_reset.reset_password.assert_called_with('password')
         assert result == {'status': 'success',

--- a/src/adhocracy_core/adhocracy_core/scripts/test_ad_export_users.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/test_ad_export_users.py
@@ -32,7 +32,7 @@ class TestGetUsers:
         mock_locator = Mock()
         registry.getMultiAdapter = mock_locator
         users = self.call_fut(context, registry)
-        mock_locator.get_users.assert_called_once()
+        assert mock_locator.return_value.get_users.called
 
 class TestWriteUsersToCSV:
 

--- a/src/adhocracy_core/adhocracy_core/test_memory.yaml
+++ b/src/adhocracy_core/adhocracy_core/test_memory.yaml
@@ -3,6 +3,7 @@
 # include 3rd party pyramid packages
 
 include:
+  pyramid_mailer: False
   pyramid_mailer.testing: True
 
 # configure 3rd party pyramid packages

--- a/src/adhocracy_core/adhocracy_core/test_persistent.yaml
+++ b/src/adhocracy_core/adhocracy_core/test_persistent.yaml
@@ -3,6 +3,7 @@
 # include 3rd party pyramid packages
 
 include:
+  pyramid_mailer: False
   pyramid_mailer.testing: True
 
 # include 3rd party pyramid packages

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -52,11 +52,11 @@ test_requires = [
     'lingua',
     'testfixtures',
     'Sphinx',
+    'sphinxcontrib_programoutput',
     'repoze.sphinx.autointerface',
     'sphinx-autodoc-annotation',
     'sphinxcontrib-blockdiag',
     'sphinxcontrib-actdiag',
-    'sphinxcontrib-programoutput',
     'sphinx-rtd-theme',
     'requires.io',
 ]

--- a/src/adhocracy_core/sources.cfg
+++ b/src/adhocracy_core/sources.cfg
@@ -5,11 +5,14 @@ always-checkout = Force
 
 [sources]
 supervisor = git https://github.com/Supervisor/supervisor.git rev=a5aedd836fe2c77eb5e16844e61393c32a84c60d
-sphinx-autodoc-annotation = git https://github.com/hsoft/sphinx-autodoc-annotation.git rev=5a5bb637dbde91ac3dde70546b6da4949851bf1c
-substanced = git https://github.com/Pylons/substanced.git rev=daba651da7f12bdcc1cd218be589988c485d84af
-# fix bug https://github.com/wichert/lingua/issues/60
-Mako = git https://bitbucket.org/ldaverio/mako.git rev=266d167
-# fix bug with date input widget
+substanced = git https://github.com/Pylons/substanced.git rev=7937fd8e0cb57d001ceb580454a49bdb4250763d
+#  fix bug with date input widget
 deform = git https://github.com/Pylons/deform.git rev=b31ca03a5239e0ccb6710249e8a80fb1776e78c8
 # checkout for development
 deform_markdown = git https://github.com/liqd/deform_markdown.git
+# fix problem with easy_install
+sphinxcontrib-programoutput = git https://github.com/solarkennedy/sphinxcontrib-programoutput.git rev=de6234a2e7a33393824b3c26c6d98f39ea6d2f17
+# fix problem with easy_install
+bpython = git https://github.com/bpython/bpython rev=237a493b2c99cefe6c28ad752cdbe633781a732d
+# checkout version 0.4dev
+hypatia = git https://github.com/Pylons/hypatia.git rev=77a07dd5515a0e5bc3db21ef12bfc66a47dfcaa5

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -1,74 +1,73 @@
 [versions]
-deform_markdown = 0.2.5
+deform_markdown = 0.2.8
 Sphinx = 1.3.5
-Jinja2 = 2.7.3
+Jinja2 = 2.8
 MarkupSafe = 0.23
 PasteDeploy = 1.5.2
-Pygments = 2.0.2
-WebOb = 1.5.1
+Pygments = 2.1.3
+WebOb = 1.6.0
 WebTest = 2.0.18
-astroid = 1.3.4
+astroid = 1.4.9
 bowerrecipe = 0.2
 collective.recipe.omelette = 0.16
 collective.recipe.supervisor = 0.20
 collective.recipe.template = 1.13
-contexttimer = 0.3.1
-python-coveralls = 2.5.0
+contexttimer = 0.3.3
+python-coveralls = 2.9.0
 PyJWT = 1.4.0
 pyramid-jwt = 1.1
-sh = 1.11
-coverage = 3.7.1
+sh = 1.12.8
+coverage = 4.0.3
 deform = 2.0a2
-docutils = 0.12
-flake8 = 3.0.4
+flake8 = 3.2.1
 flake8-debugger = 1.4.0
 flake8-docstrings = 1.0.2
 flake8-quotes = 0.8.1
 gp.recipe.node = 6.2.2.1
 hypatia = 0.3
-logilab-common = 0.63.2
-mccabe = 0.5.2
+logilab-common = 1.3
+mccabe = 0.5.3
 meld3 = 1.0.0
-mr.developer = 1.31
+mr.developer = 1.34
 pep8 = 1.7.0
 pep8-naming = 0.4.1
 peppercorn = 0.5
 pip = 7.1.2
 plone.recipe.command = 1.1
 profilehooks = 1.7.1
-pudb = 2015.2
-py = 1.4.30
+pudb = 2016.2
+py = 1.4.32
 pycallgraph = 1.0.1
-pyflakes = 0.8.1
-pylint = 1.4.1
+pyflakes = 1.3.0
+pylint = 1.6.4
 pyramid-zodbconn = 0.7
 pyrsistent = 0.11.0
-pytest-timeout = 0.5
-repoze.sendmail = 4.2
-requests = 2.5.1
+pytest-timeout = 1.2.0
+repoze.sendmail = 4.3
+requests = 2.12.4
 rubygemsrecipe = 0.2.2
-selenium = 2.44.0
+selenium = 3.0.2
 Babel = 1.3
 repoze.sphinx.autointerface = 0.8
-snowballstemmer = 1.2.0
+snowballstemmer = 1.2.1
 transifex-client = 0.11b3
-urwid = 1.3.0
+urwid = 1.3.1
 venusian = 1.0
-waitress = 0.8.9
+waitress = 1.0.1
 z3c.recipe.mkdir = 0.6
-zc.buildout = 2.5.2
+zc.buildout = 2.5.3
 zc.recipe.egg = 2.0.3
-zdaemon = 4.0.1
+zdaemon = 4.2.0
 zodbpickle = 0.6.0
 
 # Required by:
 # ZODB==4.1.0
 # hypatia==0.3
-BTrees = 4.2.0
+BTrees = 4.3.1
 
 # Required by:
 # pyramid-chameleon==0.3
-Chameleon = 2.22
+Chameleon = 3.0
 
 # Required by:
 # adhocracy-core==0.0
@@ -82,23 +81,23 @@ PyYAML = 3.11
 # ZODB==4.1.0
 # zdaemon==4.0.1
 # zodburi==2.0
-ZConfig = 3.0.4
+ZConfig = 3.1.0
 
 # Required by:
 # zodburi==2.0
-ZEO = 4.1.0
+ZEO = 5.0.4
 
 # Required by:
 # substanced==0.0
-ZODB = 4.2.0
+ZODB = 5.1.1
 
 # Required by:
 # adhocracy-core==0.0
-autobahn = 0.9.6
+autobahn = 0.17.0
 
 # Required by:
 # WebTest==2.0.18
-beautifulsoup4 = 4.4.0
+beautifulsoup4 = 4.5.1
 
 # Required by:
 # adhocracy-core==0.0
@@ -110,7 +109,7 @@ cryptacular = 1.4.1
 
 # Required by:
 # adhocracy-core==0.0
-gunicorn = 19.2.1
+gunicorn = 19.6.0
 
 # Required by:
 # gp.recipe.node==0.10.28.0
@@ -122,7 +121,7 @@ hexagonit.recipe.download = 1.7.1
 
 # Required by:
 # colander==1.0
-iso8601 = 0.1.10
+iso8601 = 0.1.11
 
 # Required by:
 # zodburi==2.0
@@ -139,12 +138,12 @@ pep257 = 0.7.0
 # Required by:
 # ZODB==4.1.0
 # hypatia==0.3
-persistent = 4.1.1
+persistent = 4.2.2
 
 # Required by:
 # adhocracy-core==0.0
 # pyramid-mako==1.0.2
-pyramid = 1.6.1
+pyramid = 1.6.3
 pyramid_bython = 0.1
 
 # Required by:
@@ -158,15 +157,15 @@ pyramid-chameleon = 0.3
 
 # Required by:
 # adhocracy-core==0.0
-pyramid-debugtoolbar = 2.4.2
+pyramid-debugtoolbar = 3.0.5
 
 # Required by:
 # adhocracy-core==0.0
-pyramid-exclog = 0.7
+pyramid-exclog = 0.8
 
 # Required by:
 # substanced==0.0
-pyramid-mailer = 0.14.1
+pyramid-mailer = 0.15.1
 
 # Required by:
 # adhocracy-frontend==0.0
@@ -174,23 +173,22 @@ pyramid-mako = 1.0.2
 
 # Required by:
 # adhocracy-core==0.0
-pyramid-tm = 0.12.1
+pyramid-tm = 1.1.1
 
 # Required by:
 # pytest-pyramid==0.1.1
-pytest = 2.9.1
-
+pytest = 3.0.5
 # Required by:
 # gp.recipe.node==0.10.28.0
 python-archive = 0.2
 
 # Required by:
 # substanced==0.0
-python-magic = 0.4.6
+python-magic = 0.4.12
 
 # Required by:
 # substanced==0.0
-pytz = 2014.10
+pytz = 2016.10
 
 # Required by:
 # pyramid-debugtoolbar==2.3
@@ -202,34 +200,33 @@ repoze.lru = 0.6
 # mr.developer==1.31
 # pyramid==1.5.2
 # zc.recipe.egg==2.0.1
-setuptools = 18.3.2
+setuptools = 32.0.0
 
 # Required by:
 # WebTest==2.0.18
 # pylint==1.4.1
 # rubygemsrecipe==0.2.1
 # websocket-client==0.23.0
-six = 1.9.0
+six = 1.10.0
 
 # Required by:
 # substanced==0.0
-statsd = 3.0.1
+statsd = 3.2.1
 
 # Required by:
 # pyramid-tm==0.10
-transaction = 1.4.4
+transaction = 2.0.3
 
 # Required by:
 # colander==1.0
-translationstring = 1.3
 
 # Required by:
 # adhocracy-core==0.0
-websocket-client = 0.23.0
+websocket-client = 0.40.0
 
 # Required by:
 # ZODB==4.1.0
-zc.lockfile = 1.1.0
+zc.lockfile = 1.2.1
 
 # Required by:
 # pyramid-zodbconn==0.7
@@ -237,7 +234,7 @@ zodburi = 2.0
 
 # Required by:
 # substanced==0.0
-zope.component = 4.2.1
+zope.component = 4.3.0
 
 # Required by:
 # substanced==0.0
@@ -249,20 +246,53 @@ zope.deprecation = 4.1.2
 
 # Required by:
 # zope.component==4.2.1
-zope.event = 4.0.3
+zope.event = 4.2.0
 
 # Required by: repoze.sphinx.autointerface==0.7.1
-zope.interface = 4.1.2
+zope.interface = 4.3.3
 
 # unsorted
 Genshi = 0.7
-argh = 0.26.1
+argh = 0.26.2
 args = 0.1.0
 buildout.requirements = 0.2.2
 collective.recipe.genshi = 1.0
-lingua = 3.10
-multipledispatch = 0.4.8
+lingua = 4.11
+multipledispatch = 0.4.9
 pathtools = 0.1.2
-polib = 1.0.7
+polib = 1.0.8
 polytester = 1.2.0
-testfixtures = 4.1.2
+testfixtures = 4.13.3
+Mako = 1.0.6
+sphinx-autodoc-annotation = 1.0-1
+Unidecode = 0.4.19
+Werkzeug = 0.11.11
+actdiag = 0.5.4
+alabaster = 0.7.9
+blessings = 1.6
+blockdiag = 1.5.3
+bpython = 0.15
+collective.recipe.template = 1.13
+curtsies = 0.2.11
+docutils = 0.12
+funcparserlib = 0.3.6
+greenlet = 0.4.11
+lxml = 3.7.1
+osa = 0.2
+pbr = 1.10.0
+pymlconf = 0.7.0
+pyramid-bpython = 0.1
+pytest-localserver = 0.3.6
+pytest-mock = 1.5.0
+requires.io = 0.2.5
+sphinx-rtd-theme = 0.1.9
+sphinxcontrib-actdiag = 0.8.5
+sphinxcontrib-blockdiag = 1.5.5
+sphinxcontrib-programoutput = 0.8
+translationstring = 1.3
+txaio = 2.5.2
+tzf.pyramid-yml = 1.1.0
+walkabout = 0.10
+wcwidth = 0.1.7
+webcolors = 1.7
+

--- a/src/adhocracy_core/wheels.cfg
+++ b/src/adhocracy_core/wheels.cfg
@@ -11,6 +11,7 @@ wheels =
        src/deform
        src/substanced
        src/adhocracy_core
+       src/hypatia
 platform = none
 input = inline:
     #!/bin/bash


### PR DESCRIPTION
- all: support python 3.5
- requests: security fixes
- ZODB: major update, refactoring, performance improvments
- pyramid_mailer: Fix #451 transaction exceptions in log file
- Mako/sphinx-autodoc-annotations: use pypi instead of custom checkout
- substanced/hypatia: use current development version
- other: mostly minor changes