### PR TITLE
Render proposal detail as markdown

### DIFF
--- a/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Detail.html
+++ b/src/adhocracy_frontend/adhocracy_frontend/static/js/Packages/Core/IdeaCollection/Proposal/Detail.html
@@ -56,7 +56,7 @@
 
 
     <section class="action-section">
-        <p>{{data.detail}}</p>
+        <adh-parse-markdown data-parsetext="data.detail"></adh-parse-markdown>
         <a href="{{ path | adhParentPath | adhResourceUrl:'comments' }}" class="action-section-button">
             <i class="icon-speechbubble"></i> {{ data.commentCount }}
         </a>


### PR DESCRIPTION
This does not really break old content but allows to have much richer
proposals in the future.