### PR TITLE
Fix unicode import from json

### DIFF
--- a/src/adhocracy_core/adhocracy_core/scripts/__init__.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/__init__.py
@@ -81,7 +81,7 @@ def _create_resource(resource_info: PMap,
 
 
 def _load_info(filename: str) -> [dict]:
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf8') as f:
         return json.load(f)
 
 

--- a/src/adhocracy_core/adhocracy_core/scripts/ad_import_users.py
+++ b/src/adhocracy_core/adhocracy_core/scripts/ad_import_users.py
@@ -102,7 +102,7 @@ def import_users(context: IResource, registry: Registry, filename: str):
 
 
 def _load_users_info(filename: str) -> [dict]:
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='utf8') as f:
         return json.load(f)
 
 


### PR DESCRIPTION
We found that importing json files with umlauts explodes - and this is why.