### PR TITLE
update bower Fix: bower using deprecated index url

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -149,7 +149,7 @@ inline =
         "devDependencies": {
             "typescript": "1.8.10",
             "tslint": "3.15.1",
-            "bower": "1.8.0",
+            "bower": "1.8.4",
             "jasmine": "2.4.1",
             "protractor": "4.0.11",
             "sync-exec": "0.6.2",


### PR DESCRIPTION
If npm is complaining about wrong checksums you have to clean the npm cache:

bin/npm cache clean