### PR TITLE
cleanup versions.cfg

### DIFF
--- a/docs/development/development.rst
+++ b/docs/development/development.rst
@@ -123,12 +123,7 @@ Update packages
 python
 ``````
 
-Check whether new Python versions exist::
-
-    bin/requires.io update-site -t a54831113b039e9edbb2d26c2d2f9a9c99887437 -r adhocracy3
-    xdg-open https://requires.io/github/liqd/adhocracy3/requirements/?branch=master
-
-You may then update the pinned Python versions in `versions.cfg` if
+Update the pinned Python versions in `versions.cfg` if
 appropriate.
 
 ruby

--- a/src/adhocracy_core/setup.py
+++ b/src/adhocracy_core/setup.py
@@ -58,7 +58,6 @@ test_requires = [
     'sphinxcontrib-blockdiag',
     'sphinxcontrib-actdiag',
     'sphinx-rtd-theme',
-    'requires.io',
 ]
 
 debug_requires = [

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -1,298 +1,145 @@
 [versions]
-deform_markdown = 0.2.8
-Sphinx = 1.3.5
-Jinja2 = 2.8
-MarkupSafe = 0.23
-PasteDeploy = 1.5.2
-Pygments = 2.1.3
-WebOb = 1.6.0
-WebTest = 2.0.18
-astroid = 1.4.9
-bowerrecipe = 0.2
-collective.recipe.omelette = 0.16
-collective.recipe.supervisor = 0.20
-contexttimer = 0.3.3
-python-coveralls = 2.9.0
-PyJWT = 1.4.0
-pyramid-jwt = 1.1
-sh = 1.12.8
-coverage = 4.0.3
-deform = 2.0a2
-flake8 = 3.2.1
-flake8-debugger = 1.4.0
-flake8-docstrings = 1.0.2
-flake8-quotes = 0.8.1
-gp.recipe.node = 6.2.2.1
-hypatia = 0.3
-logilab-common = 1.3
-mccabe = 0.5.3
-meld3 = 1.0.0
-mr.developer = 1.34
-pep8 = 1.7.0
-pep8-naming = 0.4.1
-peppercorn = 0.5
-pip = 7.1.2
-plone.recipe.command = 1.1
-profilehooks = 1.7.1
-pudb = 2016.2
-py = 1.4.32
-pycallgraph = 1.0.1
-pyflakes = 1.3.0
-pylint = 1.6.4
-pyramid-zodbconn = 0.7
-pyrsistent = 0.11.0
-pytest-timeout = 1.2.0
-repoze.sendmail = 4.3
-requests = 2.12.4
-# rubygemsrecipe = 0.2.2
-selenium = 3.0.2
-Babel = 2.3.4
-repoze.sphinx.autointerface = 0.8
-snowballstemmer = 1.2.1
-transifex-client = 0.11b3
-urwid = 1.3.1
-venusian = 1.0
-waitress = 1.0.1
-z3c.recipe.mkdir = 0.6
-# zc.buildout version is set by requirements.txt
-zc.buildout = 
-zc.recipe.egg = 2.0.3
-zdaemon = 4.2.0
-zodbpickle = 0.6.0
-
-# Required by:
-# ZODB==4.1.0
-# hypatia==0.3
-BTrees = 4.3.2
-
-# Required by:
-# pyramid-chameleon==0.3
-Chameleon = 3.0
-
-# Required by:
-# adhocracy-core==0.0
-Pillow = 4.0.0
-
-# Required by:
-# substanced==0.0
-PyYAML = 3.11
-
-# Required by:
-# ZODB==4.1.0
-# zdaemon==4.0.1
-# zodburi==2.0
-ZConfig = 3.1.0
-
-# Required by:
-# zodburi==2.0
-ZEO = 5.1.1
-
-# Required by:
-# substanced==0.0
-ZODB = 5.3.0
-
-# Required by:
-# adhocracy-core==0.0
-autobahn = 0.17.0
-
-# Required by:
-# WebTest==2.0.18
-beautifulsoup4 = 4.5.1
-
-# Required by:
-# adhocracy-core==0.0
-colander = 1.0
-
-# Required by:
-# substanced==0.0
-cryptacular = 1.4.1
-
-# Required by:
-# adhocracy-core==0.0
-gunicorn = 19.6.0
-
-# Required by:
-# gp.recipe.node==0.10.28.0
-hexagonit.recipe.cmmi = 2.0
-
-# Required by:
-# gp.recipe.phantomjs==1.9.7.2
-hexagonit.recipe.download = 1.7.1
-
-# Required by:
-# colander==1.0
-iso8601 = 0.1.11
-
-# Required by:
-# zodburi==2.0
-mock = 2.0.0
-
-# Required by:
-# cryptacular==1.4.1
-pbkdf2 = 1.3
-
-# Required by:
-# flake8-docstrings==0.2.1.post1
-pep257 = 0.7.0
-
-# Required by:
-# ZODB==4.1.0
-# hypatia==0.3
-persistent = 4.2.4.2
-
-# Required by:
-# adhocracy-core==0.0
-# pyramid-mako==1.0.2
-pyramid = 1.6.3
-pyramid_bython = 0.1
-
-# Required by:
-# adhocracy-frontend==0.0
-pyramid-cachebust = 0.1.1
-
-# Required by:
-# adhocracy-core==0.0
-# substanced==0.0
-pyramid-chameleon = 0.3
-
-# Required by:
-# adhocracy-core==0.0
-pyramid-debugtoolbar = 3.0.5
-
-# Required by:
-# adhocracy-core==0.0
-pyramid-exclog = 0.8
-
-# Required by:
-# substanced==0.0
-pyramid-mailer = 0.15.1
-
-# Required by:
-# adhocracy-frontend==0.0
-pyramid-mako = 1.0.2
-
-# Required by:
-# adhocracy-core==0.0
-pyramid-tm = 1.1.1
-
-# Required by:
-# pytest-pyramid==0.1.1
-pytest = 3.0.5
-# Required by:
-# gp.recipe.node==0.10.28.0
-python-archive = 0.2
-
-# Required by:
-# substanced==0.0
-python-magic = 0.4.12
-
-# Required by:
-# substanced==0.0
-pytz = 2016.10
-
-# Required by:
-# pyramid-debugtoolbar==2.3
-repoze.lru = 0.6
-
-# Required by:
-# flake8-quotes==0.0.1
-# hexagonit.recipe.download==1.7
-# mr.developer==1.31
-# pyramid==1.5.2
-# zc.recipe.egg==2.0.1
-# setuptools version is set by requirements.txt
-setuptools = 
-
-# Required by:
-# WebTest==2.0.18
-# pylint==1.4.1
-# rubygemsrecipe==0.2.1
-# websocket-client==0.23.0
-six = 1.11.0
-
-# Required by:
-# substanced==0.0
-statsd = 3.2.1
-
-# Required by:
-# pyramid-tm==0.10
-transaction = 2.0.3
-
-# Required by:
-# colander==1.0
-
-# Required by:
-# adhocracy-core==0.0
-websocket-client = 0.40.0
-
-# Required by:
-# ZODB==4.1.0
-zc.lockfile = 1.2.1
-
-# Required by:
-# pyramid-zodbconn==0.7
-zodburi = 2.0
-
-# Required by:
-# substanced==0.0
-zope.component = 4.3.0
-
-# Required by:
-# substanced==0.0
-zope.copy = 4.0.3
-
-# Required by:
-# substanced==0.0
-zope.deprecation = 4.1.2
-
-# Required by:
-# zope.component==4.2.1
-zope.event = 4.2.0
-
-# Required by: repoze.sphinx.autointerface==0.7.1
-zope.interface = 4.3.3
-
-# unsorted
-Genshi = 0.7
-argh = 0.26.2
-args = 0.1.0
-buildout.requirements = 0.2.2
-collective.recipe.genshi = 1.0
-lingua = 4.11
-multipledispatch = 0.4.9
-pathtools = 0.1.2
-polib = 1.0.8
-polytester = 1.2.0
-testfixtures = 4.13.3
-Mako = 1.0.6
-sphinx-autodoc-annotation = 1.0-1
-Unidecode = 0.4.19
-Werkzeug = 0.11.11
-actdiag = 0.5.4
-alabaster = 0.7.9
-blessings = 1.6
-blockdiag = 1.5.3
-bpython = 0.15
-collective.recipe.template = 2.0
-curtsies = 0.2.11
-docutils = 0.12
-funcparserlib = 0.3.6
-greenlet = 0.4.11
-lxml = 3.7.1
-osa = 0.2
-pbr = 1.10.0
-pymlconf = 0.7.0
-pyramid-bpython = 0.1
-pytest-localserver = 0.3.6
-pytest-mock = 1.5.0
-sphinx-rtd-theme = 0.1.9
-sphinxcontrib-actdiag = 0.8.5
-sphinxcontrib-blockdiag = 1.5.5
-sphinxcontrib-programoutput = 0.8
-translationstring = 1.3
-txaio = 2.5.2
-tzf.pyramid-yml = 1.1.0
-walkabout = 0.10
-wcwidth = 0.1.7
-webcolors = 1.7
-
+# version pinned in requirements.txt
+setuptools                      = 
+zc.buildout                     = 
+# main dependencies
+BTrees                          = 4.3.2
+Chameleon                       = 3.0
+Jinja2                          = 2.8
+Mako                            = 1.0.6
+MarkupSafe                      = 0.23
+Pillow                          = 4.0.0
+PyJWT                           = 1.4.0
+PyYAML                          = 3.11
+Pygments                        = 2.1.3
+Unidecode                       = 0.4.19
+WebOb                           = 1.6.0
+ZConfig                         = 3.1.0
+ZEO                             = 5.1.1
+ZODB                            = 5.3.0
+argh                            = 0.26.2
+args                            = 0.1.0
+astroid                         = 1.4.9
+autobahn                        = 0.17.0
+beautifulsoup4                  = 4.5.1
+blessings                       = 1.6.1
+colander                        = 1.0
+collective.recipe.template      = 2.0
+cryptacular                     = 1.4.1
+curtsies                        = 0.3.0
+deform                          = 2.0a2
+deform_markdown                 = 0.2.8
+greenlet                        = 0.4.11
+gunicorn                        = 19.6.0
+hypatia                         = 0.3
+iso8601                         = 0.1.11
+logilab-common                  = 1.3
+lxml                            = 3.7.1
+mock                            = 2.0.0
+multipledispatch                = 0.4.9
+olefile                         = 0.45.1
+osa                             = 0.2
+pathtools                       = 0.1.2
+pbkdf2                          = 1.3
+pbr                             = 4.0.1
+peppercorn                      = 0.5
+persistent                      = 4.2.4.2
+pip                             = 7.1.2
+py                              = 1.4.32
+pymlconf                        = 0.8.6
+pyramid                         = 1.6.3
+pyramid-cachebust               = 0.1.1
+pyramid-chameleon               = 0.3
+pyramid-exclog                  = 0.8
+pyramid-jwt                     = 1.1
+pyramid-mailer                  = 0.15.1
+pyramid-mako                    = 1.0.2
+pyramid-tm                      = 1.1.1
+pyramid-zodbconn                = 0.7
+pyramid_bython                  = 0.1
+pyrsistent                      = 0.11.0
+python-magic                    = 0.4.12
+pytz                            = 2016.10
+repoze.lru                      = 0.6
+repoze.sendmail                 = 4.3
+requests                        = 2.12.4
+sh                              = 1.12.8
+six                             = 1.11.0
+statsd                          = 3.2.1
+transaction                     = 2.0.3
+txaio                           = 2.5.2
+typing                          = 3.6.4
+tzf.pyramid-yml                 = 1.1.0
+urwid                           = 1.3.1
+venusian                        = 1.0
+waitress                        = 1.0.1
+walkabout                       = 0.10
+wcwidth                         = 0.1.7
+webcolors                       = 1.7
+websocket-client                = 0.40.0
+zc.lockfile                     = 1.2.1
+zdaemon                         = 4.2.0
+zodbpickle                      = 0.6.0
+zodburi                         = 2.0
+zope.component                  = 4.3.0
+zope.copy                       = 4.0.3
+zope.deprecation                = 4.1.2
+zope.event                      = 4.2.0
+zope.interface                  = 4.3.3
+# development dependencies
+Babel                           = 2.3.4
+Genshi                          = 0.7
+PasteDeploy                     = 1.5.2
+Sphinx                          = 1.3.5
+WebTest                         = 2.0.18
+Werkzeug                        = 0.14.1
+actdiag                         = 0.5.4
+alabaster                       = 0.7.10
+blockdiag                       = 1.5.3
+bowerrecipe                     = 0.2
+bpython                         = 0.15
+buildout.requirements           = 0.2.2
+collective.recipe.genshi        = 1.0
+collective.recipe.omelette      = 0.16
+collective.recipe.supervisor    = 0.20
+coverage                        = 4.0.3
+docutils                        = 0.14
+flake8                          = 3.2.1
+flake8-debugger                 = 1.4.0
+flake8-docstrings               = 1.0.2
+flake8-quotes                   = 0.8.1
+funcparserlib                   = 0.3.6
+gp.recipe.node                  = 6.2.2.1
+hexagonit.recipe.cmmi           = 2.0
+hexagonit.recipe.download       = 1.7.1
+lingua                          = 4.11
+mccabe                          = 0.5.3
+meld3                           = 1.0.0
+mr.developer                    = 1.34
+pep257                          = 0.7.0
+pep8                            = 1.7.0
+pep8-naming                     = 0.4.1
+polib                           = 1.1.0
+polytester                      = 1.2.0
+pyflakes                        = 1.3.0
+pylint                          = 1.6.4
+pyramid-bpython                 = 0.1
+pyramid-debugtoolbar            = 3.0.5
+pytest                          = 3.0.5
+pytest-localserver              = 0.3.6
+pytest-mock                     = 1.5.0
+pytest-timeout                  = 1.2.0
+python-coveralls                = 2.9.0
+repoze.sphinx.autointerface     = 0.8
+selenium                        = 3.0.2
+snowballstemmer                 = 1.2.1
+sphinx-autodoc-annotation       = 1.0-1
+sphinx-rtd-theme                = 0.1.9
+sphinxcontrib-actdiag           = 0.8.5
+sphinxcontrib-blockdiag         = 1.5.5
+sphinxcontrib-programoutput     = 0.8
+testfixtures                    = 4.13.3
+transifex-client                = 0.11b3
+translationstring               = 1.3
+z3c.recipe.mkdir                = 0.6
+zc.recipe.egg                   = 2.0.3

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -285,7 +285,6 @@ pymlconf = 0.7.0
 pyramid-bpython = 0.1
 pytest-localserver = 0.3.6
 pytest-mock = 1.5.0
-requires.io = 0.2.5
 sphinx-rtd-theme = 0.1.9
 sphinxcontrib-actdiag = 0.8.5
 sphinxcontrib-blockdiag = 1.5.5


### PR DESCRIPTION
- remove require.io support (service to show python package updates) 
  Was not use and is broken.
  Buildout based alternatives like zc.checkversions or buildout-versions-checker are broken to.

- cleanup versions.cfg (alphabetical sort, difference base dependencies and develpment dependencies) 