### PR TITLE
Use cryptacular from git to make it work with Python 3.6

### DIFF
--- a/src/adhocracy_core/sources.cfg
+++ b/src/adhocracy_core/sources.cfg
@@ -12,3 +12,4 @@ deform = git https://github.com/Pylons/deform.git rev=b31ca03a5239e0ccb6710249e8
 deform_markdown = git https://github.com/liqd/deform_markdown.git
 # checkout version 0.4dev
 hypatia = git https://github.com/Pylons/hypatia.git rev=77a07dd5515a0e5bc3db21ef12bfc66a47dfcaa5
+cryptacular = hg https://bitbucket.org/dholth/cryptacular rev=cb96fb3cde2bcd902af3cdecd21488a518032265

--- a/src/adhocracy_core/versions.cfg
+++ b/src/adhocracy_core/versions.cfg
@@ -22,7 +22,6 @@ autobahn                        = 0.17.0
 beautifulsoup4                  = 4.5.1
 blessings                       = 1.6.1
 colander                        = 1.0
-cryptacular                     = 1.4.1
 curtsies                        = 0.3.0
 deform                          = 2.0a2
 deform_markdown                 = 0.2.8


### PR DESCRIPTION
This works around
https://bitbucket.org/dholth/cryptacular/issues/11/not-installing-on-ubuntu-1804