### PR TITLE
update bower to 1.8.8 (security fix)

### DIFF
--- a/src/adhocracy_frontend/checkcode_and_compile.cfg
+++ b/src/adhocracy_frontend/checkcode_and_compile.cfg
@@ -151,7 +151,7 @@ inline =
         "devDependencies": {
             "typescript": "1.8.10",
             "tslint": "3.15.1",
-            "bower": "1.8.4",
+            "bower": "1.8.8",
             "jasmine": "2.4.1",
             "protractor": "4.0.11",
             "sync-exec": "0.6.2",


### PR DESCRIPTION
https://snyk.io/blog/severe-security-vulnerability-in-bowers-zip-archive-extraction/