### PR TITLE
fix regression: broken blob support for S1 package

### DIFF
--- a/buildout-s1.cfg
+++ b/buildout-s1.cfg
@@ -9,6 +9,9 @@ dump-requirements-file = ${make_wheels:platform}-requirements.txt
 frontend.static_dir = src/s1/s1/build
 package_name = s1
 
+[backend.ini]
+yaml_config = adhocracy_core:defaults.yaml, adhocracy_frontend:defaults.yaml, adhocracy_s1:defaults.dev.yaml
+
 [merge_static_directories]
 static_directories = src/s1/s1/static ${adhocracy:frontend.core.static_dir}
 

--- a/src/adhocracy_core/adhocracy_core/defaults.dev.yaml
+++ b/src/adhocracy_core/adhocracy_core/defaults.dev.yaml
@@ -1,12 +1,4 @@
 # configuration for local development
-
-configurator:
-  zodbconn:
-    uri: 'zeo://localhost:9963?cache_size=200MB&connection_cache_size=250000&storage=main'
-    uri.audit: 'zeo://localhost:9964?cache_size=10MB&connection_cache_size=50000&storage=main&blob_dir=var/blobs&shared_blob_dir=True'
-  substanced:
-    secret: 'SUPER_SECRET'
-
 adhocracy:
   ws_url: ws://localhost:6561
   canonical_url: 'http://localhost:6551/static/embed.html#!'

--- a/src/adhocracy_core/adhocracy_core/defaults.yaml
+++ b/src/adhocracy_core/adhocracy_core/defaults.yaml
@@ -17,7 +17,7 @@ configurator:
     attempts: 5
   zodbconn:
     # Example database connection:
-    # uri: 'zeo://localhost:9963?cache_size=200MB&connection_cache_size=250000&storage=main'
+    # uri: 'zeo://localhost:9963?cache_size=200MB&connection_cache_size=250000&storage=main&blob_dir=var/blobs&shared_blob_dir=True'
     # uri.audit: 'zeo://localhost:9964?cache_size=10MB&connection_cache_size=50000&storage=main&blob_dir=var/blobs&shared_blob_dir=True'
   substanced:
     secret: ''

--- a/src/adhocracy_s1/adhocracy_s1/defaults.dev.yaml
+++ b/src/adhocracy_s1/adhocracy_s1/defaults.dev.yaml
@@ -1,0 +1,7 @@
+# configuration for local development
+configurator:
+  zodbconn:
+    uri: 'zeo://localhost:9963?cache_size=10MB&connection_cache_size=50000&storage=main&blob_dir=var/db/s1/blobs&shared_blob_dir=True'
+    uri.audit: 'zeo://localhost:9964?cache_size=10MB&connection_cache_size=50000&storage=main&blob_dir=var/db/s1/blobs&shared_blob_dir=True'
+  substanced:
+    secret: 'SUPER_SECRET'


### PR DESCRIPTION
The blob storage path for the ZEO client (pyramid app) was set to
var/blobs, the path for the zeo server instead to
var/db/<package>/blobs.

This was causing file not found errors.

Now both path are pointing to var/db/<package>/blobs for the s1 package.
The other packages still need to be fixed.